### PR TITLE
BAU: Do not include evidence for user asserted CRIs

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.1.12.1-amzn

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -55,6 +55,7 @@ import java.util.UUID;
 
 import static com.nimbusds.jose.shaded.json.parser.JSONParser.MODE_JSON_SIMPLE;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getCriType;
+import static uk.gov.di.ipv.stub.cred.config.CriType.USER_ASSERTED_CRI_TYPE;
 
 public class AuthorizeHandler {
 
@@ -321,6 +322,12 @@ public class AuthorizeHandler {
             String fraudValue,
             String verificationValue)
             throws CriStubException {
+
+        if (criType.equals(USER_ASSERTED_CRI_TYPE)) {
+            // VCs from user asserted CRIs, like address, do not have GPG45 scores
+            return null;
+        }
+
         ValidationResult validationResult =
                 Validator.verifyGpg45(
                         criType,

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -8,6 +8,7 @@ import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig;
+import uk.gov.di.ipv.stub.cred.config.CriType;
 import uk.gov.di.ipv.stub.cred.domain.Credential;
 
 import java.security.KeyFactory;
@@ -28,6 +29,7 @@ import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
+import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getCriType;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_ADDRESS;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_BIRTH_DATE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_NAME;
@@ -71,8 +73,11 @@ public class VerifiableCredentialGenerator {
         // Copy any remaining attributes in. The JSON manually entered into the stub.
         credentialSubject.putAll(attributes);
         vc.put(VC_CREDENTIAL_SUBJECT, credentialSubject);
-        // The schema is unclear on how this should be presented so just copying wholesale for now.
-        vc.put(VC_EVIDENCE, List.of(credential.getEvidence()));
+
+        // VCs from user asserted CRI types, like address, should not contain an evidence attribute
+        if (getCriType() != CriType.USER_ASSERTED_CRI_TYPE) {
+            vc.put(VC_EVIDENCE, List.of(credential.getEvidence()));
+        }
 
         return generateAndSignVerifiableCredentialJwt(credential, vc);
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Do not include evidence for user asserted CRIs

### Why did it change

The stub was returning an evidence attribute in the VC for user asserted
CRIs, such as the address CRI. User asserted CRIs will not contain an
evidence attribute, and we should reflect this in what the stub returns.
