### PR TITLE
KBV-26 Do not display the VC result json in IPV Core Stub if the env var COR…

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -47,6 +47,10 @@ public class CoreStubConfig {
                     "CORE_STUB_JWT_ISS_CRI_URI",
                     "https://di-ipv-core-stub.london.cloudapps.digital");
     public static final String MAX_JAR_TTL_MINS = getConfigValue("MAX_JAR_TTL_MINS", "60");
+
+    public static final boolean CORE_STUB_SHOW_VC =
+            Boolean.parseBoolean(getConfigValue("CORE_STUB_SHOW_VC", "true"));
+
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -148,12 +148,15 @@ public class CoreStubHandler {
                                 .getJWTClaimsSet()
                                 .toString();
 
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                JsonElement je = JsonParser.parseString(userInfo);
-                String prettyPrintUserInfo = gson.toJson(je);
+                String data = "{\"result\": \"hidden\"}";
+                if (CoreStubConfig.CORE_STUB_SHOW_VC) {
+                    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                    JsonElement je = JsonParser.parseString(userInfo);
+                    data = gson.toJson(je);
+                }
 
                 Map<String, Object> moustacheDataModel = new HashMap<>();
-                moustacheDataModel.put("data", prettyPrintUserInfo);
+                moustacheDataModel.put("data", data);
                 moustacheDataModel.put("cri", credentialIssuer.id());
                 moustacheDataModel.put("criName", credentialIssuer.name());
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Only display the VC result json in IPV Core Stub if the env var `CORE_STUB_SHOW_VC` is 'true'.

If this env var is absent, then the check will evaluate to `true`.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-26](https://govukverify.atlassian.net/browse/KBV-26)

## Checklists

### Environment variables or secrets


<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
