### PR TITLE
KBV-307 - Use EC algo to sign JAR & RSA to encrypt

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -43,15 +43,16 @@ public class CoreStubConfig {
             getConfigValue("CORE_STUB_CONFIG_FILE", "/app/config/cris-dev.yaml");
     public static final byte[] CORE_STUB_KEYSTORE_BASE64 =
             getConfigValue("CORE_STUB_KEYSTORE_BASE64", null).getBytes();
-    public static final String CORE_STUB_EC_PRIVATE_KEY =
-            getConfigValue("CORE_STUB_EC_PRIVATE_KEY", null);
-    public static final String CORE_STUB_EC_PUBLIC_JWK =
-            getConfigValue("CORE_STUB_EC_PUBLIC_JWK", null);
+    public static final String CORE_STUB_SIGNING_PRIVATE_KEY =
+            getConfigValue("CORE_STUB_SIGNING_PRIVATE_KEY", null);
+    public static final String CORE_STUB_SIGNING_PUBLIC_JWK =
+            getConfigValue("CORE_STUB_SIGNING_PUBLIC_JWK", null);
+    public static final String CORE_STUB_ENCRYPTION_PUBLIC_KEY =
+            getConfigValue("CORE_STUB_ENCRYPTION_PUBLIC_KEY", null);
     public static final String CORE_STUB_KEYSTORE_PASSWORD =
             getConfigValue("CORE_STUB_KEYSTORE_PASSWORD", null);
     public static final String CORE_STUB_KEYSTORE_ALIAS =
             getConfigValue("CORE_STUB_KEYSTORE_ALIAS", null);
-
     public static final String CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI =
             getConfigValue(
                     "CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI", "https://experian.cri.account.gov.uk");


### PR DESCRIPTION
### What changed

Added support for signing JWTs with either the EC or RSA
Added encryption of JWT for JWT-secured authorisation request (JAR)

### Why did it change
To enable an (EC) signed and (RSA) encrypted JAR to be sent to the address CRI session endpoint

### Issue tracking
- [KBV-307](https://govukverify.atlassian.net/browse/KBV-307)
