### PR TITLE
KBV-91 The claims JWT should have a 'claims' node

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -177,7 +177,7 @@ public class HandlerHelper {
                                 .issuer(CoreStubConfig.CORE_STUB_CLIENT_ID)
                                 .notBeforeTime(Date.from(now))
                                 .expirationTime(Date.from(now.plus(1, ChronoUnit.HOURS)))
-                                .claim("vc_http_api", map)
+                                .claim("claims", Map.of("vc_http_api", map))
                                 .build());
 
         signedJWT.sign(new RSASSASigner(signingPrivateKey));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add a `claims` node to the claims JWT to it looks like this:
````
{
  "sub": "e7125b63-95a3-495e-b84f-fce699cd48b7",
  "nbf": 1645734250,
  "iss": "ipv-core-stub",
  "claims": {
    "vc_http_api": {
    ....
````
where it previously was:
````
{
  "sub": "e7125b63-95a3-495e-b84f-fce699cd48b7",
  "nbf": 1645734250,
  "iss": "ipv-core-stub",
  "vc_http_api": {
  ....
````

This brings the JWT structure in line with [Identity RFC 2021 #0008](https://github.com/alphagov/digital-identity-architecture/blob/70364762b85104ae6633c0ef815397233e74ec3d/rfc/0008-identity-ipv-sequence-diagram.md) which says: 
> The claims parameter will be encapsulated within a [Request Object JWT](https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests), via the request parameter, signed by the IPV service.

See it in action at https://di-ipv-core-stub.london.cloudapps.digital/, choose the KBV CRI.

### What changed

Changed the structure of the JWT we send to CRIs (in the stub Core at least).

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-91](https://govukverify.atlassian.net/browse/KBV-91)