### PR TITLE
[KBV-763] - Fix IPV Core Stub CRI Results page title From Example To Va…

### DIFF
--- a/di-ipv-core-stub/src/main/resources/templates/userinfo.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/userinfo.mustache
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 <head>
-    <title>Example - GOV.UK</title>
+    <title>IPV Core Stub Credential Result - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 


### PR DESCRIPTION
Fix IPV Core Stub CRI Results page title From Example To Valid Title


In PV Core Stub CRI Results Page The Title Till now is “Example - GOV.UK”. 

## Proposed changes
Changed  “Example - GOV.UK” to "IPV Core Stub Credential Result - GOV.UK"
### What changed
Title in File di-ipv-core-stub/src/main/resources/templates/userinfo.mustache


### Why did it change
To have Help users to see which Stub they use than an Example.


### Issue tracking

https://govukverify.atlassian.net/browse/KBV-763
