### PR TITLE
BAU: Fix passport stub gpg45 evidence structure

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -245,14 +245,12 @@ public class AuthorizeHandler {
         Map<String, Object> gpg45Score = new HashMap<>();
         switch (criType) {
             case EVIDENCE_CRI_TYPE -> {
-                Map<String, Object> evidence = new HashMap<>();
-                evidence.put(
+                gpg45Score.put(
                         CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM,
                         Integer.parseInt(strengthValue));
-                evidence.put(
+                gpg45Score.put(
                         CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM,
                         Integer.parseInt(validityValue));
-                gpg45Score.put(criType.value, evidence);
             }
             case ACTIVITY_CRI_TYPE -> gpg45Score.put(
                     CredentialIssuerConfig.ACTIVITY_PARAM, Integer.parseInt(activityValue));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the passport cri stub to return the gpg45 score structure in the correct format.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Passport CRI stub was adding the "strength" & "validation" properties within a "EVIDENCE" property which is wrong.
