### PR TITLE
PYIC-905: Make core-stub CRI signature algos configurable

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -43,6 +43,10 @@ public class CoreStubConfig {
             getConfigValue("CORE_STUB_CONFIG_FILE", "/app/config/cris-dev.yaml");
     public static final byte[] CORE_STUB_KEYSTORE_BASE64 =
             getConfigValue("CORE_STUB_KEYSTORE_BASE64", null).getBytes();
+    public static final String CORE_STUB_EC_PRIVATE_KEY =
+            getConfigValue("CORE_STUB_EC_PRIVATE_KEY", null);
+    public static final String CORE_STUB_EC_PUBLIC_JWK =
+            getConfigValue("CORE_STUB_EC_PUBLIC_JWK", null);
     public static final String CORE_STUB_KEYSTORE_PASSWORD =
             getConfigValue("CORE_STUB_KEYSTORE_PASSWORD", null);
     public static final String CORE_STUB_KEYSTORE_ALIAS =

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -9,4 +9,6 @@ public record CredentialIssuer(
         URI tokenUrl,
         URI credentialUrl,
         boolean sendIdentityClaims,
-        boolean sendOAuthJAR) {}
+        boolean sendOAuthJAR,
+        String expectedAlgo,
+        String userInfoRequestMethod) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
@@ -13,7 +13,17 @@ public class CredentialIssuerMapper {
         URI credentialUrl = URI.create((String) map.get("credentialUrl"));
         boolean sendIdentityClaims = Boolean.TRUE.equals(map.get("sendIdentityClaims"));
         boolean sendOAuthJAR = Boolean.TRUE.equals(map.get("sendOAuthJAR"));
+        String expectedAlgo = (String) map.get("expectedAlgo");
+        String userInfoRequestMethod = (String) map.get("userInfoRequestMethod");
         return new CredentialIssuer(
-                id, name, authorizeUrl, tokenUrl, credentialUrl, sendIdentityClaims, sendOAuthJAR);
+                id,
+                name,
+                authorizeUrl,
+                tokenUrl,
+                credentialUrl,
+                sendIdentityClaims,
+                sendOAuthJAR,
+                expectedAlgo,
+                userInfoRequestMethod);
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Make core-stub CRI signature algos configurable

### Why did it change

This adds some logic to allow the signatures for the CRIs to be
configurable between RS256 and ES256.

It also makes the HTTP method used when calling the issue credentials
endpoint configurable between GET and POST.

These changes are to allow the core-stub to run against the passport
CRI whist not breaking the interface with the KBV teams CRIs.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-905](https://govukverify.atlassian.net/browse/PYI-905)
