### PR TITLE
KBV-360 Set default IPV Core Stub issuer url

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -43,7 +43,9 @@ public class CoreStubConfig {
     public static final String CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64 =
             getConfigValue("CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64", null);
     public static final String CORE_STUB_JWT_ISS_CRI_URI =
-            getConfigValue("CORE_STUB_JWT_ISS_CRI_URI", "ipv-core-stub");
+            getConfigValue(
+                    "CORE_STUB_JWT_ISS_CRI_URI",
+                    "https://di-ipv-core-stub.london.cloudapps.digital");
 
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Set default IPV Core Stub issuer url - it can be hardcoded to this url as its unlikely to change, and allows for less changes to config in the `di-ipv-config` repo.

I've already run `cf set-env di-ipv-core-stub CORE_STUB_JWT_ISS_CRI_URI https://di-ipv-core-stub.london.cloudapps.digital` to land this on Stub IPV Core in PaaS, which then builds the Authz JAR with the correct expected issuer on address cri api in dev