### PR TITLE
PYI-300 Allow configuration of OAuth paths

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -5,6 +5,8 @@ public class OrchestratorConfig {
     public static final String IPV_CLIENT_ID = getConfigValue("IPV_CLIENT_ID", "some-client-id");
     public static final String IPV_ENDPOINT = getConfigValue("IPV_ENDPOINT", "https://di-ipv-core-front.london.cloudapps.digital/");
     public static final String IPV_BACKCHANNEL_ENDPOINT = getConfigValue("IPV_BACKCHANNEL_ENDPOINT", "https://ea8lfzcdq0.execute-api.eu-west-2.amazonaws.com/");
+    public static final String IPV_BACKCHANNEL_TOKEN_PATH = getConfigValue("IPV_BACKCHANNEL_TOKEN_PATH", "/dev/token");
+    public static final String IPV_BACKCHANNEL_USER_IDENTITY_PATH = getConfigValue("IPV_BACKCHANNEL_USER_IDENTITY_PATH", "/dev/user-identity");
     public static final String ORCHESTRATOR_REDIRECT_URL = getConfigValue("ORCHESTRATOR_REDIRECT_URL", "http://localhost:8083/callback");
 
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -35,6 +35,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_USER_IDENTITY_PATH;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_ENDPOINT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_REDIRECT_URL;
@@ -85,8 +87,10 @@ public class IpvHandler {
     }
 
     private AccessToken exchangeCodeForToken(AuthorizationCode authorizationCode) {
+        URI resolve = URI.create(IPV_BACKCHANNEL_ENDPOINT).resolve(IPV_BACKCHANNEL_TOKEN_PATH);
+        logger.info("token url is " + resolve);
         TokenRequest tokenRequest = new TokenRequest(
-                URI.create(IPV_BACKCHANNEL_ENDPOINT).resolve("/dev/token"),
+                resolve,
                 new ClientID(IPV_CLIENT_ID),
                 new AuthorizationCodeGrant(authorizationCode, URI.create(ORCHESTRATOR_REDIRECT_URL))
         );
@@ -108,7 +112,7 @@ public class IpvHandler {
 
     public UserInfo getUserInfo(AccessToken accessToken) {
         var userInfoRequest = new UserInfoRequest(
-                URI.create(IPV_BACKCHANNEL_ENDPOINT).resolve("/dev/user-identity"),
+                URI.create(IPV_BACKCHANNEL_ENDPOINT).resolve(IPV_BACKCHANNEL_USER_IDENTITY_PATH),
                 (BearerAccessToken) accessToken
         );
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,3 @@
+include 'di-ipv-orchestrator-stub'
+
+rootProject.name = 'di-ipv-stubs'


### PR DESCRIPTION


## Proposed changes
Allow configuration of the hardcoded `/dev/token` and `dev/user-identity` oauth paths, which currently work against the dev AWS api gateway fronting lambdas.

Retain these values as default.

### Why did it change
Allow stub-orchestrator to work with api gateway urls generated by localstack.


### Issue tracking
- [PYI-300](https://govukverify.atlassian.net/browse/PYI-300)