### PR TITLE
BAU: Remove settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,0 @@
-include 'di-ipv-orchestrator-stub'
-include 'di-ipv-credential-issuer-stub'
-
-rootProject.name = 'di-ipv-stubs'


### PR DESCRIPTION
## Proposed changes

### What changed

Remove `settings.gradle`

### Why did it change

This repo contains independent gradle projects, as such we should not have a settings.gradle in the root.
