### PR TITLE
Error handling - added state to AuthorizationErrorResponse

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -178,7 +178,7 @@ public class CoreStubHandler {
                                     credentialIssuer.name()),
                             "user-search.mustache");
                 } else {
-                    sendAuthorizationRequest(response, credentialIssuer, null);
+                    sendAuthorizationRequest(request, response, credentialIssuer, null);
                     return null;
                 }
             };
@@ -191,7 +191,7 @@ public class CoreStubHandler {
                 var credentialIssuer = handlerHelper.findCredentialIssuer(credentialIssuerId);
                 var identity = handlerHelper.findIdentityByRowNumber(rowNumber);
                 var claimIdentity = new IdentityMapper().mapToSharedClaim(identity);
-                sendAuthorizationRequest(response, credentialIssuer, claimIdentity);
+                sendAuthorizationRequest(request, response, credentialIssuer, claimIdentity);
                 return null;
             };
 
@@ -228,14 +228,18 @@ public class CoreStubHandler {
                 IdentityMapper identityMapper = new IdentityMapper();
                 var identity = identityMapper.mapFormToIdentity(identityOnRecord, queryParamsMap);
                 SharedClaims sharedClaims = identityMapper.mapToSharedClaim(identity);
-                sendAuthorizationRequest(response, credentialIssuer, sharedClaims);
+                sendAuthorizationRequest(request, response, credentialIssuer, sharedClaims);
                 return null;
             };
 
     private void sendAuthorizationRequest(
-            Response response, CredentialIssuer credentialIssuer, SharedClaims sharedClaims)
+            Request request,
+            Response response,
+            CredentialIssuer credentialIssuer,
+            SharedClaims sharedClaims)
             throws JOSEException {
         State state = createNewState(credentialIssuer);
+        request.session().attribute("state", state);
         AuthorizationRequest authRequest =
                 handlerHelper.createAuthorizationJAR(state, credentialIssuer, sharedClaims);
         LOGGER.info("🚀 sending AuthorizationRequest for state {}", state);

--- a/di-ipv-core-stub/src/main/resources/templates/error.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/error.mustache
@@ -52,18 +52,13 @@
     <main class="govuk-main-wrapper>" id="main-content" role="main">
         <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
             <h2 class="govuk-heading-xl">
-                There is a problem
+                There is a problem.
             </h2>
-        </div>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
-             data-module="govuk-error-summary">
-            <div class="govuk-error-summary__body">
-                <ul class="govuk-list govuk-error-summary__list">
-                    <li>
-                        {{error}}
-                    </li>
-                </ul>
-            </div>
+            <details class="govuk-details" data-module="govuk-details">
+                <div class="govuk-details__text">
+                    <pre><code id="data">{{error}}</code></pre>
+                </div>
+            </details>
         </div>
     </main>
 </div>


### PR DESCRIPTION
In order to conform with the standards [here](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) , have added the `AuthorizationErrorResponse` and included the `state` parameter which has been maintained via the `session`
### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-563](https://govukverify.atlassian.net/browse/KBV-563)

## Sample error payload
![image](https://user-images.githubusercontent.com/95495586/175328820-e95f082e-1e11-4d7c-93d3-b870eb65ef3e.png)
