### PR TITLE
PYI-557: Verify and build a gpg45 score for each kind of criType

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -37,7 +37,7 @@ public class CredentialIssuer {
 
     private void initRoutes(){
         Spark.get("/authorize", authorizeHandler.doAuthorize);
-        Spark.post("/authorize", authorizeHandler.generateAuthCode);
+        Spark.post("/authorize", authorizeHandler.generateResponse);
         Spark.post("/token", tokenHandler.issueAccessToken);
         Spark.get("/credential", credentialHandler.getResource);
     }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -3,6 +3,11 @@ package uk.gov.di.ipv.stub.cred.config;
 public class CredentialIssuerConfig {
     public static final String PORT = getConfigValue("CREDENTIAL_ISSUER_PORT","8084");
 
+    public static final String EVIDENCE_STRENGTH = "strength";
+    public static final String EVIDENCE_VALIDITY = "validity";
+
+    private CredentialIssuerConfig() {}
+
     private static String getConfigValue(String key, String defaultValue){
         var envValue = System.getenv(key);
         if(envValue == null){
@@ -10,5 +15,9 @@ public class CredentialIssuerConfig {
         }
 
         return envValue;
+    }
+
+    public static CriType getCriType() {
+        return CriType.EVIDENCE_CRI_TYPE;
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.stub.cred.config;
+
+public enum CriType {
+    EVIDENCE_CRI_TYPE("evidence"),
+    ACTIVITY_CRI_TYPE("activity"),
+    FRAUD_CRI_TYPE("fraud"),
+    VERIFICATION_CRI_TYPE("verification");
+
+    public final String value;
+
+    private CriType(String value) {
+        this.value = value;
+    }
+}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -1,10 +1,72 @@
 package uk.gov.di.ipv.stub.cred.validation;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import uk.gov.di.ipv.stub.cred.config.CriType;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 public class Validator {
 
+    private static final String INVALID_GPG45_SCORE_ERROR_CODE = "1001";
+    private static final String INVALID_EVIDENCE_VALUES_ERROR_CODE = "1002";
+    private static final String INVALID_ACTIVITY_VALUES_ERROR_CODE = "1003";
+    private static final String INVALID_FRAUD_VALUES_ERROR_CODE = "1004";
+    private static final String INVALID_VERIFICATION_VALUES_ERROR_CODE = "1005";
+
+    private Validator() {}
+
     public static boolean isNullBlankOrEmpty(String value) {
         return Objects.isNull(value) || value.isEmpty() || value.isBlank();
+    }
+
+    public static ValidationResult verifyGpg45(CriType criType, String strengthValue, String validityValue, String activityValue, String fraudValue, String verificationValue) {
+        switch (criType) {
+            case EVIDENCE_CRI_TYPE:
+                try {
+                    Integer.parseInt(strengthValue);
+                    Integer.parseInt(validityValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(activityValue, fraudValue, verificationValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(false, new ErrorObject(INVALID_EVIDENCE_VALUES_ERROR_CODE, "Invalid numbers provided for evidence strength and validity"));
+                }
+            case ACTIVITY_CRI_TYPE:
+                try {
+                    Integer.parseInt(activityValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(strengthValue, validityValue, fraudValue, verificationValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(false, new ErrorObject(INVALID_ACTIVITY_VALUES_ERROR_CODE, "Invalid number provided for activity"));
+                }
+            case FRAUD_CRI_TYPE:
+                try {
+                    Integer.parseInt(fraudValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(strengthValue, validityValue, activityValue, verificationValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(false, new ErrorObject(INVALID_FRAUD_VALUES_ERROR_CODE, "Invalid number provided for fraud"));
+                }
+            case VERIFICATION_CRI_TYPE:
+                try {
+                    Integer.parseInt(verificationValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(strengthValue, validityValue, activityValue, fraudValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(false, new ErrorObject(INVALID_VERIFICATION_VALUES_ERROR_CODE, "Invalid number provided for verification"));
+                }
+            default:
+                return ValidationResult.createValidResult();
+        }
+    }
+
+    private static ValidationResult areStringsNullOrEmpty(List<String> values) {
+        for (String value: values) {
+            if (!isNullBlankOrEmpty(value)) {
+                return new ValidationResult(false, new ErrorObject(INVALID_GPG45_SCORE_ERROR_CODE, "Invalid GPG45 score provided"));
+            }
+        }
+        return ValidationResult.createValidResult();
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -100,7 +100,73 @@
                     <textarea class="govuk-textarea govuk-textarea--error" id="jsonPayload" name="jsonPayload" rows="5" aria-describedby="more-detail-hint more-detail-error"></textarea>
                 </div>
             {{/hasError}}
-            <input type="hidden" name="resourceId" value="{{resource-id}}">
+
+            {{#isEvidenceType}}
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">
+                            GPG45 Evidence
+                        </h1>
+                    </legend>
+
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="strength">
+                            Strength
+                        </label>
+                        <input class="govuk-input govuk-input--width-2" id="strength" name="strength" type="number" min="0" max="5" step="1">
+                    </div>
+
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="validity">
+                            Validity
+                        </label>
+                        <input class="govuk-input govuk-input--width-2" id="validity" name="validity" type="number" min="0" max="5" step="1">
+                    </div>
+                </fieldset>
+            {{/isEvidenceType}}
+
+            {{#isActivityType}}
+                <div class="govuk-form-group">
+                    <h1 class="govuk-label-wrapper">
+                        <label class="govuk-label govuk-label--l" for="activity">
+                            GPG45 Activity
+                        </label>
+                    </h1>
+                    <label class="govuk-label" for="activity">
+                        Activity
+                    </label>
+                    <input class="govuk-input govuk-input--width-2" id="activity" name="activity" type="number" min="0" max="5" step="1">
+                </div>
+            {{/isActivityType}}
+
+            {{#isFraudType}}
+                <div class="govuk-form-group">
+                    <h1 class="govuk-label-wrapper">
+                        <label class="govuk-label govuk-label--l" for="fraud">
+                            GPG45 Fraud
+                        </label>
+                    </h1>
+                    <label class="govuk-label" for="fraud">
+                        Fraud
+                    </label>
+                    <input class="govuk-input govuk-input--width-2" id="fraud" name="fraud" type="number" min="0" max="5" step="1">
+                </div>
+            {{/isFraudType}}
+
+            {{#isVerificationType}}
+                <div class="govuk-form-group">
+                    <h1 class="govuk-label-wrapper">
+                        <label class="govuk-label govuk-label--l" for="verification">
+                            GPG45 Verification
+                        </label>
+                    </h1>
+                    <label class="govuk-label" for="verification">
+                        Verification
+                    </label>
+                    <input class="govuk-input govuk-input--width-2" id="verification" name="verification" type="number" min="0" max="5" step="1">
+                </div>
+            {{/isVerificationType}}
+            <input type="hidden" name="resourceId" value="{{resourceId}}">
             <input class="govuk-button" data-module="govuk-button" type="submit" name="submit" value="Submit data and generate auth code">
         </form>  
     </main>

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
@@ -1,13 +1,15 @@
 package uk.gov.di.ipv.stub.cred.validation;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.stub.cred.config.CriType;
 
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ValidatorTest {
+class ValidatorTest {
     @Test
     void shouldReturnFalseWhenNullBlankOrEmptyStringProvided() {
         String[] testCases = new String[] { null, "", "  " };
@@ -17,5 +19,85 @@ public class ValidatorTest {
     @Test
     void shouldReturnTrueWhenNonNullBlankOrEmptyStringProvided() {
         assertFalse(Validator.isNullBlankOrEmpty("Test value"));
+    }
+
+    @Test
+    void shouldReturnSuccessfulValidationOnValidEvidenceGpg() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.EVIDENCE_CRI_TYPE, "1", "3", null, null, null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInEvidence() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.EVIDENCE_CRI_TYPE, "abc", "/&43", null, null, null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid numbers provided for evidence strength and validity", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnEvidence() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.EVIDENCE_CRI_TYPE, "1", "2", null, "4", null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnSuccessfulValidationOnValidActivityGpg() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.ACTIVITY_CRI_TYPE, null, null, "1", null, null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInActivity() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.ACTIVITY_CRI_TYPE, null, null, "abc", null, null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid number provided for activity", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnActivity() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.ACTIVITY_CRI_TYPE, "1", "2", "1", null, null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnSuccessfulValidationOnValidFraudGpg() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.FRAUD_CRI_TYPE, null, null, null, "1", null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInFraud() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.FRAUD_CRI_TYPE, null, null, null, "abc", null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid number provided for fraud", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnFraud() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.FRAUD_CRI_TYPE, "1", "2", null, "1", null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnSuccessfulValidationOnValidVerificationGpg() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.VERIFICATION_CRI_TYPE, null, null, null, null, "1");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInVerfication() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.VERIFICATION_CRI_TYPE, null, null, null, null, "abc");
+        assertFalse(result.isValid());
+        assertEquals("Invalid number provided for verification", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnVerification() throws Exception {
+        ValidationResult result = Validator.verifyGpg45(CriType.VERIFICATION_CRI_TYPE, "1", "2", null, null, "1");
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
     }
 }


### PR DESCRIPTION


Co-authored-by: Amrit Sidhu <amrit.sidhu@digital.cabinet-office.gov.uk>

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Conditionally render the different gpg45 form options
Build and validate the gpg45 score
Add additional unit tests for the validaiton
Restructure the AuthorizeHandler class
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Depending on what type of CRI we have assigned to a deployed stub it will need to display a different GPG45 form options, i.e evidence or activity or fraud etc...
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-531](https://govukverify.atlassian.net/browse/PYI-531)


