### PR TITLE
KBV-377 - Add address to shared claims

### DIFF
--- a/di-ipv-core-stub/build.gradle
+++ b/di-ipv-core-stub/build.gradle
@@ -19,7 +19,8 @@ dependencies {
 			"com.google.code.gson:gson:2.8.9",
 			"org.slf4j:slf4j-simple:1.7.33",
 			"org.yaml:snakeyaml:1.30",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0"
+			"com.fasterxml.jackson.core:jackson-databind:2.13.3",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/CanonicalAddress.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/CanonicalAddress.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record CanonicalAddress(
+        String buildingNumber,
+        String buildingName,
+        String streetName,
+        String addressLocality,
+        String postalCode,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate validFrom,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+                LocalDate validUntil) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -81,6 +82,17 @@ public class IdentityMapper {
                                 List.of(
                                         new NameParts(GIVEN_NAME, identity.name().firstName()),
                                         new NameParts(FAMILY_NAME, identity.name().surname())))),
-                List.of(new DateOfBirth(identity.findDateOfBirth().getDOB())));
+                List.of(new DateOfBirth(identity.findDateOfBirth().getDOB())),
+                List.of(
+                        new CanonicalAddress(
+                                identity.UKAddress().street1(),
+                                null,
+                                identity.UKAddress().street2(),
+                                identity.UKAddress().townCity(),
+                                identity.UKAddress().postCode(),
+                                // default / arbitrary value assigned for now as
+                                // the validFrom date is not available in test data
+                                LocalDate.of(2021, 1, 1),
+                                null)));
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
@@ -7,4 +7,5 @@ import java.util.List;
 public record SharedClaims(
         @JsonProperty("@context") List<String> context,
         @JsonProperty("name") List<Name> name,
-        @JsonProperty("birthDate") List<DateOfBirth> birthDate) {}
+        @JsonProperty("birthDate") List<DateOfBirth> birthDate,
+        @JsonProperty("address") List<CanonicalAddress> addresses) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.stub.core.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
@@ -92,7 +93,7 @@ public class HandlerHelper {
 
     public HandlerHelper(ECKey ecSigningKey) {
         this.ecSigningKey = ecSigningKey;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         this.objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
     }
 


### PR DESCRIPTION
### What changed
The address is now included in the shared claims that can be optionally included in the JWT-secured authorisation request (JAR) 

### Why did it change
To enable the KBV and Fraud CRI to invoke the third party API with a complete identity.

### Issue tracking
- [KBV-377](https://govukverify.atlassian.net/browse/KBV-377)
