### PR TITLE
PYIC-167 Trim spaces on contraindicators input

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -230,9 +230,10 @@ public class AuthorizeHandler {
                                             CredentialIssuerConfig.VERIFICATION_PARAM));
 
                     String ciString =
-                            queryParamsMap.value(
-                                    CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM);
-                    if (!ciString.trim().isEmpty()) {
+                            queryParamsMap
+                                    .value(CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM)
+                                    .replaceAll("\\s", "");
+                    if (!ciString.isEmpty()) {
                         String[] ciList = ciString.split(",");
                         gpgMap.put(CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM, ciList);
                     }

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -491,7 +491,7 @@ class AuthorizeHandlerTest {
         queryParams.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, new String[] {"2"});
         queryParams.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, new String[] {"3"});
         queryParams.put(
-                CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM, new String[] {"A01,D03"});
+                CredentialIssuerConfig.EVIDENCE_CONTRAINDICATOR_PARAM, new String[] {"A01, D03"});
         return queryParams;
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Trim whitespace from contraindicators input to generate list

### Why did it change

Follow-up to PYIC-167 to fix whitespace bug

### Issue tracking
Follow-up to
- [PYIC-167](https://govukverify.atlassian.net/browse/PYIC-167)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
