### PR TITLE
Add new input fields to orc stub to set the user id being sent to ipv-core

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -44,7 +44,7 @@ public class JwtBuilder {
     public static final String INVALID_AUDIENCE = "invalid-audience";
     public static final String INVALID_REDIRECT_URI = "http://example.com";
 
-    public static JWTClaimsSet buildAuthorizationRequestClaims(String errorType) {
+    public static JWTClaimsSet buildAuthorizationRequestClaims(String userId, String errorType) {
         String audience = IPV_CORE_AUDIENCE;
         String redirectUri = ORCHESTRATOR_REDIRECT_URL;
         if (errorType != null) {
@@ -57,7 +57,7 @@ public class JwtBuilder {
 
         Instant now = Instant.now();
         return new JWTClaimsSet.Builder()
-                .subject(URN_UUID + UUID.randomUUID())
+                .subject(userId)
                 .audience(audience)
                 .issueTime(Date.from(now))
                 .issuer(ORCHESTRATOR_CLIENT_ID)

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -54,12 +54,25 @@
         </div>
         <h2 class="govuk-heading-l">Prove Your Identity</h2>
         <form action="/authorize">
-            <input type="hidden" name="journeyType" value="debug" />
-            <input class="govuk-button" data-module="govuk-button" type="submit" value="Debug route">
+            <input type="hidden" name="journeyType" value="full" />
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="userIdSelect">Choose a user id value:</label>
+                <select class="govuk-select" name="userIdSelect" id="userIdSelect">
+                    <option value=""></option>
+                    <option value="urn:uuid:00c6bddd-c5dc-42ab-89d1-cecf12cee10f">urn:uuid:00c6bddd-c5dc-42ab-89d1-cecf12cee10f - App journey user</option>
+                    <option value="urn:uuid:34g1agte-g88c-78aa-bn1a-dyu1f0flpo2x">urn:uuid:34g1agte-g88c-78aa-bn1a-dyu1f0flpo2x - Non app journey user</option>
+                </select>
+            </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="userIdText">Or enter one manually</label>
+                <input class="govuk-input" data-module="govuk-input" name="userIdText" id="userIdText" type="text" value="">
+            </div>
+
+            <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
         </form>
         <form action="/authorize">
-            <input type="hidden" name="journeyType" value="full" />
-            <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
+            <input type="hidden" name="journeyType" value="debug" />
+            <input class="govuk-button" data-module="govuk-button" type="submit" value="Debug route">
         </form>
         <form action="/authorize">
             <label class="govuk-label" for="error">Choose an error type:</label>


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new input fields to orc stub to be able to manually enter the user-id being sent to ipv-core.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This will be useful for testing purposes. For example we can manually set the value to be a user that is either on or not on the allowed list of userID's being sent on the app journey.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1895](https://govukverify.atlassian.net/browse/PYI-1895)

