### PR TITLE
KBV-308 Allow an EC public encryption JWK to be set per CRI

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -12,15 +12,7 @@ import uk.gov.di.ipv.stub.core.utils.HandlerHelper;
 import uk.gov.di.ipv.stub.core.utils.ViewHelper;
 
 import java.io.ByteArrayInputStream;
-import java.security.KeyFactory;
 import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.security.spec.EncodedKeySpec;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
 import java.util.Base64;
 import java.util.Map;
@@ -40,9 +32,7 @@ public class CoreStub {
 
     private void initRoutes() throws Exception {
         CoreStubHandler coreStubHandler =
-                new CoreStubHandler(
-                        new HandlerHelper(
-                                getSigningKeystore(), getEcPrivateKey(), getEncryptionPublicKey()));
+                new CoreStubHandler(new HandlerHelper(getSigningKeystore(), getEcPrivateKey()));
         Spark.get("/", coreStubHandler.serveHomePage);
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);
@@ -72,23 +62,10 @@ public class CoreStub {
                 RSAKey.load(keystore, CoreStubConfig.CORE_STUB_KEYSTORE_ALIAS, keyStorePassword));
     }
 
-    private ECKey getEcPrivateKey()
-            throws NoSuchAlgorithmException, InvalidKeySpecException, ParseException {
-        EncodedKeySpec privateKeySpec =
-                new PKCS8EncodedKeySpec(
-                        Base64.getDecoder().decode(CoreStubConfig.CORE_STUB_SIGNING_PRIVATE_KEY));
-        return new ECKey.Builder(ECKey.parse(CoreStubConfig.CORE_STUB_SIGNING_PUBLIC_JWK))
-                .privateKey(
-                        (ECPrivateKey) KeyFactory.getInstance("EC").generatePrivate(privateKeySpec))
-                .build();
-    }
-
-    private RSAPublicKey getEncryptionPublicKey()
-            throws NoSuchAlgorithmException, InvalidKeySpecException {
-        byte[] encodedKeySpec =
-                Base64.getDecoder().decode(CoreStubConfig.CORE_STUB_ENCRYPTION_PUBLIC_KEY);
-        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encodedKeySpec);
-        return (RSAPublicKey) keyFactory.generatePublic(keySpec);
+    private ECKey getEcPrivateKey() throws ParseException {
+        return ECKey.parse(
+                new String(
+                        Base64.getDecoder()
+                                .decode(CoreStubConfig.CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64)));
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -43,19 +43,13 @@ public class CoreStubConfig {
             getConfigValue("CORE_STUB_CONFIG_FILE", "/app/config/cris-dev.yaml");
     public static final byte[] CORE_STUB_KEYSTORE_BASE64 =
             getConfigValue("CORE_STUB_KEYSTORE_BASE64", null).getBytes();
-    public static final String CORE_STUB_SIGNING_PRIVATE_KEY =
-            getConfigValue("CORE_STUB_SIGNING_PRIVATE_KEY", null);
-    public static final String CORE_STUB_SIGNING_PUBLIC_JWK =
-            getConfigValue("CORE_STUB_SIGNING_PUBLIC_JWK", null);
-    public static final String CORE_STUB_ENCRYPTION_PUBLIC_KEY =
-            getConfigValue("CORE_STUB_ENCRYPTION_PUBLIC_KEY", null);
+
+    public static final String CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64 =
+            getConfigValue("CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64", null);
     public static final String CORE_STUB_KEYSTORE_PASSWORD =
             getConfigValue("CORE_STUB_KEYSTORE_PASSWORD", null);
     public static final String CORE_STUB_KEYSTORE_ALIAS =
             getConfigValue("CORE_STUB_KEYSTORE_ALIAS", null);
-    public static final String CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI =
-            getConfigValue(
-                    "CORE_STUB_JWT_AUD_EXPERIAN_CRI_URI", "https://experian.cri.account.gov.uk");
     public static final String CORE_STUB_JWT_ISS_CRI_URI =
             getConfigValue("CORE_STUB_JWT_ISS_CRI_URI", "ipv-core-stub");
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -13,4 +13,5 @@ public record CredentialIssuer(
         boolean sendOAuthJAR,
         boolean sendEncryptedOAuthJAR,
         String expectedAlgo,
-        String userInfoRequestMethod) {}
+        String userInfoRequestMethod,
+        String publicEncryptionJwkBase64) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
@@ -17,6 +17,7 @@ public class CredentialIssuerMapper {
         boolean sendEncryptedOAuthJAR = Boolean.TRUE.equals(map.get("sendEncryptedOAuthJAR"));
         String expectedAlgo = (String) map.get("expectedAlgo");
         String userInfoRequestMethod = (String) map.get("userInfoRequestMethod");
+        String publicEncryptionJwkBase64 = (String) map.get("publicEncryptionJwkBase64");
         return new CredentialIssuer(
                 id,
                 name,
@@ -28,6 +29,7 @@ public class CredentialIssuerMapper {
                 sendOAuthJAR,
                 sendEncryptedOAuthJAR,
                 expectedAlgo,
-                userInfoRequestMethod);
+                userInfoRequestMethod,
+                publicEncryptionJwkBase64);
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -8,6 +8,8 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.id.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -25,6 +27,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class CoreStubHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoreStubHandler.class);
+
     private final Map<String, CredentialIssuer> stateSession = new HashMap<>();
     private HandlerHelper handlerHelper;
 
@@ -80,6 +85,7 @@ public class CoreStubHandler {
                 var credentialIssuer = stateSession.remove(state.getValue());
                 var accessToken =
                         handlerHelper.exchangeCodeForToken(authorizationCode, credentialIssuer);
+                LOGGER.info("access token value: " + accessToken.getValue());
                 var userInfo =
                         SignedJWT.parse(handlerHelper.getUserInfo(accessToken, credentialIssuer))
                                 .getJWTClaimsSet()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Allow an EC public encryption JWK to be set per CRI. This will be the public JWK exported from the KMS decryption key in the address CRI api.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-308](https://govukverify.atlassian.net/browse/KBV-308)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
