### PR TITLE
BAU: Update env var name to match other naming patters for ttl vars

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -18,8 +18,8 @@ public class OrchestratorConfig {
             getConfigValue("ORCHESTRATOR_REDIRECT_URL", "http://localhost:8083/callback");
     public static final String ORCHESTRATOR_CLIENT_SIGNING_KEY =
             getConfigValue("ORCHESTRATOR_CLIENT_SIGNING_KEY", "missing-key");
-    public static final String ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS =
-            getConfigValue("ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS", "15");
+    public static final String ORCHESTRATOR_CLIENT_JWT_TTL =
+            getConfigValue("ORCHESTRATOR_CLIENT_JWT_TTL", "900");
 
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
@@ -16,14 +16,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Base64;
 
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
-import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_JWT_TTL;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_SIGNING_KEY;
 
 public class JwtHelper {
@@ -56,11 +55,7 @@ public class JwtHelper {
         OffsetDateTime dateTime = OffsetDateTime.now();
         claimsBuilder.claim(
                 JWTClaimNames.EXPIRATION_TIME,
-                Instant.parse(
-                                dateTime.plusMinutes(
-                                                Long.parseLong(ORCHESTRATOR_CLIENT_JWT_EXPIRY_MINS))
-                                        .toString())
-                        .toEpochMilli());
+                dateTime.plusSeconds(Long.parseLong(ORCHESTRATOR_CLIENT_JWT_TTL)).toEpochSecond());
 
         return claimsBuilder.build();
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the env var name for the orc stub client jwt ttl value and swap to seconds instead of minutes for the value.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Match the same naming pattern as ipv-core and the cri's.
<!-- Describe the reason these changes were made - the "why" -->

