### PR TITLE
PYI-508: Display configured credential issuer name

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.stub.cred.config;
 
 public class CredentialIssuerConfig {
     public static final String PORT = getConfigValue("CREDENTIAL_ISSUER_PORT","8084");
+    public static final String NAME = getConfigValue("CREDENTIAL_ISSUER_NAME","Credential Issuer Stub");
 
     public static final String EVIDENCE_STRENGTH = "strength";
     public static final String EVIDENCE_VALIDITY = "validity";

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 import uk.gov.di.ipv.stub.cred.validation.Validator;
 
 import javax.servlet.http.HttpServletResponse;
+import java.io.ObjectInputFilter;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,6 +44,7 @@ public class AuthorizeHandler {
     private static final String IS_VERIFICATION_TYPE_PARAM = "isVerificationType";
     private static final String HAS_ERROR_PARAM = "hasError";
     private static final String ERROR_PARAM = "error";
+    private static final String CRI_NAME_PARAM = "cri-name";
 
     private AuthCodeService authCodeService;
     private CredentialService credentialService;
@@ -94,6 +96,8 @@ public class AuthorizeHandler {
         if (hasError) {
             frontendParams.put(ERROR_PARAM, error);
         }
+
+        frontendParams.put(CRI_NAME_PARAM, CredentialIssuerConfig.NAME);
 
         return viewHelper.render(
                 frontendParams,

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -49,7 +49,7 @@
     <main class="govuk-main-wrapper>" id="main-content" role="main">
         <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
             <h1 class="govuk-heading-xl">
-                Credential Issuer Stub
+                {{cri-name}}
             </h1>
         </div>
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Add config to get name from an environment variable
- Display the name when rendering the main page.

### Why did it change

When running demos with CRI stubs, we want to be able to differentiate between them.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-508](https://govukverify.atlassian.net/browse/PYI-508)

## Checklists

### Environment variables or secrets

NOTE: Using an environment variable that was previously documented but not used `CREDENTIAL_ISSUER_NAME`
