### PR TITLE
BAU: Expect vc_http_api claim in a claims claim

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -70,6 +70,7 @@ public class AuthorizeHandler {
     private static final String CRI_NAME_PARAM = "cri-name";
 
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    public static final String CLAIMS_CLAIM = "claims";
 
     private AuthCodeService authCodeService;
     private CredentialService credentialService;
@@ -312,14 +313,14 @@ public class AuthorizeHandler {
                 }
 
                 JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
-                Map<String, Object> sharedAttributes =
-                        claimsSet.getJSONObjectClaim(VC_HTTP_API_CLAIM);
+                Map<String, Object> claims = claimsSet.getJSONObjectClaim(CLAIMS_CLAIM);
 
-                if (sharedAttributes == null) {
+                if (claims == null || claims.get(VC_HTTP_API_CLAIM) == null) {
                     LOGGER.error("vc_http_api claim not found in JWT");
                     return "Error: vc_http_api claim not found in JWT";
                 }
-                sharedAttributesJson = gson.toJson(sharedAttributes);
+
+                sharedAttributesJson = gson.toJson(claims.get(VC_HTTP_API_CLAIM));
             } catch (ParseException e) {
                 LOGGER.error("Failed to parse the shared attributes JWT");
                 sharedAttributesJson = "Error: failed to parse shared attribute JWT";

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -61,6 +61,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.stub.cred.handlers.AuthorizeHandler.CLAIMS_CLAIM;
 import static uk.gov.di.ipv.stub.cred.handlers.AuthorizeHandler.VC_HTTP_API_CLAIM;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -226,7 +227,9 @@ class AuthorizeHandlerTest {
         vcHttpApiClaim.put("givenNames", Arrays.asList("Daniel", "Dan", "Danny"));
 
         JWTClaimsSet claimsSet =
-                new JWTClaimsSet.Builder().claim(VC_HTTP_API_CLAIM, vcHttpApiClaim).build();
+                new JWTClaimsSet.Builder()
+                        .claim(CLAIMS_CLAIM, Map.of(VC_HTTP_API_CLAIM, vcHttpApiClaim))
+                        .build();
 
         RSASSASigner rsaSigner = new RSASSASigner(getPrivateKey());
         SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
@@ -259,8 +262,10 @@ class AuthorizeHandlerTest {
         assertTrue(
                 Boolean.parseBoolean(
                         frontendParamsCaptor.getValue().get("isEvidenceType").toString()));
+        Map<String, Object> claims =
+                (Map<String, Object>) claimsSet.toJSONObject().get(CLAIMS_CLAIM);
         assertEquals(
-                gson.toJson(claimsSet.toJSONObject().get(VC_HTTP_API_CLAIM)),
+                gson.toJson(claims.get(VC_HTTP_API_CLAIM)),
                 frontendParamsCaptor.getValue().get("sharedAttributes"));
     }
 


### PR DESCRIPTION
**Companion PR on core-back here: https://github.com/alphagov/di-ipv-core-back/pull/155**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

RFC 0008 actually specifies that the custom vc_http_api claim should be
nested under a top level claim in the JWT called `claims`.

This is to keep in line with the OIDC spec which we're sort of following.
https://openid.net/specs/openid-connect-core-1_0.html#RequestObject

### Why did it change

To meet the spec we've laid out.

