### PR TITLE
PYI-649: Add button for new journey flow

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -65,7 +65,11 @@ public class IpvHandler {
             (Request request, Response response) -> {
                 var state = new State();
                 stateSession.put(state.getValue(), null);
-
+                String journeyType = request.queryMap().get("journeyType").value();
+                URI journeyTypeEndpointURI =
+                        journeyType.equals("debug")
+                                ? new URI(IPV_ENDPOINT).resolve("/oauth2/debug-authorize")
+                                : new URI(IPV_ENDPOINT).resolve("/oauth2/authorize");
                 var authRequest =
                         new AuthorizationRequest.Builder(
                                         new ResponseType(ResponseType.Value.CODE),
@@ -73,7 +77,7 @@ public class IpvHandler {
                                 .state(state)
                                 .scope(new Scope("openid"))
                                 .redirectionURI(new URI(ORCHESTRATOR_REDIRECT_URL))
-                                .endpointURI(new URI(IPV_ENDPOINT).resolve("/oauth2/authorize"))
+                                .endpointURI(journeyTypeEndpointURI)
                                 .build();
 
                 response.redirect(authRequest.toURI().toString());

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -54,7 +54,12 @@
         </div>
         <h2 class="govuk-heading-l">Prove Your Identity</h2>
         <form action="/authorize">
-            <input class="govuk-button" data-module="govuk-button" type="submit" value="Prove your identity">
+            <input type="hidden" name="journeyType" value="debug" />
+            <input class="govuk-button" data-module="govuk-button" type="submit" value="Debug route">
+        </form>
+        <form action="/authorize">
+            <input type="hidden" name="journeyType" value="full" />
+            <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
         </form>
     </main>
 </div>


### PR DESCRIPTION
## Proposed changes

### What changed

Added a button to the orchestrator to do the core full journey
Uses request query params to determine if it goes to debug journey or full journey

Subsequent PR: https://github.com/alphagov/di-ipv-core-front/pull/69

### Why did it change

As part of the user journey we will want to see the full journey flow. This gives us the ability to test a full journey and still use the debug journey for testing.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-649](https://govukverify.atlassian.net/browse/PYI-649)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
