### PR TITLE
PYI-691: Create a signed client auth JWT and pass to ipv-core within the /token request

### DIFF
--- a/di-ipv-orchestrator-stub/README.MD
+++ b/di-ipv-orchestrator-stub/README.MD
@@ -9,13 +9,18 @@ The starting point for manual testing and demonstrating IPV journeys.
 
 ## Environment
 
-Variable | Description | Example Value
---- | --- | --- |
-ORCHESTRATOR_PORT          | The port number the orchestrator should run on | `8083` |
-IPV_CLIENT_ID              | The id of the IPV vlient | `some-client-id` |
-IPV_ENDPOINT               | The IPV core-front endpoint | `https://di-ipv-core-front.london.cloudapps.digital/` |
-IPV_BACKCHANNEL_ENDPOINT   | The IPV core-back endpoint | `https://{aws-stage-id}.execute-api.eu-west-2.amazonaws.com/` |
-ORCHESTRATOR_REDIRECT_URL  | The IPV orchestrator stub call back URL | `http://localhost:8083/callback` |
+| Variable                            | Description                                                 | Example Value                                                 |
+|-------------------------------------|-------------------------------------------------------------|---------------------------------------------------------------|
+| IPV_ENDPOINT                        | The IPV core-front endpoint                                 | `https://di-ipv-core-front.london.cloudapps.digital/`         |
+| IPV_BACKCHANNEL_ENDPOINT            | The IPV core-back endpoint                                  | `https://{aws-stage-id}.execute-api.eu-west-2.amazonaws.com/` |
+| IPV_BACKCHANNEL_TOKEN_PATH          | The IPV core-back token endpoint path                       | `/dev/token`                                                  |
+| IPV_BACKCHANNEL_USER_IDENTITY_PATH  | The IPV core-back user identity path                        | `/dev/user-identity`                                          |
+| ORCHESTRATOR_CLIENT_ID              | The id of the orch stub                                     | `some-client-id`                                              |
+| ORCHESTRATOR_REDIRECT_URL           | The orch stub call-back url                                 | `http://localhost:8083/callback`                              |
+| ORCHESTRATOR_CLIENT_SIGNING_KEY     | The orch stub private key for its client authentication JWT | `{base64 encoded pkcs8 private key}`                          |
+| ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS | The expiry time in mins for the orch client auth JWT        | `10`                                                          |
+| PORT                                | The port number the orchestrator should run on              | `8083`                                                        |
+
 
 ## Running locally
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -2,13 +2,14 @@ package uk.gov.di.ipv.stub.orc.config;
 
 public class OrchestratorConfig {
     public static final String PORT = getConfigValue("ORCHESTRATOR_PORT","8083");
-    public static final String IPV_CLIENT_ID = getConfigValue("IPV_CLIENT_ID", "some-client-id");
     public static final String IPV_ENDPOINT = getConfigValue("IPV_ENDPOINT", "https://di-ipv-core-front.london.cloudapps.digital/");
     public static final String IPV_BACKCHANNEL_ENDPOINT = getConfigValue("IPV_BACKCHANNEL_ENDPOINT", "https://ea8lfzcdq0.execute-api.eu-west-2.amazonaws.com/");
     public static final String IPV_BACKCHANNEL_TOKEN_PATH = getConfigValue("IPV_BACKCHANNEL_TOKEN_PATH", "/dev/token");
     public static final String IPV_BACKCHANNEL_USER_IDENTITY_PATH = getConfigValue("IPV_BACKCHANNEL_USER_IDENTITY_PATH", "/dev/user-identity");
+    public static final String ORCHESTRATOR_CLIENT_ID = getConfigValue("ORCHESTRATOR_CLIENT_ID", "di-ipv-orchestrator-stub");
     public static final String ORCHESTRATOR_REDIRECT_URL = getConfigValue("ORCHESTRATOR_REDIRECT_URL", "http://localhost:8083/callback");
-
+    public static final String ORCHESTRATOR_CLIENT_SIGNING_KEY = getConfigValue("ORCHESTRATOR_CLIENT_SIGNING_KEY", "missing-key");
+    public static final String ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS = getConfigValue("ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS", "15");
 
     private static String getConfigValue(String key, String defaultValue){
         var envValue = System.getenv(key);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/exceptions/OrchestratorStubException.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/exceptions/OrchestratorStubException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.stub.orc.exceptions;
+
+public class OrchestratorStubException extends Exception {
+    public OrchestratorStubException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
@@ -15,6 +17,8 @@ import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -31,10 +35,15 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 import spark.Route;
+import uk.gov.di.ipv.stub.orc.exceptions.OrchestratorStubException;
+import uk.gov.di.ipv.stub.orc.utils.JwtHelper;
 import uk.gov.di.ipv.stub.orc.utils.ViewHelper;
 
 import java.io.IOException;
 import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -43,8 +52,8 @@ import java.util.Map;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_USER_IDENTITY_PATH;
-import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_ENDPOINT;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_REDIRECT_URL;
 
 public class IpvHandler {
@@ -57,7 +66,7 @@ public class IpvHandler {
         stateSession.put(state.getValue(), null);
 
         var authRequest = new AuthorizationRequest.Builder(
-                new ResponseType(ResponseType.Value.CODE), new ClientID(IPV_CLIENT_ID))
+                new ResponseType(ResponseType.Value.CODE), new ClientID(ORCHESTRATOR_CLIENT_ID))
                 .state(state)
                 .scope(new Scope("openid"))
                 .redirectionURI(new URI(ORCHESTRATOR_REDIRECT_URL))
@@ -71,17 +80,22 @@ public class IpvHandler {
     public Route doCallback = (Request request, Response response) -> {
         var authorizationCode = getAuthorizationCode(request);
 
-        var accessToken = exchangeCodeForToken(authorizationCode);
-
-        var userInfo = getUserInfo(accessToken);
         List<Map<String, Object>> mustacheData = new ArrayList<>();
         Map<String, Object> moustacheDataModel = new HashMap<>();
 
         try {
-            mustacheData = buildMustacheData(userInfo);
-            moustacheDataModel.put("data", mustacheData);
-        } catch (ParseException | JsonSyntaxException e) {
-            moustacheDataModel.put("error", userInfo.toJSONString());
+            var accessToken = exchangeCodeForToken(authorizationCode);
+
+            var userInfo = getUserInfo(accessToken);
+
+            try {
+                mustacheData = buildMustacheData(userInfo);
+                moustacheDataModel.put("data", mustacheData);
+            } catch (ParseException | JsonSyntaxException e) {
+                moustacheDataModel.put("error", userInfo.toJSONString());
+            }
+        } catch (OrchestratorStubException e) {
+            moustacheDataModel.put("error", e.getMessage());
         }
 
         return ViewHelper.render(moustacheDataModel, "userinfo.mustache");
@@ -100,12 +114,23 @@ public class IpvHandler {
                 .getAuthorizationCode();
     }
 
-    private AccessToken exchangeCodeForToken(AuthorizationCode authorizationCode) {
+    private AccessToken exchangeCodeForToken(AuthorizationCode authorizationCode) throws OrchestratorStubException, CertificateException, JOSEException {
         URI resolve = URI.create(IPV_BACKCHANNEL_ENDPOINT).resolve(IPV_BACKCHANNEL_TOKEN_PATH);
         logger.info("token url is " + resolve);
+
+        SignedJWT signedClientJwt;
+        try {
+            signedClientJwt = JwtHelper.createSignedClientAuthJwt();
+        } catch (JOSEException | InvalidKeySpecException | NoSuchAlgorithmException e) {
+           logger.error("Failed to generate orch client JWT", e);
+           throw new OrchestratorStubException("Failed to generate orch client JWT");
+        }
+
+        ClientAuthentication clientAuthentication = new PrivateKeyJWT(signedClientJwt);
+
         TokenRequest tokenRequest = new TokenRequest(
                 resolve,
-                new ClientID(IPV_CLIENT_ID),
+                clientAuthentication,
                 new AuthorizationCodeGrant(authorizationCode, URI.create(ORCHESTRATOR_REDIRECT_URL))
         );
 
@@ -115,7 +140,7 @@ public class IpvHandler {
         if (tokenResponse instanceof TokenErrorResponse) {
             TokenErrorResponse errorResponse = tokenResponse.toErrorResponse();
             logger.error("Failed to get token: " + errorResponse.getErrorObject());
-            return null;
+            throw new OrchestratorStubException(errorResponse.getErrorObject().getDescription());
         }
 
         return tokenResponse

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -88,13 +88,9 @@ public class IpvHandler {
 
             var userInfo = getUserInfo(accessToken);
 
-            try {
-                mustacheData = buildMustacheData(userInfo);
-                moustacheDataModel.put("data", mustacheData);
-            } catch (ParseException | JsonSyntaxException e) {
-                moustacheDataModel.put("error", userInfo.toJSONString());
-            }
-        } catch (OrchestratorStubException e) {
+            mustacheData = buildMustacheData(userInfo);
+            moustacheDataModel.put("data", mustacheData);
+        } catch (OrchestratorStubException | ParseException | JsonSyntaxException e) {
             moustacheDataModel.put("error", e.getMessage());
         }
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
@@ -1,0 +1,67 @@
+package uk.gov.di.ipv.stub.orc.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.net.URI;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_SIGNING_KEY;
+
+public class JwtHelper {
+
+    public static SignedJWT createSignedClientAuthJwt()
+            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
+        JWSSigner signer = new RSASSASigner(getPrivateKey());
+        JWSHeader jwsHeader = generateHeader();
+        JWTClaimsSet claimsSet = generateClaims();
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+
+    private static JWSHeader generateHeader() {
+        return new JWSHeader.Builder(JWSAlgorithm.RS256).type(JOSEObjectType.JWT).build();
+    }
+
+    private static JWTClaimsSet generateClaims() {
+        var claimsBuilder = new JWTClaimsSet.Builder();
+
+        claimsBuilder.claim(JWTClaimNames.ISSUER, ORCHESTRATOR_CLIENT_ID);
+        claimsBuilder.claim(JWTClaimNames.SUBJECT, ORCHESTRATOR_CLIENT_ID);
+        claimsBuilder.claim(JWTClaimNames.AUDIENCE, URI.create(IPV_BACKCHANNEL_ENDPOINT).resolve(IPV_BACKCHANNEL_TOKEN_PATH).toString());
+
+        OffsetDateTime dateTime = OffsetDateTime.now();
+        claimsBuilder.claim(JWTClaimNames.EXPIRATION_TIME,
+                Instant.parse(dateTime.plusMinutes(Long.parseLong(ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS)).toString()).toEpochMilli());
+
+        return claimsBuilder.build();
+    }
+
+    private static PrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        byte[] binaryKey =
+                Base64.getDecoder().decode(ORCHESTRATOR_CLIENT_SIGNING_KEY);
+        KeyFactory factory = KeyFactory.getInstance("RSA");
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(binaryKey);
+        return factory.generatePrivate(privateKeySpec);
+    }
+}

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/userinfo.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/userinfo.mustache
@@ -86,7 +86,7 @@
                         </div>
                     {{/data}}
                     {{^data}}
-                        <h3 class="govuk-heading-s">Something went wrong when trying to format the JSON response</h3>
+                        <h3 class="govuk-heading-s">Something went wrong: </h3>
                         {{#error}}
                             {{{.}}}
                         {{/error}}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Generate a signed JWT to authenticate orc-stub as the client when interacting with ipv-core.

- Added additional env variables required for client authentication and also updated README with list of env vars
- Generate and sign a JWT with all the required client auth claims
- Send client authentication JWT to ipv-core through the /token request

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The new JWT will be used by ipv-core in order to authenticate the requesting client.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-691](https://govukverify.atlassian.net/browse/PYI-691)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Documented in the [README](./blob/main/README.md)

