### PR TITLE
PYIC-965: Set the subject of the returned VC JWT to be the user id va…

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
@@ -55,25 +54,13 @@ public class CredentialHandler {
                     return "Error: No body found in request";
                 }
 
-                String subject;
-                try {
-                    subject = PlainJWT.parse(request.body()).getJWTClaimsSet().getSubject();
-                } catch (java.text.ParseException e) {
-                    response.status(HttpServletResponse.SC_BAD_REQUEST);
-                    return "Error: Could not parse VC request JWT";
-                }
-                if (Validator.isNullBlankOrEmpty(subject)) {
-                    response.status(HttpServletResponse.SC_BAD_REQUEST);
-                    return "Error: Subject missing from VC request JWT";
-                }
-
                 String resourceId = tokenService.getPayload(accessTokenString);
                 Credential credential = credentialService.getCredential(resourceId);
 
                 String verifiableCredential;
                 try {
                     verifiableCredential =
-                            verifiableCredentialGenerator.generate(credential, subject).serialize();
+                            verifiableCredentialGenerator.generate(credential).serialize();
                 } catch (NoSuchAlgorithmException | InvalidKeySpecException | JOSEException e) {
                     response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                     return String.format("Error: Unable to generate VC - '%s'", e.getMessage());

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -44,7 +44,7 @@ public class VerifiableCredentialGenerator {
 
     public static final String EC_ALGO = "EC";
 
-    public SignedJWT generate(Credential credential, String subject)
+    public SignedJWT generate(Credential credential)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
 
         Map<String, Object> vc = new LinkedHashMap<>();
@@ -77,7 +77,7 @@ public class VerifiableCredentialGenerator {
         // The schema is unclear on how this should be presented so just copying wholesale for now.
         vc.put(VC_EVIDENCE, List.of(credential.getEvidence()));
 
-        return generateAndSignVerifiableCredentialJwt(subject, vc);
+        return generateAndSignVerifiableCredentialJwt(credential.getUserId(), vc);
     }
 
     private boolean isPopulatedList(Map<String, Object> attributes, String attributeName) {

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
@@ -61,7 +61,7 @@ public class CredentialHandlerTest {
                 .thenReturn(UUID.randomUUID().toString());
         when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
         when(mockSignedJwt.serialize()).thenReturn("A.VERIFIABLE.CREDENTIAL");
-        when(mockVerifiableCredentialGenerator.generate(any(), any())).thenReturn(mockSignedJwt);
+        when(mockVerifiableCredentialGenerator.generate(any())).thenReturn(mockSignedJwt);
 
         Object response = resourceHandler.getResource.handle(mockRequest, mockResponse);
 
@@ -118,34 +118,6 @@ public class CredentialHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenJwtInRequestBodyCanNotBeParsed() throws Exception {
-        when(mockRequest.body()).thenReturn("NOTAJWT");
-        when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
-                .thenReturn(UUID.randomUUID().toString());
-        when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
-
-        String result = (String) resourceHandler.getResource.handle(mockRequest, mockResponse);
-
-        assertEquals("Error: Could not parse VC request JWT", result);
-        verify(mockResponse).status(HttpServletResponse.SC_BAD_REQUEST);
-    }
-
-    @Test
-    void shouldReturn400WhenJwtInRequestBodyDoesNotContainSubjectClaim() throws Exception {
-        PlainJWT jwtWithoutSubject =
-                new PlainJWT(new JWTClaimsSet.Builder().claim("not a subject", "nope").build());
-        when(mockRequest.body()).thenReturn(jwtWithoutSubject.serialize());
-        when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
-                .thenReturn(UUID.randomUUID().toString());
-        when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
-
-        String result = (String) resourceHandler.getResource.handle(mockRequest, mockResponse);
-
-        assertEquals("Error: Subject missing from VC request JWT", result);
-        verify(mockResponse).status(HttpServletResponse.SC_BAD_REQUEST);
-    }
-
-    @Test
     void shouldReturn500WhenErrorGeneratingVerifiableCredential() throws Exception {
         PlainJWT requestJWT =
                 new PlainJWT(
@@ -156,8 +128,7 @@ public class CredentialHandlerTest {
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn(UUID.randomUUID().toString());
         when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
-        when(mockVerifiableCredentialGenerator.generate(any(), any()))
-                .thenThrow(JOSEException.class);
+        when(mockVerifiableCredentialGenerator.generate(any())).thenThrow(JOSEException.class);
 
         String response = (String) resourceHandler.getResource.handle(mockRequest, mockResponse);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -76,8 +76,7 @@ public class VerifiableCredentialGeneratorTest {
         String userId = "user-id";
         Credential credential = new Credential(attributes, evidence, userId);
 
-        SignedJWT verifiableCredential =
-                vcGenerator.generate(credential, "https://subject.example.com");
+        SignedJWT verifiableCredential = vcGenerator.generate(credential);
 
         KeyFactory kf = KeyFactory.getInstance(EC_ALGO);
         ECPublicKey ecPublicKey =
@@ -92,7 +91,7 @@ public class VerifiableCredentialGeneratorTest {
                 objectMapper.valueToTree(verifiableCredential.getJWTClaimsSet()).path("claims");
 
         assertEquals("https://issuer.example.com", claimsSetTree.path(ISSUER).asText());
-        assertEquals("https://subject.example.com", claimsSetTree.path(SUBJECT).asText());
+        assertEquals(userId, claimsSetTree.path(SUBJECT).asText());
         assertNotNull(claimsSetTree.path(NOT_BEFORE));
         assertEquals(
                 300,
@@ -159,8 +158,7 @@ public class VerifiableCredentialGeneratorTest {
         String userId = "user-id";
         Credential credential = new Credential(attributes, evidence, userId);
 
-        SignedJWT verifiableCredential =
-                vcGenerator.generate(credential, "https://subject.example.com");
+        SignedJWT verifiableCredential = vcGenerator.generate(credential);
 
         JsonNode claimsSetTree =
                 objectMapper.valueToTree(verifiableCredential.getJWTClaimsSet()).path("claims");


### PR DESCRIPTION
…lue from the JAR

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Set the value of the subject claim on the VC JWT to be the same as the subject of the original JAR subject claim.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To match the VC spec that says the subject of the returned VC should be the same as the subject of the JAR request.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-965](https://govukverify.atlassian.net/browse/PYI-965)
