### PR TITLE
LIME-45 Add persistent_session_id and govuk_signin_journey_id to core…

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -86,6 +86,8 @@ public class HandlerHelper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HandlerHelper.class);
     public static final String SHARED_CLAIMS = "shared_claims";
+    private static final String PERSISTENT_SESSION_ID = "persistent_session_id";
+    private static final String CLIENT_SESSION_ID = "govuk_signin_journey_id";
     public static final String UNKNOWN_ENV_VAR = "unknown";
     public static final String API_KEY_HEADER = "x-api-key";
 
@@ -246,7 +248,9 @@ public class HandlerHelper {
                                                 Integer.parseInt(CoreStubConfig.MAX_JAR_TTL_MINS),
                                                 ChronoUnit.MINUTES)))
                         .notBeforeTime(Date.from(now))
-                        .subject(getSubject());
+                        .subject(getSubject())
+                        .claim(PERSISTENT_SESSION_ID, UUID.randomUUID().toString())
+                        .claim(CLIENT_SESSION_ID, UUID.randomUUID().toString());
 
         if (Objects.nonNull(sharedClaims)) {
             Map<String, Object> map = convertToMap(sharedClaims);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -68,6 +68,7 @@ public class JwtBuilder {
                 .claim("redirect_uri", redirectUri)
                 .claim("state", UUID.randomUUID().toString())
                 .claim("govuk_signin_journey_id", UUID.randomUUID().toString())
+                .claim("persistent_session_id", UUID.randomUUID().toString())
                 .build();
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Core-Stub
Enable sending persistent_session_id and govuk_signin_journey_id in JWT.
Orchestrator-Stub
As above with govuk_signin_journey_id sending added by https://github.com/alphagov/di-ipv-stubs/pull/138

### Why did it change

Per [ADR-0039](https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0039-govuk-signin-journey-id.md) to enable following a single journey through the complete system.

PersistentSessionId= "persistent_session_id"
ClientSessionId = "govuk_signin_journey_id" 
ClientSessionId follows [IPVAuthorisationService](https://github.com/alphagov/di-authentication-api/pull/2183/files) for variable naming.

### Issue tracking

- [LIME-45](https://govukverify.atlassian.net/browse/LIME-45)
- [PYI-1755](https://govukverify.atlassian.net/browse/PYIC-1755)