### PR TITLE
Send back Insufficient questions on KBV Experian Stub

### DIFF
--- a/experian-kbv-stub/src/main/java/uk/gov/di/ipv/stub/experian/Handler.java
+++ b/experian-kbv-stub/src/main/java/uk/gov/di/ipv/stub/experian/Handler.java
@@ -182,16 +182,32 @@ public class Handler {
 
         SAAResponse saaResponse = new SAAResponse();
         SAAResponse2 saaResult = new SAAResponse2();
-
+        Results results = new Results();
+        ArrayOfString nextTransId = new ArrayOfString();
         saaResult.setControl(control);
+
+        if (saaObject
+                        .getSAARequest()
+                        .getApplicant()
+                        .getName()
+                        .getForename()
+                        .equalsIgnoreCase("SUZIE")
+                && saaObject
+                        .getSAARequest()
+                        .getApplicant()
+                        .getName()
+                        .getSurname()
+                        .equalsIgnoreCase("SHREEVE")) {
+            simulateThinFileResult(sw, saaResponse, saaResult, results, nextTransId);
+            return;
+        }
+
         Questions questions = new Questions();
         List<Question> questionList = questions.getQuestion();
         questionList.add(getQuestion1());
         questionList.add(getQuestion2());
         saaResult.setQuestions(questions);
-        Results results = new Results();
         results.setOutcome("Authentication Questions returned");
-        ArrayOfString nextTransId = new ArrayOfString();
         nextTransId.getString().add("RTQ");
         results.setNextTransId(nextTransId);
         saaResult.setResults(results);
@@ -199,6 +215,24 @@ public class Handler {
         saaResponse.setSAAResult(saaResult);
 
         saaResponseMarshaller.marshal(saaResponse, sw);
+    }
+
+    private void simulateThinFileResult(
+            StringWriter sw,
+            SAAResponse saaResponse,
+            SAAResponse2 saaResult,
+            Results results,
+            ArrayOfString nextTransId)
+            throws JAXBException {
+        results.setOutcome("Insufficient Questions (Unable to Authenticate)");
+        results.setAuthenticationResult(UNABLE_TO_AUTHENTICATE);
+        nextTransId.getString().add("END");
+        results.setNextTransId(nextTransId);
+        saaResult.setResults(results);
+        saaResponse.setSAAResult(saaResult);
+
+        saaResponseMarshaller.marshal(saaResponse, sw);
+        return;
     }
 
     private void stubRTQ(StringWriter sw, Document bodyDoc) throws JAXBException {


### PR DESCRIPTION
## Proposed changes
- Added code to check if user identity matches _Suzie Shreeve_
- A result with status `Unable to Authenticate` is sent back for the above user

### Issue tracking
- [KBV-614](https://govukverify.atlassian.net/browse/KBV-614)

## Sample
![image](https://user-images.githubusercontent.com/95495586/176681588-cc2a7a4c-8f1e-4281-899a-f62ffe26f798.png)
