### PR TITLE
Bau increase spark header limit size

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/App.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/App.java
@@ -37,7 +37,7 @@ public class App {
                 Stream.of(server.getConnectors()).map(Connector::getConnectionFactories).flatMap(Collection::stream)
                         .filter(t -> t.getClass().isAssignableFrom(HttpConnectionFactory.class))
                         .map(t -> ((HttpConnectionFactory) t).getHttpConfiguration()).forEach(t -> {
-                            t.setRequestHeaderSize(10 * 1024);
+                            t.setRequestHeaderSize(9 * 1024);
                             t.setSendServerVersion(false);
                             t.setSendDateHeader(false);
                         });

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/App.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/App.java
@@ -1,8 +1,48 @@
 package uk.gov.di.ipv.stub.cred;
 
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import spark.embeddedserver.EmbeddedServerFactory;
+import spark.embeddedserver.EmbeddedServers;
+import spark.embeddedserver.jetty.EmbeddedJettyFactory;
+import spark.embeddedserver.jetty.JettyServerFactory;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+
 public class App {
 
     public static void main(String[] args) {
+        EmbeddedServers.add(EmbeddedServers.Identifiers.JETTY, createEmbeddedServerFactory());
+
         new CredentialIssuer();
+    }
+
+    private static EmbeddedServerFactory createEmbeddedServerFactory() {
+        return new EmbeddedJettyFactory(new JettyServerFactory() {
+            @Override
+            public Server create(int maxThreads, int minThreads, int threadTimeoutMillis) {
+                return create(maxThreads <= 0 ? null
+                        : new QueuedThreadPool(maxThreads, minThreads, threadTimeoutMillis));
+            }
+
+            @Override
+            public Server create(ThreadPool threadPool) {
+                Server server = new Server(threadPool);
+
+                Stream.of(server.getConnectors()).map(Connector::getConnectionFactories).flatMap(Collection::stream)
+                        .filter(t -> t.getClass().isAssignableFrom(HttpConnectionFactory.class))
+                        .map(t -> ((HttpConnectionFactory) t).getHttpConfiguration()).forEach(t -> {
+                            t.setRequestHeaderSize(10 * 1024);
+                            t.setSendServerVersion(false);
+                            t.setSendDateHeader(false);
+                        });
+                return server;
+            }
+        });
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/App.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/App.java
@@ -13,7 +13,6 @@ import spark.embeddedserver.jetty.JettyServerFactory;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-
 public class App {
 
     public static void main(String[] args) {
@@ -23,26 +22,38 @@ public class App {
     }
 
     private static EmbeddedServerFactory createEmbeddedServerFactory() {
-        return new EmbeddedJettyFactory(new JettyServerFactory() {
-            @Override
-            public Server create(int maxThreads, int minThreads, int threadTimeoutMillis) {
-                return create(maxThreads <= 0 ? null
-                        : new QueuedThreadPool(maxThreads, minThreads, threadTimeoutMillis));
-            }
+        return new EmbeddedJettyFactory(
+                new JettyServerFactory() {
+                    @Override
+                    public Server create(int maxThreads, int minThreads, int threadTimeoutMillis) {
+                        return create(
+                                maxThreads <= 0
+                                        ? null
+                                        : new QueuedThreadPool(
+                                                maxThreads, minThreads, threadTimeoutMillis));
+                    }
 
-            @Override
-            public Server create(ThreadPool threadPool) {
-                Server server = new Server(threadPool);
+                    @Override
+                    public Server create(ThreadPool threadPool) {
+                        Server server = new Server(threadPool);
 
-                Stream.of(server.getConnectors()).map(Connector::getConnectionFactories).flatMap(Collection::stream)
-                        .filter(t -> t.getClass().isAssignableFrom(HttpConnectionFactory.class))
-                        .map(t -> ((HttpConnectionFactory) t).getHttpConfiguration()).forEach(t -> {
-                            t.setRequestHeaderSize(9 * 1024);
-                            t.setSendServerVersion(false);
-                            t.setSendDateHeader(false);
-                        });
-                return server;
-            }
-        });
+                        Stream.of(server.getConnectors())
+                                .map(Connector::getConnectionFactories)
+                                .flatMap(Collection::stream)
+                                .filter(
+                                        t ->
+                                                t.getClass()
+                                                        .isAssignableFrom(
+                                                                HttpConnectionFactory.class))
+                                .map(t -> ((HttpConnectionFactory) t).getHttpConfiguration())
+                                .forEach(
+                                        t -> {
+                                            t.setRequestHeaderSize(9 * 1024);
+                                            t.setSendServerVersion(false);
+                                            t.setSendDateHeader(false);
+                                        });
+                        return server;
+                    }
+                });
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Set up a custom Spark EmbeddedServerFactory so that we can customise the request header size limit. 

We have increased the request header limit from 8*1024, to 9*1024. This value was chose because our AWS api gateways have a value of 10*1024, so having it slightly lower can act as a warning for us if we ever run into this issue again.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Due to the increase in the shared claims size we send on certain journeys we were tipping over the request header size limits.
<!-- Describe the reason these changes were made - the "why" -->

