### PR TITLE
PYIC-964: persist the subject value from the JAR

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/Credential.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/Credential.java
@@ -5,10 +5,12 @@ import java.util.Map;
 public class Credential {
     private final Map<String, Object> attributes;
     private final Map<String, Object> evidence;
+    private final String userId;
 
-    public Credential(Map<String, Object> attributes, Map<String, Object> evidence) {
+    public Credential(Map<String, Object> attributes, Map<String, Object> evidence, String userId) {
         this.attributes = attributes;
         this.evidence = evidence;
+        this.userId = userId;
     }
 
     public Map<String, Object> getAttributes() {
@@ -17,5 +19,9 @@ public class Credential {
 
     public Map<String, Object> getEvidence() {
         return evidence;
+    }
+
+    public String getUserId() {
+        return userId;
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -158,6 +158,7 @@ public class AuthorizeHandler {
                                 .getJWTClaimsSet()
                                 .getClaim(RequestParamConstants.REDIRECT_URI)
                                 .toString();
+                String userId = signedJWT.getJWTClaimsSet().getSubject();
 
                 try {
                     Map<String, Object> attributesMap =
@@ -180,7 +181,7 @@ public class AuthorizeHandler {
                                     queryParamsMap.value(
                                             CredentialIssuerConfig.VERIFICATION_PARAM));
 
-                    Credential credential = new Credential(combinedAttributeJson, gpgMap);
+                    Credential credential = new Credential(combinedAttributeJson, gpgMap, userId);
 
                     AuthorizationSuccessResponse successResponse =
                             generateAuthCode(

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/service/CredentialServiceTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/service/CredentialServiceTest.java
@@ -20,7 +20,7 @@ public class CredentialServiceTest {
     @Test
     void shouldPersistAndGetPayload() {
         Credential credential =
-                new Credential(Map.of("an", "attribute"), Map.of("a", "gpg45Score"));
+                new Credential(Map.of("an", "attribute"), Map.of("a", "gpg45Score"), "user-id");
 
         credentialService.persist(credential, "1234");
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -73,7 +73,8 @@ public class VerifiableCredentialGeneratorTest {
                         "type", "CriStubCheck",
                         "strength", 4,
                         "validity", 2);
-        Credential credential = new Credential(attributes, evidence);
+        String userId = "user-id";
+        Credential credential = new Credential(attributes, evidence, userId);
 
         SignedJWT verifiableCredential =
                 vcGenerator.generate(credential, "https://subject.example.com");
@@ -155,7 +156,8 @@ public class VerifiableCredentialGeneratorTest {
                         "type", "CriStubCheck",
                         "strength", 4,
                         "validity", 2);
-        Credential credential = new Credential(attributes, evidence);
+        String userId = "user-id";
+        Credential credential = new Credential(attributes, evidence, userId);
 
         SignedJWT verifiableCredential =
                 vcGenerator.generate(credential, "https://subject.example.com");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Persist the subject of the JAR request so that it can be used as the subject of the returned VC JWT subject claim.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This value will be used when the VC is generated. The value will be used as the subject claim of the returned VC. This will be covered in a separate PR under the PYIC-965 ticket.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-964](https://govukverify.atlassian.net/browse/PYI-964)

