### PR TITLE
PYIC-1126: Add datasets

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/criStubData.json
@@ -1,0 +1,334 @@
+{
+  "data": [
+    {
+      "criType": "ukPassport",
+      "label": "Mary Watson (Valid) Passport",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Mary",
+                "type": "GivenName"
+              },
+              {
+                "value": "Watson",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1932-02-25"
+          }
+        ],
+        "passportNumber": "824159121",
+        "passportExpiryDate": "2030-01-01"
+      }
+    },
+    {
+      "criType": "Address (Stub)",
+      "label": "Mary Watson Valid Address",
+      "payload": {
+        "address": [
+          {
+            "buildingName": "221B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 6XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Fraud (Stub)",
+      "label": "Mary Watson (Valid) Fraud",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Mary",
+                "type": "GivenName"
+              },
+              {
+                "value": "Watson",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1932-02-25"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "221B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 6XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "KBV (Stub)",
+      "label": "Mary Watson (Valid) KBV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Mary",
+                "type": "GivenName"
+              },
+              {
+                "value": "Watson",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1932-02-25"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "221B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 6XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "ukPassport",
+      "label": "James Moriarty (Invalid) Passport",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "James",
+                "type": "GivenName"
+              },
+              {
+                "value": "Moriarty",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1939-10-09"
+          }
+        ],
+        "passportNumber": "532114382",
+        "passportExpiryDate": "2030-01-01"
+      }
+    },
+    {
+      "criType": "Address (Stub)",
+      "label": "James Moriarty (Invalid) Address",
+      "payload": {
+        "address": [
+          {
+            "buildingName": "111B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 1XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Fraud (Stub)",
+      "label": "James Moriarty (Invalid) Fraud",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "James",
+                "type": "GivenName"
+              },
+              {
+                "value": "Moriarty",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1939-10-09"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "111B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 1XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "KBV (Stub)",
+      "label": "James Moriarty (Invalid) KBV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "James",
+                "type": "GivenName"
+              },
+              {
+                "value": "Moriarty",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1939-10-09"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "111B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 1XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "ukPassport",
+      "label": "Decerqueira Kenneth (Valid Experian) Passport",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Decerqueira",
+                "type": "GivenName"
+              },
+              {
+                "value": "Kenneth",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1959-08-23"
+          }
+        ],
+        "passportNumber": "321654987",
+        "passportExpiryDate": "2030-01-01"
+      }
+    },
+    {
+      "criType": "Address (Stub)",
+      "label": "Decerqueira Kenneth (Valid Experian) Address",
+      "payload": {
+        "address": [
+          {
+            "buildingName": "333B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW3 3XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Fraud (Stub)",
+      "label": "Decerqueira Kenneth (Valid Experian) Fraud",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Decerqueira",
+                "type": "GivenName"
+              },
+              {
+                "value": "Kenneth",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1959-08-23"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "333B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW3 3XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "KBV (Stub)",
+      "label": "Decerqueira Kenneth (Valid Experian) KBV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Decerqueira",
+                "type": "GivenName"
+              },
+              {
+                "value": "Kenneth",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1959-08-23"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "333B",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW3 3XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1887-01-01"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -25,6 +25,12 @@
 <script>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
+<script
+        src="https://code.jquery.com/jquery-3.6.0.min.js"
+        integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
+        crossorigin="anonymous">
+
+</script>
 <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
 <header class="govuk-header " role="banner" data-module="govuk-header">
@@ -65,6 +71,8 @@
                 </div>
             </details>
         {{/shared_claims}}
+
+        <div class="govuk-form-group" id="test_data_block"></div>
 
         {{#hasError}}
             <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
@@ -208,5 +216,27 @@
 <script>
     window.GOVUKFrontend.initAll();
 </script>
+<script>
+    var dropdownData = {{{cri_stub_data}}}
+    var filtered = dropdownData.filter(x => x.criType === "{{cri-name}}")
+    $(document).ready(function() {
+        var select = $('<select class="govuk-select" id="test_data" name="sort">')
+        select.append($("<option selected disabled hidden value=''>").text('Select from dropdown...'))
+        $(filtered).each(function() {
+            select.append($("<option>")
+            .prop('value', this.label)
+            .text(this.label));
+        });
+
+        var label = $('<label class="govuk-label" for="sort">').text("Select CRI stub data: ");
+        $('#test_data_block').append(label).append(select);
+        $("#test_data").on("change", function(event) {
+            var val = $(event.target).val();
+            var {payload} = filtered.find(x => x.label === val)
+            $("#jsonPayload").val(JSON.stringify(payload, undefined, 4))
+        });
+    });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added JSON file containing cri stub data of 3 different credentials

Used JQuery to add example datasets to a select list, when item selected from list it then populates the textarea with correct json relating to a specific credential issuer and credential

Each credential has been given a `criType`, this is used to match with the `cri-name`. With this it adds the stub data relating to the cri to the dropdown list
<img width="350" alt="Screenshot 2022-05-19 at 15 01 28" src="https://user-images.githubusercontent.com/24409958/169312147-5736d8ed-4364-483f-b322-0afdc3eba4bd.png">
<img width="350" alt="Screenshot 2022-05-19 at 15 01 34" src="https://user-images.githubusercontent.com/24409958/169312194-92a862d7-f1be-426b-af1b-1d9abb8ae162.png">


### Why did it change

This makes it more convenient when we want to test credentials

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1126](https://govukverify.atlassian.net/browse/PYI-1126)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
