### PR TITLE
Fix query params being passed into client authentication method

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifier.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifier.java
@@ -6,10 +6,15 @@ import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
 import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import com.nimbusds.oauth2.sdk.id.Audience;
+import spark.QueryParamsMap;
 import uk.gov.di.ipv.stub.cred.config.ClientConfig;
 import uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig;
 import uk.gov.di.ipv.stub.cred.error.ClientAuthenticationException;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class ClientJwtVerifier {
@@ -23,11 +28,12 @@ public class ClientJwtVerifier {
         this.verifier = getPopulatedClientAuthVerifier();
     }
 
-    public void authenticateClient(String queryString) throws ClientAuthenticationException {
+    public void authenticateClient(QueryParamsMap queryParamsMap)
+            throws ClientAuthenticationException {
 
         PrivateKeyJWT authenticationJwt;
         try {
-            authenticationJwt = PrivateKeyJWT.parse(queryString);
+            authenticationJwt = PrivateKeyJWT.parse(listifyParamValues(queryParamsMap));
         } catch (ParseException e) {
             throw new ClientAuthenticationException(e);
         }
@@ -50,6 +56,14 @@ public class ClientJwtVerifier {
         } catch (InvalidClientException | JOSEException e) {
             throw new ClientAuthenticationException(e);
         }
+    }
+
+    private Map<String, List<String>> listifyParamValues(QueryParamsMap requestParams) {
+        Map<String, List<String>> listifiedParams = new HashMap<>();
+        requestParams
+                .toMap()
+                .forEach((key, value) -> listifiedParams.put(key, Arrays.asList(value)));
+        return listifiedParams;
     }
 
     private ClientAuthenticationVerifier<Object> getPopulatedClientAuthVerifier() {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
@@ -63,7 +63,7 @@ public class TokenHandler {
                 if (Validator.isNullBlankOrEmpty(
                         requestParams.value(RequestParamConstants.CLIENT_ID))) {
                     try {
-                        clientJwtVerifier.authenticateClient(request.queryString());
+                        clientJwtVerifier.authenticateClient(requestParams);
                     } catch (ClientAuthenticationException e) {
                         LOGGER.error("Failed client JWT authentication: %s", e);
                         TokenErrorResponse errorResponse =

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -209,7 +209,7 @@ public class TokenHandlerTest {
                 .thenReturn(ValidationResult.createValidResult());
         doThrow(new ClientAuthenticationException("Fail."))
                 .when(mockJwtAuthenticationService)
-                .authenticateClient(null);
+                .authenticateClient(any());
 
         String result = (String) tokenHandler.issueAccessToken.handle(mockRequest, mockResponse);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Refactored how the form-url encoded body is passed into the client authenticate method.

- Use the request.queryMap() method
- Convert QueryParamsMap into required Map<String, List<String>> structure 

<!-- Describe the changes in detail - the "what"-->

### Why did it change
request.queryString() doesn't return form-url-encoded body values so the request.queryMap() needs to be used instead.
<!-- Describe the reason these changes were made - the "why" -->

