### PR TITLE
PYI-573: Get JWT from request param and parse the claims set into JSON

### DIFF
--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -19,6 +19,7 @@ dependencies {
         "com.fasterxml.jackson.core:jackson-core:2.13.1",
         "com.fasterxml.jackson.core:jackson-databind:2.13.1",
         "com.fasterxml.jackson.core:jackson-annotations:2.13.1",
+        "com.google.code.gson:gson:2.8.9",
         "org.slf4j:slf4j-simple:1.7.32"
 
     compileOnly 'org.projectlombok:lombok:1.18.22'

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -6,6 +6,7 @@ public class RequestParamConstants {
     public static final String REDIRECT_URI = "redirect_uri";
     public static final String STATE = "state";
     public static final String GRANT_TYPE = "grant_type";
+    public static final String REQUEST = "request";
     public static final String AUTH_CODE = "code";
     public static final String RESOURCE_ID = "resourceId";
     public static final String JSON_PAYLOAD = "jsonPayload";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Retrieve JWT from the "request" query param and decode it.
Parse the claims set into a JSON object
<!-- Describe the changes in detail - the "what"-->

### Why did it change
So that the claims set containing the shared attributes can be passed into a pretty-print rendered onto the cri-stub front-end.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-573](https://govukverify.atlassian.net/browse/PYI-573)

