### PR TITLE
OJ-940: Add a postcode claim to IPV core stub

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -31,6 +31,7 @@ public class CoreStub {
         Spark.get("/", coreStubHandler.serveHomePage);
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);
+        Spark.get("/credential-issuer?cri=address-cri-dev/edit-postcode", coreStubHandler.editPostCode);
         Spark.get("/authorize", coreStubHandler.authorize);
         Spark.get("/user-search", coreStubHandler.userSearch);
         Spark.get("/edit-user", coreStubHandler.editUser);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -31,7 +31,7 @@ public class CoreStub {
         Spark.get("/", coreStubHandler.serveHomePage);
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);
-        Spark.get("/credential-issuer?cri=address-cri-dev/edit-postcode", coreStubHandler.editPostCode);
+        Spark.get("/edit-postcode", coreStubHandler.editPostcode);
         Spark.get("/authorize", coreStubHandler.authorize);
         Spark.get("/user-search", coreStubHandler.userSearch);
         Spark.get("/edit-user", coreStubHandler.editUser);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -12,4 +12,8 @@ public record CredentialIssuer(
         boolean sendIdentityClaims,
         String expectedAlgo,
         String publicEncryptionJwkBase64,
-        String apiKeyEnvVar) {}
+        String apiKeyEnvVar) {
+    public boolean isAddressCri() {
+        return this.id.contains("address");
+    }
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/CanonicalAddress.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/CanonicalAddress.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDate;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record CanonicalAddress(
         String buildingNumber,
         String buildingName,

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -124,15 +124,15 @@ public class IdentityMapper {
                 canonicalAddresses);
     }
 
-    public PostcodeSharedClaims mapToAddressSharedClaims(String postcode){
-        CanonicalAddress canonicalAddress = new CanonicalAddress(
-                null, null,null,null,postcode,null,null);
+    public PostcodeSharedClaims mapToAddressSharedClaims(String postcode) {
+        CanonicalAddress canonicalAddress =
+                new CanonicalAddress(null, null, null, null, postcode, null, null);
 
         return new PostcodeSharedClaims(
                 List.of(
                         "https://www.w3.org/2018/credentials/v1",
                         "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"),
-              List.of(canonicalAddress));
+                List.of(canonicalAddress));
     }
 
     public List<QuestionAndAnswer> mapToQuestionAnswers(

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -124,6 +124,17 @@ public class IdentityMapper {
                 canonicalAddresses);
     }
 
+    public PostcodeSharedClaims mapToAddressSharedClaims(String postcode){
+        CanonicalAddress canonicalAddress = new CanonicalAddress(
+                null, null,null,null,postcode,null,null);
+
+        return new PostcodeSharedClaims(
+                List.of(
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"),
+              List.of(canonicalAddress));
+    }
+
     public List<QuestionAndAnswer> mapToQuestionAnswers(
             Identity identity, Map<String, String> questionsMap) {
         return identity.questions().questions().stream()

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/PostcodeSharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/PostcodeSharedClaims.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-
-public record PostcodeSharedClaims(@JsonProperty("@context") List<String> context,
-                                   @JsonProperty("address") List<CanonicalAddress> addresses) {
-}
+public record PostcodeSharedClaims(
+        @JsonProperty("@context") List<String> context,
+        @JsonProperty("address") List<CanonicalAddress> addresses) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/PostcodeSharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/PostcodeSharedClaims.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+
+public record PostcodeSharedClaims(@JsonProperty("@context") List<String> context,
+                                   @JsonProperty("address") List<CanonicalAddress> addresses) {
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -361,6 +361,8 @@ public class CoreStubHandler {
                 return tokenRequest.toHTTPRequest().getQuery();
             };
 
+    public Route editPostCode;
+
     private String createBackendSessionRequestJSONReply(AuthorizationRequest authorizationRequest) {
         // Splits the QueryString from the Auth URI.  Turning the list of parameters
         // (key1=value1&key2=value2 etc...) into a json object.

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -173,7 +173,9 @@ public class CoreStubHandler {
                 var credentialIssuer =
                         handlerHelper.findCredentialIssuer(
                                 Objects.requireNonNull(request.queryParams("cri")));
-                if (credentialIssuer.sendIdentityClaims()) {
+                var postcode = request.queryParams("postcode");
+                if (credentialIssuer.sendIdentityClaims()
+                        && Objects.isNull(request.queryParams("postcode"))) {
                     return ViewHelper.render(
                             Map.of(
                                     "cri",
@@ -181,7 +183,7 @@ public class CoreStubHandler {
                                     "criName",
                                     credentialIssuer.name()),
                             "user-search.mustache");
-                }else if(Objects.nonNull(request.queryParams("postcode"))){
+                } else if (postcode != null && !postcode.isBlank()) {
                     var claimIdentity =
                             new IdentityMapper()
                                     .mapToAddressSharedClaims(request.queryParams("postcode"));
@@ -248,10 +250,7 @@ public class CoreStubHandler {
             };
 
     private <T> void sendAuthorizationRequest(
-            Request request,
-            Response response,
-            CredentialIssuer credentialIssuer,
-            T sharedClaims)
+            Request request, Response response, CredentialIssuer credentialIssuer, T sharedClaims)
             throws JOSEException, java.text.ParseException {
         State state = createNewState(credentialIssuer);
         request.session().attribute("state", state);
@@ -361,7 +360,13 @@ public class CoreStubHandler {
                 return tokenRequest.toHTTPRequest().getQuery();
             };
 
-    public Route editPostCode;
+    public Route editPostcode =
+            (Request request, Response response) -> {
+                LOGGER.info("editPostcode Start");
+                var credentialIssuerId = Objects.requireNonNull(request.queryParams("cri"));
+                return ViewHelper.render(
+                        Map.of("cri", credentialIssuerId), "edit-postcode.mustache");
+            };
 
     private String createBackendSessionRequestJSONReply(AuthorizationRequest authorizationRequest) {
         // Splits the QueryString from the Auth URI.  Turning the list of parameters

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -173,7 +173,6 @@ public class CoreStubHandler {
                 var credentialIssuer =
                         handlerHelper.findCredentialIssuer(
                                 Objects.requireNonNull(request.queryParams("cri")));
-
                 if (credentialIssuer.sendIdentityClaims()) {
                     return ViewHelper.render(
                             Map.of(
@@ -182,6 +181,12 @@ public class CoreStubHandler {
                                     "criName",
                                     credentialIssuer.name()),
                             "user-search.mustache");
+                }else if(Objects.nonNull(request.queryParams("postcode"))){
+                    var claimIdentity =
+                            new IdentityMapper()
+                                    .mapToAddressSharedClaims(request.queryParams("postcode"));
+                    sendAuthorizationRequest(request, response, credentialIssuer, claimIdentity);
+                    return null;
                 } else {
                     sendAuthorizationRequest(request, response, credentialIssuer, null);
                     return null;
@@ -242,11 +247,11 @@ public class CoreStubHandler {
                 return null;
             };
 
-    private void sendAuthorizationRequest(
+    private <T> void sendAuthorizationRequest(
             Request request,
             Response response,
             CredentialIssuer credentialIssuer,
-            SharedClaims sharedClaims)
+            T sharedClaims)
             throws JOSEException, java.text.ParseException {
         State state = createNewState(credentialIssuer);
         request.session().attribute("state", state);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -226,8 +226,8 @@ public class HandlerHelper {
         }
     }
 
-    public AuthorizationRequest createAuthorizationJAR(
-            State state, CredentialIssuer credentialIssuer, SharedClaims sharedClaims)
+    public <T> AuthorizationRequest createAuthorizationJAR(
+            State state, CredentialIssuer credentialIssuer, T sharedClaims)
             throws JOSEException, java.text.ParseException {
         ClientID clientID = new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID);
         JWTClaimsSet claimsSet =
@@ -268,10 +268,10 @@ public class HandlerHelper {
         return signedJWT;
     }
 
-    public JWTClaimsSet createJWTClaimsSets(
+    public <T> JWTClaimsSet createJWTClaimsSets(
             State state,
             CredentialIssuer credentialIssuer,
-            SharedClaims sharedClaims,
+            T sharedClaims,
             ClientID clientID) {
 
         Instant now = Instant.now();

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -48,7 +48,6 @@ import spark.utils.StringUtils;
 import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
 import uk.gov.di.ipv.stub.core.config.credentialissuer.CredentialIssuer;
 import uk.gov.di.ipv.stub.core.config.uatuser.Identity;
-import uk.gov.di.ipv.stub.core.config.uatuser.SharedClaims;
 
 import java.io.IOException;
 import java.net.URI;
@@ -269,10 +268,7 @@ public class HandlerHelper {
     }
 
     public <T> JWTClaimsSet createJWTClaimsSets(
-            State state,
-            CredentialIssuer credentialIssuer,
-            T sharedClaims,
-            ClientID clientID) {
+            State state, CredentialIssuer credentialIssuer, T sharedClaims, ClientID clientID) {
 
         Instant now = Instant.now();
 

--- a/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
@@ -59,7 +59,7 @@
 
         {{#cris}}
             <p>
-                <a href="/credential-issuer?cri={{id}}"><input class="govuk-button" data-module="govuk-button"
+                <a href="/credential-issuer?cri={{id}}{{#isAddressCri}}/edit-postcode{{/isAddressCri}}"><input class="govuk-button" data-module="govuk-button"
                                                                type="button"
                                                                value="{{name}}"></a>
             </p>

--- a/di-ipv-core-stub/src/main/resources/templates/edit-postcode.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/edit-postcode.mustache
@@ -47,26 +47,27 @@
         </div>
     </div>
 </header>
-
 <div class="govuk-width-container ">
     <main class="govuk-main-wrapper>" id="main-content" role="main">
-        <a href="/" class="govuk-back-link">Back</a>
-        <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
-            <h2 class="govuk-heading-xl">
-                Visit Credential Issuers
-            </h2>
-        </div>
 
-        {{#cris}}
-            <p>
-                <a href="{{^isAddressCri}}/credential-issuer{{/isAddressCri}}{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}">
-                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}"></a>
-            </p>
-            <p>
-            <a href="{{#isAddressCri}}/credential-issuer?cri={{id}}{{/isAddressCri}}">
-                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
-            </p>
-        {{/cris}}
+		<a href="/" class="govuk-back-link">Back</a>
+		<div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
+			<h2 class="govuk-heading-xl">
+				Enter Postcode for test user
+			</h2>
+		</div>
+
+		<legend class="govuk-fieldset__legend govuk-label">Postcode (optional)</legend>
+        <form action="/credential-issuer?cri={{cri}}">
+            <input type="hidden" name="cri" value="{{cri}}">
+            <div class="govuk-form-group">
+                <input class="govuk-input govuk-input--width-10" id="postcode" name="postcode" type="text">
+                <button class="govuk-button" data-module="govuk-button">Continue</button>
+            </div>
+        </form>
+
+
+        </form>
 
     </main>
 </div>


### PR DESCRIPTION
## Proposed changes

Added new `edit-postcode` spark route for partial address postcode claim

In addition to the existing `address cri`, a new Address CRI postcode button has been introduced to support the above functionality. Below is the screenshot for it.

![image](https://user-images.githubusercontent.com/95495586/191980149-3ee3f168-204e-4ed4-b8ca-0ae06e275c39.png)

### What changed

Added new `PostcodeSharedClaims.java` sending partial address postcode claim

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
- [OJ-940](https://govukverify.atlassian.net/browse/OJ-940)