### PR TITLE
BAU: Add Github Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- Provide a general summary of your changes in the Title above -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->
+
+## Proposed changes
+
+### What changed
+
+<!-- Describe the changes in detail - the "what"-->
+
+### Why did it change
+
+<!-- Describe the reason these changes were made - the "why" -->
+
+### Issue tracking
+<!-- List any related Jira tickets or GitHub issues -->
+<!-- List any related ADRs or RFCs -->
+<!-- Delete/copy as appropriate -->
+
+- [PYI-XXXX]()
+
+## Checklists
+
+### Environment variables or secrets
+
+<!-- Delete if changes DO include new environment variables or secrets -->
+- [ ] No environment variables or secrets were added or changed
+
+<!-- Delete if changes DO NOT include new environment variables or secrets -->
+- [ ] Documented in the [README](./blob/main/README.md)
+- [ ] Added to deployment repository
+- [ ] Added to local startup repository
+
+### Other considerations
+
+- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


### PR DESCRIPTION
### What

Add a github pull request template.

### Why

To help us write better pull requests.