### PR TITLE
KBV-231: Changes for the custom claims structure

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -48,6 +48,11 @@ public class CoreStubConfig {
     public static final String CORE_STUB_KEYSTORE_ALIAS =
             getConfigValue("CORE_STUB_KEYSTORE_ALIAS", null);
 
+    public static final String CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI = getConfigValue("CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI", "https://experian.cri.account.gov.uk");
+    public static final String CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI = getConfigValue("CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI", "https://ipv.core.account.gov.uk");
+    public static final String CORE_STUB_CONTEXT = getConfigValue("CORE_STUB_CONTEXT", "https://www.w3.org/2018/credentials/v1");
+    public static final String CORE_STUB_JSON_SCHEMA = getConfigValue("CORE_STUB_JSON_SCHEMA", "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld");
+
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -51,14 +51,8 @@ public class CoreStubConfig {
     public static final String CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI =
             getConfigValue(
                     "CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI", "https://experian.cri.account.gov.uk");
-    public static final String CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI =
-            getConfigValue("CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI", "https://ipv.core.account.gov.uk");
-    public static final String CORE_STUB_CONTEXT =
-            getConfigValue("CORE_STUB_CONTEXT", "https://www.w3.org/2018/credentials/v1");
-    public static final String CORE_STUB_JSON_SCHEMA =
-            getConfigValue(
-                    "CORE_STUB_JSON_SCHEMA",
-                    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld");
+    public static final String CORE_STUB_JWT_ISS_CRI_URI =
+            getConfigValue("CORE_STUB_JWT_ISS_CRI_URI", "https://dev.core.ipv.account.gov.uk");
 
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -48,10 +48,17 @@ public class CoreStubConfig {
     public static final String CORE_STUB_KEYSTORE_ALIAS =
             getConfigValue("CORE_STUB_KEYSTORE_ALIAS", null);
 
-    public static final String CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI = getConfigValue("CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI", "https://experian.cri.account.gov.uk");
-    public static final String CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI = getConfigValue("CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI", "https://ipv.core.account.gov.uk");
-    public static final String CORE_STUB_CONTEXT = getConfigValue("CORE_STUB_CONTEXT", "https://www.w3.org/2018/credentials/v1");
-    public static final String CORE_STUB_JSON_SCHEMA = getConfigValue("CORE_STUB_JSON_SCHEMA", "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld");
+    public static final String CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI =
+            getConfigValue(
+                    "CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI", "https://experian.cri.account.gov.uk");
+    public static final String CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI =
+            getConfigValue("CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI", "https://ipv.core.account.gov.uk");
+    public static final String CORE_STUB_CONTEXT =
+            getConfigValue("CORE_STUB_CONTEXT", "https://www.w3.org/2018/credentials/v1");
+    public static final String CORE_STUB_JSON_SCHEMA =
+            getConfigValue(
+                    "CORE_STUB_JSON_SCHEMA",
+                    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld");
 
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/DateOfBirth.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/DateOfBirth.java
@@ -4,5 +4,4 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
 
-public record DateOfBirth(@JsonProperty("value") Date dob) {
-}
+public record DateOfBirth(@JsonProperty("value") Date dob) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/DateOfBirth.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/DateOfBirth.java
@@ -1,14 +1,8 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
 
-public record DateOfBirth(Instant dateOfBirth, Instant dateOfEntryOnCtdb) {
-
-    public Date getDOB() {
-        long diff = ChronoUnit.SECONDS.between(dateOfEntryOnCtdb, Instant.now());
-        Instant aged = dateOfBirth.plus(diff, ChronoUnit.SECONDS);
-        return Date.from(aged);
-    }
+public record DateOfBirth(@JsonProperty("value") Date dob) {
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FindDateOfBirth.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FindDateOfBirth.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+public record FindDateOfBirth(Instant dateOfBirth, Instant dateOfEntryOnCtdb) {
+
+    public Date getDOB() {
+        long diff = ChronoUnit.SECONDS.between(dateOfEntryOnCtdb, Instant.now());
+        Instant aged = dateOfBirth.plus(diff, ChronoUnit.SECONDS);
+        return Date.from(aged);
+    }
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FullName.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FullName.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+import spark.utils.StringUtils;
+
+public record FullName(String firstName, String surname) {
+        public String firstLastName() {
+        return "%s %s"
+                .formatted(nonBlankValueOrBlank(firstName), nonBlankValueOrBlank(surname))
+                .trim();
+    }
+
+    private String nonBlankValueOrBlank(String value) {
+        if (StringUtils.isNotBlank(value)) {
+            return value.trim();
+        } else {
+            return "";
+        }
+    }
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FullName.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FullName.java
@@ -1,8 +1,9 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
+
 import spark.utils.StringUtils;
 
 public record FullName(String firstName, String surname) {
-        public String firstLastName() {
+    public String firstLastName() {
         return "%s %s"
                 .formatted(nonBlankValueOrBlank(firstName), nonBlankValueOrBlank(surname))
                 .trim();

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Identity.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Identity.java
@@ -5,6 +5,6 @@ public record Identity(
         String accountNumber,
         String ctdbDatabase,
         UKAddress UKAddress,
-        DateOfBirth dateOfBirth,
-        Name name,
+        FindDateOfBirth findDateOfBirth,
+        FullName name,
         Questions questions) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
+import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -7,6 +9,9 @@ import java.util.Map;
 import static java.util.stream.Collectors.toList;
 
 public class IdentityMapper {
+
+    public static final String GIVEN_NAME = "GivenName";
+    public static final String FAMILY_NAME = "FamilyName";
 
     public Identity map(Map<String, String> map, int rowNumber) {
         List<Question> listOfQuestions =
@@ -47,9 +52,9 @@ public class IdentityMapper {
 
         Instant dob = Instant.parse(map.get("dob"));
         Instant dateOfEntryOnCtdb = Instant.parse(map.get("dateOfEntryOnCtdb"));
-        DateOfBirth dateOfBirth = new DateOfBirth(dob, dateOfEntryOnCtdb);
+        FindDateOfBirth dateOfBirth = new FindDateOfBirth(dob, dateOfEntryOnCtdb);
 
-        Name name = new Name(map.get("name"), map.get("surname"));
+        FullName name = new FullName(map.get("name"), map.get("surname"));
 
         return new Identity(
                 rowNumber,
@@ -68,10 +73,10 @@ public class IdentityMapper {
                 identity.questions().numQuestionsTotal());
     }
 
-    public JWTClaimIdentity mapToJTWClaim(Identity identity) {
-        return new JWTClaimIdentity(
-                List.of(identity.name()),
-                List.of(identity.UKAddress()),
-                List.of(identity.dateOfBirth().getDOB()));
+    public SharedClaims mapToSharedClaim(Identity identity) {
+        return new SharedClaims(
+                List.of(CoreStubConfig.CORE_STUB_CONTEXT, CoreStubConfig.CORE_STUB_JSON_SCHEMA),
+                List.of(new Name(List.of(new NameParts(GIVEN_NAME, identity.name().firstName()), new NameParts(FAMILY_NAME, identity.name().surname())))),
+                List.of(new DateOfBirth(identity.findDateOfBirth().getDOB())));
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -76,7 +76,11 @@ public class IdentityMapper {
     public SharedClaims mapToSharedClaim(Identity identity) {
         return new SharedClaims(
                 List.of(CoreStubConfig.CORE_STUB_CONTEXT, CoreStubConfig.CORE_STUB_JSON_SCHEMA),
-                List.of(new Name(List.of(new NameParts(GIVEN_NAME, identity.name().firstName()), new NameParts(FAMILY_NAME, identity.name().surname())))),
+                List.of(
+                        new Name(
+                                List.of(
+                                        new NameParts(GIVEN_NAME, identity.name().firstName()),
+                                        new NameParts(FAMILY_NAME, identity.name().surname())))),
                 List.of(new DateOfBirth(identity.findDateOfBirth().getDOB())));
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
-import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +73,9 @@ public class IdentityMapper {
 
     public SharedClaims mapToSharedClaim(Identity identity) {
         return new SharedClaims(
-                List.of("https://www.w3.org/2018/credentials/v1", "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"),
+                List.of(
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"),
                 List.of(
                         new Name(
                                 List.of(

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -75,7 +75,7 @@ public class IdentityMapper {
 
     public SharedClaims mapToSharedClaim(Identity identity) {
         return new SharedClaims(
-                List.of(CoreStubConfig.CORE_STUB_CONTEXT, CoreStubConfig.CORE_STUB_JSON_SCHEMA),
+                List.of("https://www.w3.org/2018/credentials/v1", "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"),
                 List.of(
                         new Name(
                                 List.of(

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/JWTClaimIdentity.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/JWTClaimIdentity.java
@@ -1,7 +1,0 @@
-package uk.gov.di.ipv.stub.core.config.uatuser;
-
-import java.util.Date;
-import java.util.List;
-
-public record JWTClaimIdentity(
-        List<Name> names, List<UKAddress> UKAddresses, List<Date> datesOfBirth) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Name.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Name.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record Name(@JsonProperty("nameParts") List<NameParts> nameParts) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/NameParts.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/NameParts.java
@@ -1,5 +1,5 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 
-public record Name(@JsonProperty("nameParts") List<NameParts> nameParts) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NameParts(@JsonProperty("type") String type, @JsonProperty("value") String value) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record SharedClaims(@JsonProperty("@context") List<String> context, @JsonProperty("name") List<Name> name, @JsonProperty("birthDate") List<DateOfBirth> birthDate) {
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
@@ -4,5 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public record SharedClaims(@JsonProperty("@context") List<String> context, @JsonProperty("name") List<Name> name, @JsonProperty("birthDate") List<DateOfBirth> birthDate) {
-}
+public record SharedClaims(
+        @JsonProperty("@context") List<String> context,
+        @JsonProperty("name") List<Name> name,
+        @JsonProperty("birthDate") List<DateOfBirth> birthDate) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -113,8 +113,7 @@ public class CoreStubHandler {
                         Integer.valueOf(Objects.requireNonNull(request.queryParams("rowNumber")));
                 var credentialIssuer = handlerHelper.findCredentialIssuer(credentialIssuerId);
                 var identity = handlerHelper.findIdentityByRowNumber(rowNumber);
-
-                var claimIdentity = new IdentityMapper().mapToJTWClaim(identity);
+                var claimIdentity = new IdentityMapper().mapToSharedClaim(identity);
                 var jwt = handlerHelper.createClaimsJWT(claimIdentity, signingKey);
                 var state = createNewState(credentialIssuer);
                 var authRequest =

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
 
 public class HandlerHelper {
 
+    public static final String URN_UUID = "urn:uuid:";
+    public static final String SHARED_CLAIMS = "shared_claims";
     private final Logger logger = LoggerFactory.getLogger(HandlerHelper.class);
 
     public AuthorizationResponse getAuthorizationResponse(Request request) throws ParseException {
@@ -159,7 +161,7 @@ public class HandlerHelper {
 
     public String createClaimsJWT(Object identity, RSAKey signingPrivateKey) throws JOSEException {
 
-        String ipv_session_id = UUID.randomUUID().toString();
+        String subjectIdentifier = URN_UUID + UUID.randomUUID();
         Instant now = Instant.now();
 
         ObjectMapper objectMapper = new ObjectMapper();
@@ -172,12 +174,13 @@ public class HandlerHelper {
                                 .keyID(signingPrivateKey.getKeyID())
                                 .build(),
                         new JWTClaimsSet.Builder()
-                                .subject(ipv_session_id)
+                                .subject(subjectIdentifier)
+                                .audience(CoreStubConfig.CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI)
                                 .issueTime(Date.from(now))
-                                .issuer(CoreStubConfig.CORE_STUB_CLIENT_ID)
+                                .issuer(CoreStubConfig.CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI)
                                 .notBeforeTime(Date.from(now))
                                 .expirationTime(Date.from(now.plus(1, ChronoUnit.HOURS)))
-                                .claim("claims", Map.of("vc_http_api", map))
+                                .claim(SHARED_CLAIMS, map)
                                 .build());
 
         signedJWT.sign(new RSASSASigner(signingPrivateKey));

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -177,7 +177,7 @@ public class HandlerHelper {
                                 .subject(subjectIdentifier)
                                 .audience(CoreStubConfig.CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI)
                                 .issueTime(Date.from(now))
-                                .issuer(CoreStubConfig.CORE_STUB_JWT_ISS_EXPERIAN_CRI_URI)
+                                .issuer(CoreStubConfig.CORE_STUB_JWT_ISS_CRI_URI)
                                 .notBeforeTime(Date.from(now))
                                 .expirationTime(Date.from(now.plus(1, ChronoUnit.HOURS)))
                                 .claim(SHARED_CLAIMS, map)


### PR DESCRIPTION
A specification was required for how data is passed in from IPV Core to credential issuers so that both IPV Core and the credential issuer team(s) can track their compliance against more easily.

### What changed

Refactored the classes and objects to create a custom claim object called `shared_claims` as discussed in meetings with @galund and tech leads.

### Current Format:

```{
  "sub": "urn:uuid:2328d856-524f-431e-a7e4-acf0168c9f7d",
  "aud": "https://experian.cri.account.gov.uk",
  "nbf": 1648717302,
  "shared_claims": {
    "name": [
      {
        "nameParts": [
          {
            "type": "GivenName",
            "value": "xxxxxx"
          },
          {
            "type": "FamilyName",
            "value": "xxxxxx"
          }
        ]
      }
    ],
    "@context": [
      "https://www.w3.org/2018/credentials/v1",
      "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
    ],
    "birthDate": [
      {
        "value": "1970-01-01"
      }
    ]
  },
  "iss": "https://dev.core.ipv.account.gov.uk",
  "exp": 1648720902,
  "iat": 1648717302
}
```

### Issue tracking
[Related RFC](https://github.com/alphagov/digital-identity-architecture/pull/109)

- [KBV-231](https://govukverify.atlassian.net/browse/KBV-231)

### Environment variables or secrets

We can consider adding these as environment variables on PaaS:

CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI=https://experian.cri.account.gov.uk
CORE_STUB_JWT_ISS_CRI_URI=https://dev.core.ipv.account.gov.uk

### Other considerations

- The structure can change based on further custom claims which may be introduced at a later stage for other credential issuers such as address, passport etc. Currently it has been formulated to work with the KBV CRI
- The structure can also change to contain information related to documents that can be used for DVLA and Passport flows and this is all for future consideration
