### PR TITLE
chore: Add GHA to build image of di-ipv-core-stub

### DIFF
--- a/.github/workflows/core-stub-image.yml
+++ b/.github/workflows/core-stub-image.yml
@@ -1,0 +1,26 @@
+name: Build & Deploy Core-Stub
+
+on:
+  push:
+    branches:
+      - main
+      - KBV-254-build-docker-image
+    paths:
+      - "di-ipv-core-stub/**"
+      - ".github/workflows/core-stub-image.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "di-ipv-core-stub/**"
+
+jobs:
+  build-and-push:
+    uses: alphagov/di-dockerfiles/.github/workflows/publish_to_ghcr.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      docker_context: ./di-ipv-core-stub
+      push_to_ghcr: true
+      ghcr_repo: ghcr.io/alphagov/di/di-ipv-core-stub
+      image_tag: ${{ github.event.inputs.image_tag }}

--- a/di-ipv-core-stub/Dockerfile
+++ b/di-ipv-core-stub/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=build \
 	/app/
 
 WORKDIR /app
-ADD config config
+# ADD config config
 
 RUN tar -xvf src.tar \
 	&& rm src.tar

--- a/di-ipv-core-stub/startup.sh
+++ b/di-ipv-core-stub/startup.sh
@@ -3,16 +3,9 @@ set -eu
 
 CONFIG_DIR="../../di-ipv-config/stubs/di-ipv-core-stub"
 
-clean_up () {
-    rm -r config
-}
-trap clean_up EXIT
-
 if [ ! -d "$CONFIG_DIR" ]; then
   { echo "🛑 config dir '$CONFIG_DIR' does not exist in expected location"; exit 1; }
 fi
 
-cp -r $CONFIG_DIR config
-
 docker build -t ipv-core-stub .
-docker run -p 8085:8085 --env-file ${CONFIG_DIR}/.env ipv-core-stub
+docker run -p 8085:8085 --env-file ${CONFIG_DIR}/.env --mount type=bind,source="$(pwd)/$CONFIG_DIR",target=/app/config ipv-core-stub


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Build a Docker image and push to GHCR

<!-- Describe the changes in detail - the "what"-->

### Why did it change

In order to run the Credential Issuers, a valid JWT needs to be passed through to the API.

Locally this can be done by accessing this repo as a sibling repo (e.g. `../di-ipv-stubs`), but this is more difficult in PR branches, and has security implications for accessing config.

Instead, the required config has been stored in S3, which is accessed inside this GHA to build the image. This image will then be stored in GHCR, and used in other repositories as required.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
- [KBV-254](https://govukverify.atlassian.net/browse/KBV-254)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
