### PR TITLE
PYIC-901: Update orc stub to handle the new user-identity JSON structure for the VCs

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -57,6 +57,9 @@ import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_REDI
 
 public class IpvHandler {
 
+    private static final String CREDENTIALS_URL_PROPERTY =
+            "https://vocab.sign-in.service.gov.uk/v1/credentials";
+
     private final Logger logger = LoggerFactory.getLogger(IpvHandler.class);
     private final Map<String, Object> stateSession = new HashMap<>();
 
@@ -170,8 +173,11 @@ public class IpvHandler {
             throws ParseException, JsonSyntaxException, java.text.ParseException {
         List<Map<String, Object>> moustacheDataModel = new ArrayList<>();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        for (String key : credentials.keySet()) {
-            SignedJWT signedJWT = SignedJWT.parse(credentials.get(key).toString());
+
+        List<String> vcJwts = (List<String>) credentials.get(CREDENTIALS_URL_PROPERTY);
+
+        for (String vc : vcJwts) {
+            SignedJWT signedJWT = SignedJWT.parse(vc);
 
             JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
             Map<String, Object> claims = claimsSet.toJSONObject();
@@ -180,7 +186,7 @@ public class IpvHandler {
 
             Map<String, Object> criMap = new HashMap<>();
             criMap.put("VC", json);
-            criMap.put("criType", key);
+            criMap.put("criType", claims.get("iss"));
             moustacheDataModel.add(criMap);
         }
         return moustacheDataModel;


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated orc stub to be able to handle and render the new user-identity response structure.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The user-identity response now stores the VC's under a array property called "https://vocab.sign-in.service.gov.uk/v1/credentials"
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-901](https://govukverify.atlassian.net/browse/PYI-901)

