### PR TITLE
PYIC-167 Update to allow providing contraindicators via text field

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -24,6 +24,7 @@ public class CredentialIssuerConfig {
     public static final String ACTIVITY_PARAM = "activityHistoryScore";
     public static final String FRAUD_PARAM = "identityFraudScore";
     public static final String VERIFICATION_PARAM = "verificationScore";
+    public static final String EVIDENCE_CONTRAINDICATOR_PARAM = "ci";
 
     public static Map<String, ClientConfig> CLIENT_CONFIGS;
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -229,6 +229,14 @@ public class AuthorizeHandler {
                                     queryParamsMap.value(
                                             CredentialIssuerConfig.VERIFICATION_PARAM));
 
+                    String ciString =
+                            queryParamsMap.value(
+                                    CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM);
+                    if (!ciString.trim().isEmpty()) {
+                        String[] ciList = ciString.split(",");
+                        gpgMap.put(CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM, ciList);
+                    }
+
                     Credential credential =
                             new Credential(combinedAttributeJson, gpgMap, userId, clientIdValue);
 

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -188,6 +188,18 @@
                 </div>
             {{/isVerificationType}}
 
+            <div class="govuk-form-group">
+                <h1 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--l" for="ci">
+                        Contraindicators
+                    </label>
+                </h1>
+                <div id="ci-more-detail-hint" class="govuk-hint">
+                    Please provide a comma-separated list e.g. A01,D02
+                </div>
+                <textarea class="govuk-textarea" id="ci" name="ci" rows="1" aria-describedby="ci-more-detail-hint"></textarea>
+            </div>
+
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -62,6 +62,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -339,6 +340,7 @@ class AuthorizeHandlerTest {
         Map<String, Object> persistedEvidence = persistedCredential.getValue().getEvidence();
         assertEquals(List.of("123 random street, M13 7GE"), persistedAttributes.get("addresses"));
         assertEquals("test-value", persistedAttributes.get("test"));
+        assertArrayEquals(new String[] {"A01", "D03"}, (String[]) persistedEvidence.get("ci"));
         assertEquals("IdentityCheck", persistedEvidence.get("type"));
         assertNotNull(persistedEvidence.get("txn"));
         assertNotNull(persistedEvidence.get("strengthScore"));
@@ -488,6 +490,8 @@ class AuthorizeHandlerTest {
                 new String[] {"26c6ad15-a595-4e13-9497-f7c891fabe1d"});
         queryParams.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, new String[] {"2"});
         queryParams.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, new String[] {"3"});
+        queryParams.put(
+                CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM, new String[] {"A01,D03"});
         return queryParams;
     }
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -81,7 +81,9 @@ public class VerifiableCredentialGeneratorTest {
                         "strengthScore",
                         4,
                         "validityScore",
-                        2);
+                        2,
+                        "ci",
+                        new String[] {"A01", "D03"});
         String userId = "user-id";
         Credential credential = new Credential(attributes, evidence, userId, "clientIdValid");
 
@@ -150,6 +152,8 @@ public class VerifiableCredentialGeneratorTest {
         assertEquals("some-uuid", evidenceTree.path(0).path("txn").asText());
         assertEquals(4, evidenceTree.path(0).path("strengthScore").asInt());
         assertEquals(2, evidenceTree.path(0).path("validityScore").asInt());
+        assertEquals("A01", evidenceTree.path(0).path("ci").path(0).asText());
+        assertEquals("D03", evidenceTree.path(0).path("ci").path(1).asText());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Add field to input list of contraindicators via the CRI stub

### Why did it change

So that we can set contraindicators on the VC

### Issue tracking
- [PYIC-167](https://govukverify.atlassian.net/browse/PYIC-167)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

