### PR TITLE
PYIC-1009 Permit API Gateway Domains for Callback URL

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -27,6 +27,8 @@ public class Validator {
     private static final String INVALID_VERIFICATION_VALUES_ERROR_CODE = "1005";
 
     private static final String REDIRECT_URI_SEPARATOR = ",";
+    public static final String API_GATEWAY_CALLBACK_SUFFIX =
+            "execute-api.eu-west-2.amazonaws.com/credential-issuer/callback";
 
     private final AuthCodeService authCodeService;
 
@@ -116,7 +118,8 @@ public class Validator {
     public static boolean redirectUrlIsInvalid(String clientId, String redirectUri) {
         ClientConfig clientConfig = CredentialIssuerConfig.getClientConfig(clientId);
 
-        if (isRedirectUriPaasDomain(redirectUri)) {
+        if (isRedirectUriPaasDomain(redirectUri)
+                || isRedirectUriAmazonApiGatewayCallback(redirectUri)) {
             return false;
         }
 
@@ -142,6 +145,10 @@ public class Validator {
      */
     private static boolean isRedirectUriPaasDomain(String redirectUri) {
         return redirectUri != null && redirectUri.contains(PAAS_DOMAIN);
+    }
+
+    private static boolean isRedirectUriAmazonApiGatewayCallback(String redirectUri) {
+        return redirectUri != null && redirectUri.contains(API_GATEWAY_CALLBACK_SUFFIX);
     }
 
     public ValidationResult validateRedirectUrlsMatch(


### PR DESCRIPTION
We share the CRI stubs across developer environments. The validation on
the callback url was previously relaxed to allow all PaaS domains in
order to permit this sharing. Now core-front is being migrated to AWS
and is invoked behind an API Gateway we need to permit AWS API Gateway
like domains. When the stubs are deployed we will not know all of the
API Gateway ids for each of the developer environments which can change
as their environments are created and destroyed.

Once we have DNS set-up (and if we apply it to development
environments) this validation can be tightened, or post MVP a more
sophisticated check added.
