### PR TITLE
KBV-87 pick up core-stub CRI config from a file deployed with the app

### DIFF
--- a/di-ipv-core-stub/README.MD
+++ b/di-ipv-core-stub/README.MD
@@ -14,6 +14,12 @@ This stub allows us to:
 * send these claims to a credential issuer
 * view the credentials returned
 
+## Config
+
+Core Stub config from the `di-ipv-config` repository directory `/stubs/di-ipv-core-stub` will be available at:
+* Docker image: `/app/config/`
+* PaaS: `config/`
+
 ## Environment
 
 Variable | Description | Example Value
@@ -23,7 +29,7 @@ CORE_STUB_CLIENT_ID              | The id of the IPV Core Stub client | `ipv-cor
 CORE_STUB_REDIRECT_URL               | The OAuth callback url | `http://localhost:8085/callback` |
 CORE_STUB_MAX_SEARCH_RESULTS   | Max search by name results | `200` |
 CORE_STUB_USER_DATA_PATH  | File path to Experian user data zip file | `/app/config/experian-uat-users-large.zip` |
-CORE_STUB_CONFIG_BASE64  | Base64 of the credential issuer config i.e. cris-dev.yaml ||
+CORE_STUB_CONFIG_FILE  | File path to the credential issuer config | `/app/config/cris-dev.yaml` for Docker, `config/cris-dev.yaml` for PaaS|
 CORE_STUB_KEYSTORE_BASE64  | Base64 of p12 signing keystore ||
 CORE_STUB_KEYSTORE_PASSWORD  | password for the p12 signing keystore | `puppet` |
 CORE_STUB_KEYSTORE_ALIAS  | alias for key in the p12 signing keystore | `ipv-core-stub` |

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -67,7 +67,6 @@ public class CoreStubConfig {
             CredentialIssuerMapper mapper = new CredentialIssuerMapper();
             List<Map> cis = (List<Map>) obj.get("credentialIssuerConfigs");
             credentialIssuers.addAll(cis.stream().map(mapper::map).collect(Collectors.toList()));
-
         }
 
     }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -68,7 +68,6 @@ public class CoreStubConfig {
             List<Map> cis = (List<Map>) obj.get("credentialIssuerConfigs");
             credentialIssuers.addAll(cis.stream().map(mapper::map).collect(Collectors.toList()));
         }
-
     }
 
     public static void initUATUsers() throws IOException {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -8,7 +8,7 @@ import uk.gov.di.ipv.stub.core.config.credentialissuer.CredentialIssuerMapper;
 import uk.gov.di.ipv.stub.core.config.uatuser.Identity;
 import uk.gov.di.ipv.stub.core.config.uatuser.IdentityMapper;
 
-import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,7 +18,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,8 +39,8 @@ public class CoreStubConfig {
             Integer.parseInt(getConfigValue("CORE_STUB_MAX_SEARCH_RESULTS", "200"));
     public static final String CORE_STUB_USER_DATA_PATH =
             getConfigValue("CORE_STUB_USER_DATA_PATH", "config/experian-uat-users-large.zip");
-    public static final String CORE_STUB_CONFIG_BASE64 =
-            getConfigValue("CORE_STUB_CONFIG_BASE64", null);
+    public static final String CORE_STUB_CONFIG_FILE =
+            getConfigValue("CORE_STUB_CONFIG_FILE", "/app/config/cris-dev.yaml");
     public static final byte[] CORE_STUB_KEYSTORE_BASE64 =
             getConfigValue("CORE_STUB_KEYSTORE_BASE64", null).getBytes();
     public static final String CORE_STUB_KEYSTORE_PASSWORD =
@@ -62,11 +61,15 @@ public class CoreStubConfig {
     }
 
     public static void initCRIS() throws IOException {
-        byte[] decode = Base64.getDecoder().decode(CoreStubConfig.CORE_STUB_CONFIG_BASE64);
-        Map<String, Object> obj = new Yaml().load(new ByteArrayInputStream(decode));
-        CredentialIssuerMapper mapper = new CredentialIssuerMapper();
-        List<Map> cis = (List<Map>) obj.get("credentialIssuerConfigs");
-        credentialIssuers.addAll(cis.stream().map(mapper::map).collect(Collectors.toList()));
+        String configFile = CoreStubConfig.CORE_STUB_CONFIG_FILE;
+        try (FileInputStream inputStream = new FileInputStream(configFile)) {
+            Map<String, Object> obj = new Yaml().load(inputStream);
+            CredentialIssuerMapper mapper = new CredentialIssuerMapper();
+            List<Map> cis = (List<Map>) obj.get("credentialIssuerConfigs");
+            credentialIssuers.addAll(cis.stream().map(mapper::map).collect(Collectors.toList()));
+
+        }
+
     }
 
     public static void initUATUsers() throws IOException {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Set CRI config from a file in the app rather than an env var.

This means we don't have to fiddle with base64 encoding yaml files to env vars.

The path to the cri-dev.yaml file for the PaaS deploy has already been set with:
````
cf set-env di-ipv-core-stub CORE_STUB_CONFIG_FILE config/cris-dev.yaml
````
I've tested this on Docker with `./startup.sh`.
