### PR TITLE
LIME-151 Log response from API Gateway when requesting VC.

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -207,6 +207,7 @@ public class HandlerHelper {
                 state,
                 userInfoRequest.getURL());
         HTTPResponse userInfoHttpResponse = sendHttpRequest(userInfoRequest);
+        LOGGER.debug("UserInfoHttpResponse : {}", userInfoHttpResponse.getContent());
         return userInfoHttpResponse.getContent();
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add logging of the response from the API Gateway when requesting a VC.

### Why did it change

In non-happy path the API gateway will instead of the expected JWT, return a JSON response with an error message that may be useful for debugging.
When this occurs the response is evaluated as a JWT, which fails and an unhelpful JWT error message displayed in the browser.
The Logged API Gateway response will have the real error information in this scenario.

### Issue tracking

- [LIME-151](https://govukverify.atlassian.net/browse/LIME-151)