### PR TITLE
LIME-116 Allow starting a backend only journey.

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -37,7 +37,22 @@ public class CoreStub {
         Spark.post("/edit-user", coreStubHandler.updateUser);
         Spark.get("/callback", coreStubHandler.doCallback);
         Spark.get("/answers", coreStubHandler.answers);
+        setupBackendRoutes(coreStubHandler);
         Spark.exception(Exception.class, exceptionHandler());
+    }
+
+    private void setupBackendRoutes(CoreStubHandler coreStubHandler) {
+        if (!CoreStubConfig.CORE_STUB_ENABLE_BACKEND_ROUTES) {
+            LOGGER.info("BackendRoutes Disabled.");
+            return;
+        }
+
+        LOGGER.warn("BackendRoutes Enabled.");
+
+        Spark.get(
+                "/backend/generateInitialClaimsSet",
+                coreStubHandler.backendGenerateInitialClaimsSet);
+        Spark.post("/backend/createSessionRequest", coreStubHandler.createBackendSessionRequest);
     }
 
     private ExceptionHandler exceptionHandler() {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -53,6 +53,9 @@ public class CoreStubConfig {
     public static final boolean CORE_STUB_SHOW_VC =
             Boolean.parseBoolean(getConfigValue("CORE_STUB_SHOW_VC", "true"));
 
+    public static final boolean CORE_STUB_ENABLE_BACKEND_ROUTES =
+            Boolean.parseBoolean(getConfigValue("CORE_STUB_ENABLE_BACKEND_ROUTES", "true"));
+
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add two routes to core-stub.

/backend/generateInitialClaimSet

/backend/createSessionRequest

Minor refactoring to allow backend/frontend journey to share the same code path.

### Why did it change

To enable starting a backend only journey.

Tested for FraudCRI and AddressCRI via -

Making a Get request to http://localhost:8085/backend/generateInitialClaimsSet?cri=fraud-cri-dev&rowNumber=3
Which will return a complete ClaimSet (JSON) with the shared_claims populated for the matching row. For simplifying operation - state and client_id are set in the claimsSet now.


Post the JSON/ClaimsSet to http://localhost:8085/backend/createSessionRequest?cri=fraud-cri-dev
This will then create a JWT using the claimSet which is then signed and encrypted.
A JSON reply (AuthorizationRequest) will be returned in the format `{"request":", "Data, client_id":"ipv-core-stub"}`, which can then be posted to the session resource on the private api gateway.
Outputted in the logs will be the equivalent AuthorizationRequest URI which (if the cri front end is running) allow picking up the journey in the frontend for debugging.

For dev testing the following script was used for posting the JSON/ClaimsSet back.

```
#!/bin/sh
curl -X POST "http://localhost:8085/backend/createSessionRequest?cri=$2" \
-H "Content-Type: application/json" \
-d "$1"
```
`./json-request.sh '{Valid JSON}' 'fraud-cri-dev'`

### Issue tracking

- [LIME-116](https://govukverify.atlassian.net/browse/LIME-116)