### PR TITLE
PYI-677 Relax Redirect Url Validation on Stubs

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 public class Validator {
 
+    private static final String PAAS_DOMAIN = ".london.cloudapps.digital";
     private static final String INVALID_GPG45_SCORE_ERROR_CODE = "1001";
     private static final String INVALID_EVIDENCE_VALUES_ERROR_CODE = "1002";
     private static final String INVALID_ACTIVITY_VALUES_ERROR_CODE = "1003";
@@ -107,6 +108,10 @@ public class Validator {
 
     public static boolean redirectUrlIsInvalid(QueryParamsMap queryParams) {
         String redirectUri = queryParams.value(RequestParamConstants.REDIRECT_URI);
+        if (isRedirectUriPaasDomain(redirectUri)) {
+            return false;
+        }
+
         String clientId = queryParams.value(RequestParamConstants.CLIENT_ID);
 
         ClientConfig clientConfig = CredentialIssuerConfig.getClientConfig(clientId);
@@ -117,6 +122,21 @@ public class Validator {
                                 .get("validRedirectUrls")
                                 .split(REDIRECT_URI_SEPARATOR));
         return !validRedirectUrls.contains(redirectUri);
+    }
+
+    /**
+     * To simplify the configuration of the CRI stubs they will accept any redirectUri that includes
+     * the London PaaS Domain. This removes the need to configure the stub with the redirect uri of
+     * each of the developer environments which share the common stubs.
+     *
+     * <p>Keeping some redirect uri validation will still permit developers to check the behaviour
+     * when required.
+     *
+     * @param redirectUri
+     * @return true if the redirect uri includes the London PaaS Domain
+     */
+    private static boolean isRedirectUriPaasDomain(String redirectUri) {
+        return redirectUri != null && redirectUri.contains(PAAS_DOMAIN);
     }
 
     public ValidationResult validateRedirectUrlsMatch(

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
@@ -164,6 +164,15 @@ class ValidatorTest {
     }
 
     @Test
+    void redirectUrlValidationShouldAcceptARedirectUriWithAPaaSDomain() {
+        QueryParamsMap queryParams = mock(QueryParamsMap.class);
+        when(queryParams.value(RequestParamConstants.REDIRECT_URI))
+                .thenReturn("https://valid.london.cloudapps.digital");
+
+        assertFalse(Validator.redirectUrlIsInvalid(queryParams));
+    }
+
+    @Test
     void redirectUrlIsInvalidShouldReturnFalseForValidUrlWithMultipleRegistered() {
         QueryParamsMap queryParams = mock(QueryParamsMap.class);
         when(queryParams.value(RequestParamConstants.REDIRECT_URI))


### PR DESCRIPTION
To enable the simpler reusing of stubs across Developer environments
accept redirect urls that include the London PaaS domain. The validation
could be tighter since this will accept a URI where the PaaS domain
simply appears in the path but these are stubs and including the extra
logic to guard against this seems unnecessary at present.


## Proposed changes
Validate that the redirect uri includes the London PaaS domain rather than a domain specific to a particular core front app. This allows them to be reused without needing to configure the stubs to know about every developer environment.

