### PR TITLE
PYIC-1534 Add missing jti claim for token request

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -77,6 +77,7 @@ public class JwtBuilder {
                 .audience(IPV_CORE_AUDIENCE)
                 .issuer(ORCHESTRATOR_CLIENT_ID)
                 .expirationTime(generateExpirationTime(now))
+                .jwtID(UUID.randomUUID().toString())
                 .build();
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Set a value (random uuid) for the jti (JWT id) claim for the token request auth

### Why did it change

OpenID Connect Core 1.0 Section 9 ([Final: OpenID Connect Core 1.0 incorporating errata set 1](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)) states that the private_key_jwt is required to contain a jti claim, which is a unique identifier for the JWT. We'll now be validating this in core so it should be present.

### Issue tracking
- [PYIC-1534](https://govukverify.atlassian.net/browse/PYIC-1534)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
