### PR TITLE
PYI-558: Load cri type as an env variable

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -3,14 +3,19 @@ package uk.gov.di.ipv.stub.cred.config;
 public class CredentialIssuerConfig {
     public static final String PORT = getConfigValue("CREDENTIAL_ISSUER_PORT","8084");
 
-    public static final String EVIDENCE_STRENGTH = "strength";
-    public static final String EVIDENCE_VALIDITY = "validity";
+    public static final String EVIDENCE_STRENGTH_PARAM = "strength";
+    public static final String EVIDENCE_VALIDITY_PARAM = "validity";
+    public static final String ACTIVITY_PARAM = "activity";
+    public static final String FRAUD_PARAM = "fraud";
+    public static final String VERIFICATION_PARAM = "verification";
+
+    private static final String CREDENTIAL_ISSUER_TYPE_VAR = "CREDENTIAL_ISSUER_TYPE";
 
     private CredentialIssuerConfig() {}
 
     private static String getConfigValue(String key, String defaultValue){
         var envValue = System.getenv(key);
-        if(envValue == null){
+        if (envValue == null) {
             return defaultValue;
         }
 
@@ -18,6 +23,6 @@ public class CredentialIssuerConfig {
     }
 
     public static CriType getCriType() {
-        return CriType.EVIDENCE_CRI_TYPE;
+        return CriType.fromValue(getConfigValue(CREDENTIAL_ISSUER_TYPE_VAR, CriType.EVIDENCE_CRI_TYPE.value));
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
@@ -1,14 +1,24 @@
 package uk.gov.di.ipv.stub.cred.config;
 
 public enum CriType {
-    EVIDENCE_CRI_TYPE("evidence"),
-    ACTIVITY_CRI_TYPE("activity"),
-    FRAUD_CRI_TYPE("fraud"),
-    VERIFICATION_CRI_TYPE("verification");
+    EVIDENCE_CRI_TYPE("EVIDENCE"),
+    ACTIVITY_CRI_TYPE("ACTIVITY"),
+    FRAUD_CRI_TYPE("FRAUD"),
+    VERIFICATION_CRI_TYPE("VERIFICATION"),
+    USER_ASSERTED_CRI_TYPE("USER_ASSERTED");
 
     public final String value;
 
     private CriType(String value) {
         this.value = value;
+    }
+
+    public static CriType fromValue(String value) {
+        for (CriType type : values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        return null;
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -107,11 +107,11 @@ public class AuthorizeHandler {
 
             Map<String, Object> gpgMap = generateGpg45Score(
                     CredentialIssuerConfig.getCriType(),
-                    queryParamsMap.value(CredentialIssuerConfig.EVIDENCE_STRENGTH),
-                    queryParamsMap.value(CredentialIssuerConfig.EVIDENCE_VALIDITY),
-                    queryParamsMap.value(CriType.ACTIVITY_CRI_TYPE.value),
-                    queryParamsMap.value(CriType.FRAUD_CRI_TYPE.value),
-                    queryParamsMap.value(CriType.VERIFICATION_CRI_TYPE.value)
+                    queryParamsMap.value(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM),
+                    queryParamsMap.value(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM),
+                    queryParamsMap.value(CredentialIssuerConfig.ACTIVITY_PARAM),
+                    queryParamsMap.value(CredentialIssuerConfig.FRAUD_PARAM),
+                    queryParamsMap.value(CredentialIssuerConfig.VERIFICATION_PARAM)
             );
 
             Map<String, Object> credential = new HashMap<>();
@@ -170,13 +170,13 @@ public class AuthorizeHandler {
         switch (criType) {
             case EVIDENCE_CRI_TYPE -> {
                 Map<String, Object> evidence = new HashMap<>();
-                evidence.put(CredentialIssuerConfig.EVIDENCE_STRENGTH, Integer.parseInt(strengthValue));
-                evidence.put(CredentialIssuerConfig.EVIDENCE_VALIDITY, Integer.parseInt(validityValue));
+                evidence.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, Integer.parseInt(strengthValue));
+                evidence.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, Integer.parseInt(validityValue));
                 gpg45Score.put(criType.value, evidence);
             }
-            case ACTIVITY_CRI_TYPE -> gpg45Score.put(criType.value, Integer.parseInt(activityValue));
-            case FRAUD_CRI_TYPE -> gpg45Score.put(criType.value, Integer.parseInt(fraudValue));
-            case VERIFICATION_CRI_TYPE -> gpg45Score.put(criType.value, Integer.parseInt(verificationValue));
+            case ACTIVITY_CRI_TYPE -> gpg45Score.put(CredentialIssuerConfig.ACTIVITY_PARAM, Integer.parseInt(activityValue));
+            case FRAUD_CRI_TYPE -> gpg45Score.put(CredentialIssuerConfig.FRAUD_PARAM, Integer.parseInt(fraudValue));
+            case VERIFICATION_CRI_TYPE -> gpg45Score.put(CredentialIssuerConfig.VERIFICATION_PARAM, Integer.parseInt(verificationValue));
         }
         return gpg45Score;
     }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -90,7 +90,7 @@
                         </label>
                     </h1>
                     <div id="more-detail-hint" class="govuk-hint">
-                        { test : example }
+                        { "test" : "example" }
                     </div>
 
                     <p id="more-detail-error" class="govuk-error-message">

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -134,8 +134,8 @@ class AuthorizeHandlerTest {
         queryParams.put(RequestParamConstants.STATE, new String[]{"test-state"});
         queryParams.put(RequestParamConstants.RESOURCE_ID, new String[]{UUID.randomUUID().toString()});
         queryParams.put(RequestParamConstants.JSON_PAYLOAD, new String[]{"{\"test\": \"test-value\"}"});
-        queryParams.put(CredentialIssuerConfig.EVIDENCE_STRENGTH, new String[]{"2"});
-        queryParams.put(CredentialIssuerConfig.EVIDENCE_VALIDITY, new String[]{"3"});
+        queryParams.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, new String[]{"2"});
+        queryParams.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, new String[]{"3"});
         when(mockHttpRequest.getParameterMap()).thenReturn(queryParams);
 
         QueryParamsMap queryParamsMap = new QueryParamsMap(mockHttpRequest);
@@ -162,8 +162,8 @@ class AuthorizeHandlerTest {
         queryParams.put(RequestParamConstants.STATE, new String[]{"test-state"});
         queryParams.put(RequestParamConstants.RESOURCE_ID, new String[]{UUID.randomUUID().toString()});
         queryParams.put(RequestParamConstants.JSON_PAYLOAD, new String[]{"invalid-json"});
-        queryParams.put(CredentialIssuerConfig.EVIDENCE_STRENGTH, new String[]{"2"});
-        queryParams.put(CredentialIssuerConfig.EVIDENCE_VALIDITY, new String[]{"3"});
+        queryParams.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, new String[]{"2"});
+        queryParams.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, new String[]{"3"});
         when(mockHttpRequest.getParameterMap()).thenReturn(queryParams);
 
         QueryParamsMap queryParamsMap = new QueryParamsMap(mockHttpRequest);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Loads the cri type from an environment variable that is provided to each instance of the stub from the concourse manifest file during deployment.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
In order to dynamically change and control what type of CRI we deploy and control what kind of GPG45 score details are required from the stub UI.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-558](https://govukverify.atlassian.net/browse/PYI-558)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [ ] Added to local startup repository
