### PR TITLE
BAU: Don't expect to receive body when accessing resource

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
@@ -49,11 +49,6 @@ public class CredentialHandler {
                     return validationResult.getError().getDescription();
                 }
 
-                if (Validator.isNullBlankOrEmpty(request.body())) {
-                    response.status(HttpServletResponse.SC_BAD_REQUEST);
-                    return "Error: No body found in request";
-                }
-
                 String resourceId = tokenService.getPayload(accessTokenString);
                 Credential credential = credentialService.getCredential(resourceId);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -51,12 +49,6 @@ public class CredentialHandlerTest {
 
     @Test
     public void shouldReturn201AndProtectedResourceWhenValidRequestReceived() throws Exception {
-        PlainJWT requestJWT =
-                new PlainJWT(
-                        new JWTClaimsSet.Builder()
-                                .claim("sub", "https://subject.example.com")
-                                .build());
-        when(mockRequest.body()).thenReturn(requestJWT.serialize());
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn(UUID.randomUUID().toString());
         when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
@@ -105,26 +97,7 @@ public class CredentialHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenRequestBodyIsMissing() throws Exception {
-        when(mockRequest.body()).thenReturn("");
-        when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
-                .thenReturn(UUID.randomUUID().toString());
-        when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
-
-        String result = (String) resourceHandler.getResource.handle(mockRequest, mockResponse);
-
-        assertEquals("Error: No body found in request", result);
-        verify(mockResponse).status(HttpServletResponse.SC_BAD_REQUEST);
-    }
-
-    @Test
     void shouldReturn500WhenErrorGeneratingVerifiableCredential() throws Exception {
-        PlainJWT requestJWT =
-                new PlainJWT(
-                        new JWTClaimsSet.Builder()
-                                .claim("sub", "https://subject.example.com")
-                                .build());
-        when(mockRequest.body()).thenReturn(requestJWT.serialize());
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn(UUID.randomUUID().toString());
         when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Don't expect to receive body when accessing resource

### Why did it change

We've changed the way we request the VC from a CRI - we no longer
require a plain JWT to be posted the resource endpoint.
