### PR TITLE
KBV-401 send API keys in IPV Core Stub

### DIFF
--- a/di-ipv-core-stub/README.MD
+++ b/di-ipv-core-stub/README.MD
@@ -22,14 +22,22 @@ Core Stub config from the `di-ipv-config` repository directory `/stubs/di-ipv-co
 
 ## Environment
 
-Variable | Description | Example Value
---- | --- | --- |
-CORE_STUB_PORT             | The port number the IPV Core Stub should run on | `8085` |
-CORE_STUB_CLIENT_ID              | The id of the IPV Core Stub client | `ipv-core-stub` |
-CORE_STUB_REDIRECT_URL               | The OAuth callback url | `http://localhost:8085/callback` |
-CORE_STUB_MAX_SEARCH_RESULTS   | Max search by name results | `200` |
-CORE_STUB_USER_DATA_PATH  | File path to Experian user data zip file | `/app/config/experian-uat-users-large.zip` |
-CORE_STUB_CONFIG_FILE  | File path to the credential issuer config | `/app/config/cris-dev.yaml` for Docker, `config/cris-dev.yaml` for PaaS|
+Variable | Description                                              | Example Value
+--- |----------------------------------------------------------| --- |
+CORE_STUB_PORT             | The port number the IPV Core Stub should run on          | `8085` |
+CORE_STUB_CLIENT_ID              | The id of the IPV Core Stub client                       | `ipv-core-stub` |
+CORE_STUB_REDIRECT_URL               | The OAuth callback url                                   | `http://localhost:8085/callback` |
+CORE_STUB_MAX_SEARCH_RESULTS   | Max search by name results                               | `200` |
+CORE_STUB_USER_DATA_PATH  | File path to Experian user data zip file                 | `/app/config/experian-uat-users-large.zip` |
+CORE_STUB_CONFIG_FILE  | File path to the credential issuer config                | `/app/config/cris-dev.yaml` for Docker, `config/cris-dev.yaml` for PaaS|
+API_KEY_CRI_DEV | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_ADDRESS_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_ADDRESS_STAGING | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_ADDRESS_INTEGRATION | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_KBV_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_KBV_STAGING | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_KBV_INTEGRATION | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_FRAUD_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
 
 ## Running locally
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -47,13 +47,10 @@ public class CoreStubConfig {
                     "CORE_STUB_JWT_ISS_CRI_URI",
                     "https://di-ipv-core-stub.london.cloudapps.digital");
     public static final String MAX_JAR_TTL_MINS = getConfigValue("MAX_JAR_TTL_MINS", "60");
-    public static final String PASSPORT_PRIVATE_API_KEY =
-            getConfigValue("PASSPORT_PRIVATE_API_KEY", "unknown");
-
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();
 
-    private static String getConfigValue(String key, String defaultValue) {
+    public static String getConfigValue(String key, String defaultValue) {
         String envValue = Optional.ofNullable(System.getenv(key)).orElse(defaultValue);
         if (StringUtils.isBlank(envValue)) {
             throw new IllegalStateException(

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -11,4 +11,5 @@ public record CredentialIssuer(
         URI audience,
         boolean sendIdentityClaims,
         String expectedAlgo,
-        String publicEncryptionJwkBase64) {}
+        String publicEncryptionJwkBase64,
+        String apiKeyEnvVar) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
@@ -14,6 +14,7 @@ public class CredentialIssuerMapper {
         URI audience = URI.create((String) map.get("audience"));
         boolean sendIdentityClaims = Boolean.TRUE.equals(map.get("sendIdentityClaims"));
         String publicEncryptionJwkBase64 = (String) map.get("publicEncryptionJwkBase64");
+        String apiKeyEnvVar = (String) map.get("apiKeyEnvVar");
         return new CredentialIssuer(
                 id,
                 name,
@@ -23,6 +24,7 @@ public class CredentialIssuerMapper {
                 audience,
                 sendIdentityClaims,
                 "ES256",
-                publicEncryptionJwkBase64);
+                publicEncryptionJwkBase64,
+                apiKeyEnvVar);
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -142,6 +142,11 @@ public class HandlerHelper {
                     "Found api key and sending it in token request to cri: {}",
                     credentialIssuer.id());
             httpRequest.setHeader(API_KEY_HEADER, apiKey);
+        } else {
+            LOGGER.warn(
+                    "Did not find api key for env var {}, not setting api key header {} in token request",
+                    credentialIssuer.apiKeyEnvVar(),
+                    API_KEY_HEADER);
         }
 
         var httpTokenResponse = sendHttpRequest(httpRequest);
@@ -178,7 +183,7 @@ public class HandlerHelper {
             userInfoRequest.setHeader(API_KEY_HEADER, apiKey);
         } else {
             LOGGER.warn(
-                    "Did not find api key for env var {}, not setting api key header {}",
+                    "Did not find api key for env var {}, not setting api key header {} in credential request",
                     credentialIssuer.apiKeyEnvVar(),
                     API_KEY_HEADER);
         }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -135,7 +135,8 @@ public class HandlerHelper {
         TokenRequest tokenRequest = new TokenRequest(tokenURI, privateKeyJWT, authzGrant);
 
         HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
-        String apiKey = CoreStubConfig.PASSPORT_PRIVATE_API_KEY;
+        String apiKey =
+                CoreStubConfig.getConfigValue(credentialIssuer.apiKeyEnvVar(), UNKNOWN_ENV_VAR);
         if (!apiKey.equals(UNKNOWN_ENV_VAR)) {
             LOGGER.info(
                     "Found api key and sending it in token request to cri: {}",
@@ -168,12 +169,18 @@ public class HandlerHelper {
         HTTPRequest userInfoRequest =
                 new HTTPRequest(HTTPRequest.Method.POST, credentialIssuer.credentialUrl());
 
-        String apiKey = CoreStubConfig.PASSPORT_PRIVATE_API_KEY;
+        String apiKey =
+                CoreStubConfig.getConfigValue(credentialIssuer.apiKeyEnvVar(), UNKNOWN_ENV_VAR);
         if (!apiKey.equals(UNKNOWN_ENV_VAR)) {
             LOGGER.info(
                     "Found api key and sending it in credential request to cri: {}",
                     credentialIssuer.id());
             userInfoRequest.setHeader(API_KEY_HEADER, apiKey);
+        } else {
+            LOGGER.warn(
+                    "Did not find api key for env var {}, not setting api key header {}",
+                    credentialIssuer.apiKeyEnvVar(),
+                    API_KEY_HEADER);
         }
 
         userInfoRequest.setAuthorization(accessToken.toAuthorizationHeader());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Set API keys in IPV Core for backchannel OAuth flows for address, fraud and kbv CRIs.

These env vars will be set by hand on the PaaS deploy of IPV Core Stub.

See related PR https://github.com/alphagov/di-ipv-config/pull/640