### PR TITLE
PYI-513: Fix JSON parsing of credential attributes

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -2,8 +2,8 @@ package uk.gov.di.ipv.stub.orc.handlers;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonIOException;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
@@ -80,7 +80,7 @@ public class IpvHandler {
         try {
             mustacheData = buildMustacheData(userInfo);
             moustacheDataModel.put("data", mustacheData);
-        } catch (ParseException | JsonIOException e) {
+        } catch (ParseException | JsonSyntaxException e) {
             moustacheDataModel.put("error", userInfo.toJSONString());
         }
 
@@ -139,13 +139,11 @@ public class IpvHandler {
         }
     }
 
-    private List<Map<String, Object>> buildMustacheData(JSONObject credentials) throws ParseException {
+    private List<Map<String, Object>> buildMustacheData(JSONObject credentials) throws ParseException, JsonSyntaxException {
         List<Map<String, Object>> moustacheDataModel = new ArrayList<>();
-
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
         for (String key : credentials.keySet()) {
-            JSONObject criJson = JSONObjectUtils.getJSONObject(credentials, key);
-
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            JSONObject criJson = gson.fromJson(credentials.get(key).toString(), JSONObject.class);
 
             String attributesJson;
             if (JSONObjectUtils.containsKey(criJson, "attributes")) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fixed the JSON parsing to convert string value into JSONObject using gson.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Previously it was assumed that the attributes parameter would already have been a JSONObject rather than a string, so this change fixes the parsing to handle the string formatted JSON.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-513](https://govukverify.atlassian.net/browse/PYI-513)

