### PR TITLE
PYIC-1187 Display full user identity object in orc stub

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -105,6 +105,10 @@ public class IpvHandler {
 
                     var userInfo = getUserInfo(accessToken);
 
+                    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                    String userInfoJson = gson.toJson(userInfo);
+                    moustacheDataModel.put("rawUserInfo", userInfoJson);
+
                     mustacheData = buildMustacheData(userInfo);
                     moustacheDataModel.put("data", mustacheData);
                 } catch (OrchestratorStubException | ParseException | JsonSyntaxException e) {
@@ -197,6 +201,7 @@ public class IpvHandler {
             criMap.put("criType", claims.get("iss"));
             moustacheDataModel.add(criMap);
         }
+
         return moustacheDataModel;
     }
 

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/userinfo.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/userinfo.mustache
@@ -54,6 +54,18 @@
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">Raw User Info Object</span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        <pre><code>{{rawUserInfo}}</code></pre>
+                    </div>
+                </details>
+            </div>
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
                 <dl class="govuk-summary-list">
                     {{#data}}
                         <div class="govuk-summary-list__row">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Display raw user identity object on return to orch stub
![image](https://user-images.githubusercontent.com/32681701/168797645-5bdf9e30-84b9-4146-84c5-4b7b63b54ae0.png)

### Why did it change

For test/debugging output the full user identity response, including new VTM claim

### Issue tracking
- [PYIC-1187](https://govukverify.atlassian.net/browse/PYI-1187)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
