### PR TITLE
PYIC-2024: Generate random IDs for app journey users

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
@@ -6,12 +6,17 @@ import spark.Route;
 import uk.gov.di.ipv.stub.orc.utils.ViewHelper;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 public class HomeHandler {
+    public static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
+    public static final String NON_APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:";
     public static Route serveHomePage =
             (Request request, Response response) -> {
                 var modelMap = new HashMap<String, Object>();
-                modelMap.put("welcome", "Hello world");
+                modelMap.put("appJourneyUserId", APP_JOURNEY_USER_ID_PREFIX + UUID.randomUUID());
+                modelMap.put(
+                        "nonAppJourneyUserId", NON_APP_JOURNEY_USER_ID_PREFIX + UUID.randomUUID());
 
                 return ViewHelper.render(modelMap, "home.mustache");
             };

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -59,8 +59,8 @@
                 <label class="govuk-label" for="userIdSelect">Choose a user id value:</label>
                 <select class="govuk-select" name="userIdSelect" id="userIdSelect">
                     <option value=""></option>
-                    <option value="urn:uuid:00c6bddd-c5dc-42ab-89d1-cecf12cee10f">urn:uuid:00c6bddd-c5dc-42ab-89d1-cecf12cee10f - App journey user</option>
-                    <option value="urn:uuid:34g1agte-g88c-78aa-bn1a-dyu1f0flpo2x">urn:uuid:34g1agte-g88c-78aa-bn1a-dyu1f0flpo2x - Non app journey user</option>
+                    <option value="{{appJourneyUserId}}">{{appJourneyUserId}} - App journey user</option>
+                    <option value="{{nonAppJourneyUserId}}">{{nonAppJourneyUserId}} - Non app journey user</option>
                 </select>
             </div>
             <div class="govuk-form-group">


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Generate random IDs for app journey users

### Why did it change

Once we start to use the stored CIs in the core, using the same user ID for functional tests that generate CIs will break.

The core has been updated to send any user whos ID starts with a certain prefix on an app journey. This way we can use a new user ID and still trigger an app journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-2024](https://govukverify.atlassian.net/browse/PYI-2024)
