### PR TITLE
KBV-484: Minor patch to allow testing of fraud check with users who have house names

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -43,6 +43,7 @@ public class IdentityMapper {
         UKAddress address =
                 new UKAddress(
                         houseNo,
+                        map.get("houseName"),
                         map.get("street"),
                         map.get("district"),
                         map.get("posttown"),
@@ -85,9 +86,9 @@ public class IdentityMapper {
                 List.of(new DateOfBirth(identity.findDateOfBirth().getDOB())),
                 List.of(
                         new CanonicalAddress(
-                                identity.UKAddress().street1(),
-                                null,
-                                identity.UKAddress().street2(),
+                                identity.UKAddress().buildingNumber(),
+                                identity.UKAddress().buildingName(),
+                                identity.UKAddress().street(),
                                 identity.UKAddress().townCity(),
                                 identity.UKAddress().postCode(),
                                 // default / arbitrary value assigned for now as

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/UKAddress.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/UKAddress.java
@@ -1,8 +1,9 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
 public record UKAddress(
-        String street1,
-        String street2,
+        String buildingNumber,
+        String buildingName,
+        String street,
         String county,
         String townCity,
         String postCode,


### PR DESCRIPTION
## Proposed changes

### What changed

Mapped house name to street 1 if house house number is not present

### Why did it change

To ease the testing of fraud

