### PR TITLE
PYIC-1322: Send api key value to CRI if env var is there

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -47,6 +47,8 @@ public class CoreStubConfig {
                     "CORE_STUB_JWT_ISS_CRI_URI",
                     "https://di-ipv-core-stub.london.cloudapps.digital");
     public static final String MAX_JAR_TTL_MINS = getConfigValue("MAX_JAR_TTL_MINS", "60");
+    public static final String PASSPORT_PRIVATE_API_KEY =
+            getConfigValue("PASSPORT_PRIVATE_API_KEY", null);
 
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Set the x-api-key header on the CRI /token & /credential requests if the ENV var has been setup.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The external api endpoints on CRI's will be private now. We intend to provide the private api key for this via an env variable for core-stub to use.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1322](https://govukverify.atlassian.net/browse/PYI-1322)

