### PR TITLE
PYIC-1125: Allow OAuth errors to be triggered in CRI stub

### DIFF
--- a/di-ipv-core-stub/startup.sh
+++ b/di-ipv-core-stub/startup.sh
@@ -15,4 +15,4 @@ fi
 cp -r $CONFIG_DIR config
 
 docker build -t ipv-core-stub .
-docker run -p 8085:8085 --env-file ${CONFIG_DIR}/.env ipv-core-stub
+docker run -p 8085:8085 -p 8087:8087 --env-file ${CONFIG_DIR}/.env ipv-core-stub

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.stub.cred.handlers.CredentialHandler;
 import uk.gov.di.ipv.stub.cred.handlers.TokenHandler;
 import uk.gov.di.ipv.stub.cred.service.AuthCodeService;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.utils.ViewHelper;
 import uk.gov.di.ipv.stub.cred.validation.Validator;
@@ -29,11 +30,22 @@ public class CredentialIssuer {
         ClientJwtVerifier clientJwtVerifier = new ClientJwtVerifier();
         CredentialService credentialService = new CredentialService();
         VerifiableCredentialGenerator vcGenerator = new VerifiableCredentialGenerator();
+        RequestedErrorResponseService requestedErrorResponseService =
+                new RequestedErrorResponseService();
 
         authorizeHandler =
-                new AuthorizeHandler(new ViewHelper(), authCodeService, credentialService);
+                new AuthorizeHandler(
+                        new ViewHelper(),
+                        authCodeService,
+                        credentialService,
+                        requestedErrorResponseService);
         tokenHandler =
-                new TokenHandler(authCodeService, tokenService, validator, clientJwtVerifier);
+                new TokenHandler(
+                        authCodeService,
+                        tokenService,
+                        validator,
+                        clientJwtVerifier,
+                        requestedErrorResponseService);
         credentialHandler = new CredentialHandler(credentialService, tokenService, vcGenerator);
 
         initRoutes();

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.stub.cred.error.CriStubException;
 import uk.gov.di.ipv.stub.cred.service.AuthCodeService;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.utils.ES256SignatureVerifier;
+import uk.gov.di.ipv.stub.cred.utils.RequestedErrorResponseHelper;
 import uk.gov.di.ipv.stub.cred.utils.ViewHelper;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 import uk.gov.di.ipv.stub.cred.validation.Validator;
@@ -69,6 +70,8 @@ public class AuthorizeHandler {
     private static final String CRI_NAME_PARAM = "cri-name";
 
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private static final RequestedErrorResponseHelper requestedErrorResponseHelper =
+            new RequestedErrorResponseHelper();
 
     private final AuthCodeService authCodeService;
     private final CredentialService credentialService;
@@ -166,6 +169,12 @@ public class AuthorizeHandler {
     public Route generateResponse =
             (Request request, Response response) -> {
                 QueryParamsMap queryParamsMap = request.queryMap();
+
+                AuthorizationErrorResponse authErrorResponse =
+                        requestedErrorResponseHelper.getRequestedAuthErrorResponse(queryParamsMap);
+                if (authErrorResponse != null) {
+                    response.redirect(authErrorResponse.toURI().toString());
+                }
 
                 String clientIdValue = queryParamsMap.value(RequestParamConstants.CLIENT_ID);
                 String requestValue = queryParamsMap.value(RequestParamConstants.REQUEST);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -17,7 +17,8 @@ public class RequestParamConstants {
     public static final String CLIENT_ASSERTION = "client_assertion";
     public static final String ISSUER = "iss";
     public static final String AUDIENCE = "aud";
-    public static final String REQUESTED_OAUTH_ERROR_RESPONSE = "requested_oauth_error_response";
+    public static final String REQUESTED_OAUTH_ERROR = "requested_oauth_error";
+    public static final String REQUESTED_OAUTH_ERROR_ENDPOINT = "requested_oauth_error_endpoint";
     public static final String REQUESTED_OAUTH_ERROR_DESCRIPTION =
             "requested_oauth_error_description";
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -17,4 +17,7 @@ public class RequestParamConstants {
     public static final String CLIENT_ASSERTION = "client_assertion";
     public static final String ISSUER = "iss";
     public static final String AUDIENCE = "aud";
+    public static final String REQUESTED_OAUTH_ERROR_RESPONSE = "requested_oauth_error_response";
+    public static final String REQUESTED_OAUTH_ERROR_DESCRIPTION =
+            "requested_oauth_error_description";
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/RequestedErrorResponseHelper.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/RequestedErrorResponseHelper.java
@@ -1,0 +1,82 @@
+package uk.gov.di.ipv.stub.cred.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationErrorResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.id.State;
+import spark.QueryParamsMap;
+import uk.gov.di.ipv.stub.cred.config.ClientConfig;
+import uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig;
+import uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants;
+
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.text.ParseException;
+
+public class RequestedErrorResponseHelper {
+
+    public static final String AUTH_PREFIX = "auth_";
+
+    public AuthorizationErrorResponse getRequestedAuthErrorResponse(QueryParamsMap queryParamsMap)
+            throws NoSuchAlgorithmException, InvalidKeySpecException, ParseException {
+        String requestedOauthErrorResponse =
+                queryParamsMap.value(RequestParamConstants.REQUESTED_OAUTH_ERROR_RESPONSE);
+        String requestedOauthErrorDescription =
+                queryParamsMap.value(RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION);
+
+        if (requestedOauthErrorResponse != null
+                && requestedOauthErrorResponse.startsWith(AUTH_PREFIX)) {
+            String clientIdValue = queryParamsMap.value(RequestParamConstants.CLIENT_ID);
+            ClientConfig clientConfig = CredentialIssuerConfig.getClientConfig(clientIdValue);
+
+            String redirectUri =
+                    getSignedJWT(
+                                    queryParamsMap.value(RequestParamConstants.REQUEST),
+                                    clientConfig.getEncryptionPrivateKey())
+                            .getJWTClaimsSet()
+                            .getClaim(RequestParamConstants.REDIRECT_URI)
+                            .toString();
+
+            String state = queryParamsMap.value(RequestParamConstants.STATE);
+
+            return new AuthorizationErrorResponse(
+                    URI.create(redirectUri),
+                    new ErrorObject(
+                            requestedOauthErrorResponse.substring(AUTH_PREFIX.length()),
+                            requestedOauthErrorDescription),
+                    (state == null || state.isEmpty()) ? null : new State(state),
+                    new Issuer(CredentialIssuerConfig.NAME),
+                    ResponseMode.QUERY);
+        }
+        return null;
+    }
+
+    private SignedJWT getSignedJWT(String request, PrivateKey encryptionPrivateKey)
+            throws ParseException {
+        try {
+            JWEObject jweObject = getJweObject(request, encryptionPrivateKey);
+            return jweObject.getPayload().toSignedJWT();
+        } catch (ParseException
+                | NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | JOSEException e) {
+            return SignedJWT.parse(request);
+        }
+    }
+
+    private JWEObject getJweObject(String requestParam, PrivateKey encryptionPrivateKey)
+            throws ParseException, NoSuchAlgorithmException, InvalidKeySpecException,
+                    JOSEException {
+        JWEObject encryptedJweObject = JWEObject.parse(requestParam);
+        RSADecrypter rsaDecrypter = new RSADecrypter(encryptionPrivateKey);
+        encryptedJweObject.decrypt(rsaDecrypter);
+        return encryptedJweObject;
+    }
+}

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -183,33 +183,46 @@
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">
-                        OAuth error to return
+                        Force an OAuth error response
                     </h1>
                 </legend>
 
                 <div class="govuk-form-group">
-                    <label class="govuk-label" for="requested_oauth_error_response">
-                        OAuth error response
+                    <label class="govuk-label" for="requested_oauth_error_endpoint">
+                        Endpoint to return the error from
                     </label>
-                    <select class="govuk-select" id="requested_oauth_error_response" name="requested_oauth_error_response">
-                        <option value="none" selected>Do not trigger an error response</option>
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="endpoint" name="requested_oauth_error_endpoint" type="radio" value="auth">
+                            <label class="govuk-label govuk-radios__label" for="requested_oauth_error_endpoint">
+                                Authorization
+                            </label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="requested_oauth_error_endpoint_2" name="requested_oauth_error_endpoint" type="radio" value="token">
+                            <label class="govuk-label govuk-radios__label" for="requested_oauth_error_endpoint_2">
+                                Access Token
+                            </label>
+                        </div>
+                    </div>
+                </div>
 
-                        <option value="auth_invalid_request">Authorization Response - invalid_request</option>
-                        <option value="auth_unauthorized_client">Authorization Response - unauthorized_client</option>
-                        <option value="auth_access_denied">Authorization Response - access_denied</option>
-                        <option value="auth_unsupported_response_type">Authorization Response - unsupported_response_type</option>
-                        <option value="auth_invalid_scope">Authorization Response - invalid_scope</option>
-                        <option value="auth_server_error">Authorization Response - server_error</option>
-                        <option value="auth_temporarily_unavailable">Authorization Response - temporarily_unavailable</option>
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="requested_oauth_error">
+                        OAuth error
+                    </label>
+                    <select class="govuk-select" id="requested_oauth_error" name="requested_oauth_error">
+                        <option value="none" selected>none</option>
 
-                        <option value="token_invalid_request">Access Token Response - invalid_request</option>
-                        <option value="token_unauthorized_client">Access Token Response - unauthorized_client</option>
-                        <option value="token_access_denied">Access Token Response - access_denied</option>
-                        <option value="token_unsupported_response_type">Access Token Response - unsupported_response_type</option>
-                        <option value="token_invalid_scope">Access Token Response - invalid_scope</option>
-                        <option value="token_server_error">Access Token Response - server_error</option>
-                        <option value="token_temporarily_unavailable">Access Token Response - temporarily_unavailable</option>
-                    </select>                </div>
+                        <option value="invalid_request">invalid_request</option>
+                        <option value="unauthorized_client">unauthorized_client</option>
+                        <option value="access_denied">access_denied</option>
+                        <option value="unsupported_response_type">unsupported_response_type</option>
+                        <option value="invalid_scope">invalid_scope</option>
+                        <option value="server_error">server_error</option>
+                        <option value="temporarily_unavailable">temporarily_unavailable</option>
+                    </select>
+                </div>
 
                 <div class="govuk-form-group">
                     <label class="govuk-label" for="requested_oauth_error_description">

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -179,6 +179,46 @@
                     <input class="govuk-input govuk-input--width-2" id="verification" name="verification" type="number" min="0" max="5" step="1">
                 </div>
             {{/isVerificationType}}
+
+            <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <h1 class="govuk-fieldset__heading">
+                        OAuth error to return
+                    </h1>
+                </legend>
+
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="requested_oauth_error_response">
+                        OAuth error response
+                    </label>
+                    <select class="govuk-select" id="requested_oauth_error_response" name="requested_oauth_error_response">
+                        <option value="none" selected>Do not trigger an error response</option>
+
+                        <option value="auth_invalid_request">Authorization Response - invalid_request</option>
+                        <option value="auth_unauthorized_client">Authorization Response - unauthorized_client</option>
+                        <option value="auth_access_denied">Authorization Response - access_denied</option>
+                        <option value="auth_unsupported_response_type">Authorization Response - unsupported_response_type</option>
+                        <option value="auth_invalid_scope">Authorization Response - invalid_scope</option>
+                        <option value="auth_server_error">Authorization Response - server_error</option>
+                        <option value="auth_temporarily_unavailable">Authorization Response - temporarily_unavailable</option>
+
+                        <option value="token_invalid_request">Access Token Response - invalid_request</option>
+                        <option value="token_unauthorized_client">Access Token Response - unauthorized_client</option>
+                        <option value="token_access_denied">Access Token Response - access_denied</option>
+                        <option value="token_unsupported_response_type">Access Token Response - unsupported_response_type</option>
+                        <option value="token_invalid_scope">Access Token Response - invalid_scope</option>
+                        <option value="token_server_error">Access Token Response - server_error</option>
+                        <option value="token_temporarily_unavailable">Access Token Response - temporarily_unavailable</option>
+                    </select>                </div>
+
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="requested_oauth_error_description">
+                        OAuth error description
+                    </label>
+                    <input class="govuk-input" id="requested_oauth_error_description" name="requested_oauth_error_description" type="text" value="This error was triggered manually in the stub CRI">
+                </div>
+            </fieldset>
+
             <input type="hidden" name="resourceId" value="{{resourceId}}">
             <input class="govuk-button" data-module="govuk-button" type="submit" name="submit" value="Submit data and generate auth code">
         </form>  

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -375,6 +375,8 @@ class AuthorizeHandlerTest {
 
     private Map<String, String[]> validDoAuthorizeQueryParams() throws Exception {
         Map<String, String[]> queryParams = new HashMap<>();
+        queryParams.put(
+                RequestParamConstants.REQUESTED_OAUTH_ERROR_RESPONSE, new String[] {"none"});
         queryParams.put(RequestParamConstants.CLIENT_ID, new String[] {"clientIdValid"});
         queryParams.put(
                 RequestParamConstants.REQUEST,
@@ -387,6 +389,8 @@ class AuthorizeHandlerTest {
 
     private Map<String, String[]> validEncryptedDoAuthorizeQueryParams() throws Exception {
         Map<String, String[]> queryParams = new HashMap<>();
+        queryParams.put(
+                RequestParamConstants.REQUESTED_OAUTH_ERROR_RESPONSE, new String[] {"none"});
         queryParams.put(RequestParamConstants.CLIENT_ID, new String[] {"clientIdValid"});
         queryParams.put(
                 RequestParamConstants.REQUEST,
@@ -419,6 +423,8 @@ class AuthorizeHandlerTest {
 
     private Map<String, String[]> invalidResponseTypeDoAuthorizeQueryParams() throws Exception {
         Map<String, String[]> queryParams = new HashMap<>();
+        queryParams.put(
+                RequestParamConstants.REQUESTED_OAUTH_ERROR_RESPONSE, new String[] {"none"});
         queryParams.put(RequestParamConstants.CLIENT_ID, new String[] {"clientIdValid"});
         queryParams.put(
                 RequestParamConstants.REQUEST,
@@ -431,6 +437,8 @@ class AuthorizeHandlerTest {
 
     private Map<String, String[]> invalidRedirectUriDoAuthorizeQueryParams() throws Exception {
         Map<String, String[]> queryParams = new HashMap<>();
+        queryParams.put(
+                RequestParamConstants.REQUESTED_OAUTH_ERROR_RESPONSE, new String[] {"none"});
         queryParams.put(RequestParamConstants.CLIENT_ID, new String[] {"clientIdValid"});
         queryParams.put(
                 RequestParamConstants.REQUEST,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow OAuth errors to be triggered in CRI stub

### Why did it change

To allow us to more easily test journeys in the core where a CRI has returned an error.

One thing this piece of work doesn't do is allow the return of an
error response on the initial call to the auth endpoint. It's possible
for an error to happen, but we'd need a way to "prime" the CRI before
getting to the page presented by a GET to the auth endpoint. Some 
sort of backchannel request. Maybe this could be looked at in future.

The tests are fairly minimal and don't cover all use cases. The new
service is also being tested implicitly rather than directly. It's also
not being tested across an actual journey between the auth and token
endpoints. It would require a functional test with an app which is more
effort that it's probably worth right now.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1125](https://govukverify.atlassian.net/browse/PYI-1125)

#### Screenshot of the CRI stub with changes
<img width="784" alt="Screenshot 2022-05-19 at 21 55 23" src="https://user-images.githubusercontent.com/13836290/169403464-f1e22784-da69-4a87-b278-e4efb81ae715.png">

