### PR TITLE
PYIC-1048 Update VC to conform to RFC0024

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -16,11 +16,14 @@ public class CredentialIssuerConfig {
 
     public static String CLIENT_AUDIENCE = getConfigValue("CLIENT_AUDIENCE", null);
 
-    public static final String EVIDENCE_STRENGTH_PARAM = "strength";
-    public static final String EVIDENCE_VALIDITY_PARAM = "validity";
-    public static final String ACTIVITY_PARAM = "activity";
-    public static final String FRAUD_PARAM = "fraud";
-    public static final String VERIFICATION_PARAM = "verification";
+    public static final String EVIDENCE_TYPE_PARAM = "type";
+    public static final String EVIDENCE_TYPE_IDENTITY_CHECK = "IdentityCheck";
+    public static final String EVIDENCE_TXN_PARAM = "txn";
+    public static final String EVIDENCE_STRENGTH_PARAM = "strengthScore";
+    public static final String EVIDENCE_VALIDITY_PARAM = "validityScore";
+    public static final String ACTIVITY_PARAM = "activityHistoryScore";
+    public static final String FRAUD_PARAM = "identityFraudScore";
+    public static final String VERIFICATION_PARAM = "verificationScore";
 
     public static Map<String, ClientConfig> CLIENT_CONFIGS;
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -297,6 +297,10 @@ public class AuthorizeHandler {
         }
 
         Map<String, Object> gpg45Score = new HashMap<>();
+        gpg45Score.put(
+                CredentialIssuerConfig.EVIDENCE_TYPE_PARAM,
+                CredentialIssuerConfig.EVIDENCE_TYPE_IDENTITY_CHECK);
+        gpg45Score.put(CredentialIssuerConfig.EVIDENCE_TXN_PARAM, UUID.randomUUID().toString());
         switch (criType) {
             case EVIDENCE_CRI_TYPE -> {
                 gpg45Score.put(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialConstants.java
@@ -1,9 +1,6 @@
 package uk.gov.di.ipv.stub.cred.vc;
 
 public interface VerifiableCredentialConstants {
-    String VC_CONTEXT = "@context";
-    String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
-    String DI_CONTEXT = "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld";
     String VC_TYPE = "type";
     String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
     String IDENTITY_CHECK_CREDENTIAL_TYPE = "IdentityCheckCredential";

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -31,15 +31,12 @@ import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_ADDRESS;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_BIRTH_DATE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_NAME;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.DI_CONTEXT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CONTEXT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_TYPE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.W3_BASE_CONTEXT;
 
 public class VerifiableCredentialGenerator {
 
@@ -49,7 +46,6 @@ public class VerifiableCredentialGenerator {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
 
         Map<String, Object> vc = new LinkedHashMap<>();
-        vc.put(VC_CONTEXT, new String[] {W3_BASE_CONTEXT, DI_CONTEXT});
         vc.put(VC_TYPE, new String[] {VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE});
 
         Map<String, Object> credentialSubject = new LinkedHashMap<>();

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -329,8 +329,13 @@ class AuthorizeHandlerTest {
         verify(mockCredentialService)
                 .persist(persistedCredential.capture(), eq("26c6ad15-a595-4e13-9497-f7c891fabe1d"));
         Map<String, Object> persistedAttributes = persistedCredential.getValue().getAttributes();
+        Map<String, Object> persistedEvidence = persistedCredential.getValue().getEvidence();
         assertEquals(List.of("123 random street, M13 7GE"), persistedAttributes.get("addresses"));
         assertEquals("test-value", persistedAttributes.get("test"));
+        assertEquals("IdentityCheck", persistedEvidence.get("type"));
+        assertNotNull(persistedEvidence.get("txn"));
+        assertNotNull(persistedEvidence.get("strengthScore"));
+        assertNotNull(persistedEvidence.get("validityScore"));
     }
 
     private String createExpectedErrorQueryStringParams(ErrorObject error) {

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -34,15 +34,12 @@ import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.EC_PUBLIC_KEY_1;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_ADDRESS;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_BIRTH_DATE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_NAME;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.DI_CONTEXT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CONTEXT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_TYPE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.W3_BASE_CONTEXT;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator.EC_ALGO;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -77,9 +74,14 @@ public class VerifiableCredentialGeneratorTest {
 
         Map<String, Object> evidence =
                 Map.of(
-                        "type", "CriStubCheck",
-                        "strength", 4,
-                        "validity", 2);
+                        "type",
+                        "CriStubCheck",
+                        "txn",
+                        "some-uuid",
+                        "strengthScore",
+                        4,
+                        "validityScore",
+                        2);
         String userId = "user-id";
         Credential credential = new Credential(attributes, evidence, userId, "clientIdValid");
 
@@ -107,9 +109,6 @@ public class VerifiableCredentialGeneratorTest {
                         - claimsSetTree.path(NOT_BEFORE).asLong());
 
         JsonNode vcClaimTree = claimsSetTree.path(VC_CLAIM);
-        assertEquals(W3_BASE_CONTEXT, vcClaimTree.path(VC_CONTEXT).path(0).asText());
-        assertEquals(DI_CONTEXT, vcClaimTree.path(VC_CONTEXT).path(1).asText());
-
         assertEquals(VERIFIABLE_CREDENTIAL_TYPE, vcClaimTree.path(VC_TYPE).path(0).asText());
         assertEquals(IDENTITY_CHECK_CREDENTIAL_TYPE, vcClaimTree.path(VC_TYPE).path(1).asText());
 
@@ -148,8 +147,9 @@ public class VerifiableCredentialGeneratorTest {
 
         JsonNode evidenceTree = vcClaimTree.path(VC_EVIDENCE);
         assertEquals("CriStubCheck", evidenceTree.path(0).path("type").asText());
-        assertEquals(4, evidenceTree.path(0).path("strength").asInt());
-        assertEquals(2, evidenceTree.path(0).path("validity").asInt());
+        assertEquals("some-uuid", evidenceTree.path(0).path("txn").asText());
+        assertEquals(4, evidenceTree.path(0).path("strengthScore").asInt());
+        assertEquals(2, evidenceTree.path(0).path("validityScore").asInt());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed
Updates to conform to [rfc-0024](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0024-identity-vc-for-checks.md) and based on similar [passport CRI changes](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/127)
- renames of evidence scoring params
- addition of required `type` and `txn` properties in evidence object
- removal of `@context` properties no longer needed

### Why did it change

To conform to rfc-0024 and align with real CRIs

### Issue tracking
- [PYIC-1048](https://govukverify.atlassian.net/browse/PYIC-1048)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

