### PR TITLE
BAU: changed code to return the JWT string returned by credential issuer

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -76,7 +76,10 @@ public class CoreStubHandler {
                 var credentialIssuer = stateSession.remove(state.getValue());
                 var accessToken =
                         handlerHelper.exchangeCodeForToken(authorizationCode, credentialIssuer);
-                var userInfo = SignedJWT.parse(handlerHelper.getUserInfo(accessToken, credentialIssuer)).getJWTClaimsSet().toString();
+                var userInfo =
+                        SignedJWT.parse(handlerHelper.getUserInfo(accessToken, credentialIssuer))
+                                .getJWTClaimsSet()
+                                .toString();
 
                 Map<String, Object> moustacheDataModel = new HashMap<>();
                 moustacheDataModel.put("data", userInfo);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.stub.core.handlers;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -80,10 +80,8 @@ public class CoreStubHandler {
                         handlerHelper.exchangeCodeForToken(authorizationCode, credentialIssuer);
                 var userInfo = handlerHelper.getUserInfo(accessToken, credentialIssuer);
 
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                Map jsonMap = gson.fromJson(userInfo.toJSONString(), Map.class);
                 Map<String, Object> moustacheDataModel = new HashMap<>();
-                moustacheDataModel.put("data", gson.toJson(jsonMap));
+                moustacheDataModel.put("data", userInfo);
                 moustacheDataModel.put("cri", credentialIssuer.id());
                 moustacheDataModel.put("criName", credentialIssuer.name());
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -76,7 +76,7 @@ public class CoreStubHandler {
                 var credentialIssuer = stateSession.remove(state.getValue());
                 var accessToken =
                         handlerHelper.exchangeCodeForToken(authorizationCode, credentialIssuer);
-                var userInfo = handlerHelper.getUserInfo(accessToken, credentialIssuer);
+                var userInfo = SignedJWT.parse(handlerHelper.getUserInfo(accessToken, credentialIssuer)).getJWTClaimsSet().toString();
 
                 Map<String, Object> moustacheDataModel = new HashMap<>();
                 moustacheDataModel.put("data", userInfo);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -183,7 +183,7 @@ public class HandlerHelper {
         }
     }
 
-    public JSONObject getUserInfo(AccessToken accessToken, CredentialIssuer credentialIssuer) {
+    public String getUserInfo(AccessToken accessToken, CredentialIssuer credentialIssuer) {
         // The CRIs userInfo endpoint should be post. Supporting GET for backwards compatability
         HTTPRequest.Method method = HTTPRequest.Method.GET;
         if (HTTPRequest.Method.POST.name().equals(credentialIssuer.userInfoRequestMethod())) {
@@ -194,11 +194,7 @@ public class HandlerHelper {
 
         HTTPResponse userInfoHttpResponse = sendHttpRequest(userInfoRequest.toHTTPRequest());
 
-        try {
-            return userInfoHttpResponse.getContentAsJSONObject();
-        } catch (ParseException e) {
-            throw new RuntimeException("Failed to parse user info response to JSON");
-        }
+        return userInfoHttpResponse.getContent();
     }
 
     public HTTPResponse sendHttpRequest(HTTPRequest httpRequest) {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -40,7 +40,6 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
-import net.minidev.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

`credential/issue` endpoint returns a JWT string and that needs to be picked up a `string` as opposed to a `json` string.

