### PR TITLE
BAU: Expect sharedAttribute values in vc_http_api claim

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -51,6 +51,8 @@ import java.util.UUID;
 
 public class AuthorizeHandler {
 
+    public static final String VC_HTTP_API_CLAIM = "vc_http_api";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizeHandler.class);
 
     private static final String DEFAULT_RESPONSE_CONTENT_TYPE = "application/x-www-form-urlencoded";
@@ -310,8 +312,14 @@ public class AuthorizeHandler {
                 }
 
                 JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
-                Map<String, Object> claimsMap = claimsSet.toJSONObject();
-                sharedAttributesJson = gson.toJson(claimsMap);
+                Map<String, Object> sharedAttributes =
+                        claimsSet.getJSONObjectClaim(VC_HTTP_API_CLAIM);
+
+                if (sharedAttributes == null) {
+                    LOGGER.error("vc_http_api claim not found in JWT");
+                    return "Error: vc_http_api claim not found in JWT";
+                }
+                sharedAttributesJson = gson.toJson(sharedAttributes);
             } catch (ParseException e) {
                 LOGGER.error("Failed to parse the shared attributes JWT");
                 sharedAttributesJson = "Error: failed to parse shared attribute JWT";


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Expect sharedAttribute values in vc_http_api claim

### Why did it change

In [RFC 0008](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0008-identity-ipv-sequence-diagram.md#authorize)
we stipulate that the shared attributes will be encapsulated in a top
level claim in the JWT called vc_http_api.

The KBV team has implemented this, and we should probably do the same
thing.

core-back has been updated to use this top level claim in [PR 154](https://github.com/alphagov/di-ipv-core-back/pull/154)

