### PR TITLE
Pyic 1847 app gpg45 data

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -24,6 +24,9 @@ public class CredentialIssuerConfig {
     public static final String ACTIVITY_PARAM = "activityHistoryScore";
     public static final String FRAUD_PARAM = "identityFraudScore";
     public static final String VERIFICATION_PARAM = "verificationScore";
+    public static final String CHECK_DETAILS_PARAM = "checkDetails";
+    public static final String FAILED_CHECK_DETAILS_PARAM = "failedCheckDetails";
+    public static final String BIOMETRICK_VERIFICATION_PARAM = "biometricVerificationScore";
     public static final String EVIDENCE_CONTRAINDICATOR_PARAM = "ci";
 
     public static Map<String, ClientConfig> CLIENT_CONFIGS;

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -21,6 +21,7 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.util.MapUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.QueryParamsMap;
@@ -370,20 +371,25 @@ public class AuthorizeHandler {
             case VERIFICATION_CRI_TYPE -> gpg45Score.put(
                     CredentialIssuerConfig.VERIFICATION_PARAM, Integer.parseInt(verificationValue));
             case DOC_CHECK_APP_CRI_TYPE -> {
-                gpg45Score.put(
-                        CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM,
-                        Integer.parseInt(strengthValue));
-                int validityNum = Integer.parseInt(validityValue);
+                int strengthNum =
+                        StringUtils.isNotBlank(validityValue) ? Integer.parseInt(strengthValue) : 3;
+                gpg45Score.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, strengthNum);
+                int validityNum =
+                        StringUtils.isNotBlank(validityValue) ? Integer.parseInt(validityValue) : 2;
                 gpg45Score.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, validityNum);
 
                 List<Map<String, Object>> checkDetailsValue = new ArrayList<>();
                 checkDetailsValue.add(Map.of("checkMethod", "vri"));
+                int biometricVerificationNum =
+                        StringUtils.isNotBlank(biometricVerificationValue)
+                                ? Integer.parseInt(biometricVerificationValue)
+                                : 2;
                 checkDetailsValue.add(
                         Map.of(
                                 "checkMethod",
                                 "bvr",
                                 "biometricVerificationProcessLevel",
-                                biometricVerificationValue));
+                                biometricVerificationNum));
 
                 if (validityNum < 2) {
                     gpg45Score.put(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -48,7 +48,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -74,6 +76,7 @@ public class AuthorizeHandler {
     private static final String IS_ACTIVITY_TYPE_PARAM = "isActivityType";
     private static final String IS_FRAUD_TYPE_PARAM = "isFraudType";
     private static final String IS_VERIFICATION_TYPE_PARAM = "isVerificationType";
+    private static final String IS_DOC_CHECKING_TYPE_PARAM = "isDocCheckingType";
     private static final String HAS_ERROR_PARAM = "hasError";
     private static final String ERROR_PARAM = "error";
     private static final String CRI_NAME_PARAM = "cri-name";
@@ -163,6 +166,8 @@ public class AuthorizeHandler {
                 frontendParams.put(IS_FRAUD_TYPE_PARAM, criType.equals(CriType.FRAUD_CRI_TYPE));
                 frontendParams.put(
                         IS_VERIFICATION_TYPE_PARAM, criType.equals(CriType.VERIFICATION_CRI_TYPE));
+                frontendParams.put(
+                        IS_DOC_CHECKING_TYPE_PARAM, criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE));
                 if (!criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
                     frontendParams.put(SHARED_CLAIMS, getSharedAttributes(queryParamsMap));
                 }
@@ -235,8 +240,9 @@ public class AuthorizeHandler {
                                             CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM),
                                     queryParamsMap.value(CredentialIssuerConfig.ACTIVITY_PARAM),
                                     queryParamsMap.value(CredentialIssuerConfig.FRAUD_PARAM),
+                                    queryParamsMap.value(CredentialIssuerConfig.VERIFICATION_PARAM),
                                     queryParamsMap.value(
-                                            CredentialIssuerConfig.VERIFICATION_PARAM));
+                                            CredentialIssuerConfig.BIOMETRICK_VERIFICATION_PARAM));
 
                     String ciString =
                             queryParamsMap
@@ -320,7 +326,8 @@ public class AuthorizeHandler {
             String validityValue,
             String activityValue,
             String fraudValue,
-            String verificationValue)
+            String verificationValue,
+            String biometricVerificationValue)
             throws CriStubException {
 
         if (criType.equals(USER_ASSERTED_CRI_TYPE)) {
@@ -362,6 +369,29 @@ public class AuthorizeHandler {
                     CredentialIssuerConfig.FRAUD_PARAM, Integer.parseInt(fraudValue));
             case VERIFICATION_CRI_TYPE -> gpg45Score.put(
                     CredentialIssuerConfig.VERIFICATION_PARAM, Integer.parseInt(verificationValue));
+            case DOC_CHECK_APP_CRI_TYPE -> {
+                gpg45Score.put(
+                        CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM,
+                        Integer.parseInt(strengthValue));
+                int validityNum = Integer.parseInt(validityValue);
+                gpg45Score.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, validityNum);
+
+                List<Map<String, Object>> checkDetailsValue = new ArrayList<>();
+                checkDetailsValue.add(Map.of("checkMethod", "vri"));
+                checkDetailsValue.add(
+                        Map.of(
+                                "checkMethod",
+                                "bvr",
+                                "biometricVerificationProcessLevel",
+                                biometricVerificationValue));
+
+                if (validityNum < 2) {
+                    gpg45Score.put(
+                            CredentialIssuerConfig.FAILED_CHECK_DETAILS_PARAM, checkDetailsValue);
+                } else {
+                    gpg45Score.put(CredentialIssuerConfig.CHECK_DETAILS_PARAM, checkDetailsValue);
+                }
+            }
         }
         return gpg45Score;
     }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -347,6 +347,40 @@
           }
         ]
       }
+    },
+    {
+      "criType": "DOC Checking App (Stub)",
+      "label": "Joe Shmoe (Valid) Driving Licence",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Joe Shmoe",
+                "type": "GivenName"
+              },
+              {
+                "value": "Doe The Ball",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1985-02-08"
+          }
+        ],
+        "drivingPermit": [
+          {
+            "personalNumber": "DOE99802085J99FG",
+            "expiryDate": "2023-01-18",
+            "issueNumber": null,
+            "issuedBy": null,
+            "issueDate": null
+          }
+        ]
+      }
     }
   ]
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -146,6 +146,37 @@
                 </fieldset>
             {{/isEvidenceType}}
 
+            {{#isDocCheckingType}}
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">
+                            GPG45 Evidence
+                        </h1>
+                    </legend>
+
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="strength">
+                            Strength
+                        </label>
+                        <input class="govuk-input govuk-input--width-2" id="strength" name="strengthScore" type="number" min="0" max="5" step="1">
+                    </div>
+
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="validity">
+                            Validity
+                        </label>
+                        <input class="govuk-input govuk-input--width-2" id="validity" name="validityScore" type="number" min="0" max="5" step="1">
+                    </div>
+
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="validity">
+                            Biometric Verification Process Level
+                        </label>
+                        <input class="govuk-input govuk-input--width-2" id="validity" name="biometricVerificationScore" type="number" min="0" max="5" step="1">
+                    </div>
+                </fieldset>
+            {{/isDocCheckingType}}
+
             {{#isActivityType}}
                 <div class="govuk-form-group">
                     <h1 class="govuk-label-wrapper">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new GPG45 score input fields for the app stub and build out the `evidence` block of the returned VC.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Ipv-core needs the stub to return a VC that follows the same structure as the the doc checking app. These changes ensure that the GPG45 evidence block of the VC now contains the correct fields.

If the new input fields are left blank, than default values will be used that reflect a successful happy path VC. i.e
StrengthScore: 3
ValidityScore: 2
BiometrickVerificationProcessLevel: 2

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1847](https://govukverify.atlassian.net/browse/PYI-1847)

