### PR TITLE
Fix core-stub for missing api key env var

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -48,7 +48,7 @@ public class CoreStubConfig {
                     "https://di-ipv-core-stub.london.cloudapps.digital");
     public static final String MAX_JAR_TTL_MINS = getConfigValue("MAX_JAR_TTL_MINS", "60");
     public static final String PASSPORT_PRIVATE_API_KEY =
-            getConfigValue("PASSPORT_PRIVATE_API_KEY", null);
+            getConfigValue("PASSPORT_PRIVATE_API_KEY", "unknown");
 
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -87,6 +87,7 @@ public class HandlerHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(HandlerHelper.class);
     public static final String URN_UUID = "urn:uuid:";
     public static final String SHARED_CLAIMS = "shared_claims";
+    public static final String UNKNOWN_ENV_VAR = "unknown";
     public static final String API_KEY_HEADER = "x-api-key";
 
     private final ECKey ecSigningKey;
@@ -135,7 +136,7 @@ public class HandlerHelper {
 
         HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
         String apiKey = CoreStubConfig.PASSPORT_PRIVATE_API_KEY;
-        if (apiKey != null) {
+        if (!apiKey.equals(UNKNOWN_ENV_VAR)) {
             LOGGER.info(
                     "Found api key and sending it in token request to cri: {}",
                     credentialIssuer.id());
@@ -168,7 +169,7 @@ public class HandlerHelper {
                 new HTTPRequest(HTTPRequest.Method.POST, credentialIssuer.credentialUrl());
 
         String apiKey = CoreStubConfig.PASSPORT_PRIVATE_API_KEY;
-        if (apiKey != null) {
+        if (!apiKey.equals(UNKNOWN_ENV_VAR)) {
             LOGGER.info(
                     "Found api key and sending it in credential request to cri: {}",
                     credentialIssuer.id());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fix core stub by setting string value for missing ENV var.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Using null as the default value was causing the an exception to be thrown in the core-stub config/
<!-- Describe the reason these changes were made - the "why" -->

