### PR TITLE
PYIC-1099: use new env variable as the aud claim value in the token request JWT

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -20,6 +20,8 @@ public class OrchestratorConfig {
             getConfigValue("ORCHESTRATOR_CLIENT_SIGNING_KEY", "missing-key");
     public static final String ORCHESTRATOR_CLIENT_JWT_TTL =
             getConfigValue("ORCHESTRATOR_CLIENT_JWT_TTL", "900");
+    public static final String IPV_CORE_AUDIENCE =
+            getConfigValue("IPV_CORE_AUDIENCE", "https://build-di-ipv-cri-uk-passport-front.london.cloudapps.digital");
 
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -21,7 +21,9 @@ public class OrchestratorConfig {
     public static final String ORCHESTRATOR_CLIENT_JWT_TTL =
             getConfigValue("ORCHESTRATOR_CLIENT_JWT_TTL", "900");
     public static final String IPV_CORE_AUDIENCE =
-            getConfigValue("IPV_CORE_AUDIENCE", "https://build-di-ipv-cri-uk-passport-front.london.cloudapps.digital");
+            getConfigValue(
+                    "IPV_CORE_AUDIENCE",
+                    "https://build-di-ipv-cri-uk-passport-front.london.cloudapps.digital");
 
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
@@ -10,7 +10,6 @@ import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
-import java.net.URI;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -19,8 +18,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.OffsetDateTime;
 import java.util.Base64;
 
-import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
-import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_CORE_AUDIENCE;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_JWT_TTL;
@@ -47,9 +44,7 @@ public class JwtHelper {
 
         claimsBuilder.claim(JWTClaimNames.ISSUER, ORCHESTRATOR_CLIENT_ID);
         claimsBuilder.claim(JWTClaimNames.SUBJECT, ORCHESTRATOR_CLIENT_ID);
-        claimsBuilder.claim(
-                JWTClaimNames.AUDIENCE,
-                IPV_CORE_AUDIENCE);
+        claimsBuilder.claim(JWTClaimNames.AUDIENCE, IPV_CORE_AUDIENCE);
 
         OffsetDateTime dateTime = OffsetDateTime.now();
         claimsBuilder.claim(

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtHelper.java
@@ -21,6 +21,7 @@ import java.util.Base64;
 
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_CORE_AUDIENCE;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_JWT_TTL;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_SIGNING_KEY;
@@ -48,9 +49,7 @@ public class JwtHelper {
         claimsBuilder.claim(JWTClaimNames.SUBJECT, ORCHESTRATOR_CLIENT_ID);
         claimsBuilder.claim(
                 JWTClaimNames.AUDIENCE,
-                URI.create(IPV_BACKCHANNEL_ENDPOINT)
-                        .resolve(IPV_BACKCHANNEL_TOKEN_PATH)
-                        .toString());
+                IPV_CORE_AUDIENCE);
 
         OffsetDateTime dateTime = OffsetDateTime.now();
         claimsBuilder.claim(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
update the aud claim value on the orchestrator /token request to match with the new IPV-core aud value
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The expected aud claim value for clients connecting to IPV core has changed, so now orc stub loads this value from an env variable.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1099](https://govukverify.atlassian.net/browse/PYI-1099)
