### PR TITLE
OJ-979: Backend only to add postcode claim

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -57,7 +57,9 @@ public class CoreStub {
         Spark.get(
                 "/backend/createTokenRequestPrivateKeyJWT",
                 coreStubHandler.createTokenRequestPrivateKeyJWT);
-        Spark.get("/backend/generateInitialClaimsSetPostCode", coreStubHandler.backendGenerateInitialClaimsSetPostCode);
+        Spark.get(
+                "/backend/generateInitialClaimsSetPostCode",
+                coreStubHandler.backendGenerateInitialClaimsSetPostCode);
     }
 
     private ExceptionHandler exceptionHandler() {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -57,6 +57,7 @@ public class CoreStub {
         Spark.get(
                 "/backend/createTokenRequestPrivateKeyJWT",
                 coreStubHandler.createTokenRequestPrivateKeyJWT);
+        Spark.get("/backend/generateInitialClaimsSetPostCode", coreStubHandler.backendGenerateInitialClaimsSetPostCode);
     }
 
     private ExceptionHandler exceptionHandler() {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.stub.core.config.uatuser.FindDateOfBirth;
 import uk.gov.di.ipv.stub.core.config.uatuser.FullName;
 import uk.gov.di.ipv.stub.core.config.uatuser.Identity;
 import uk.gov.di.ipv.stub.core.config.uatuser.IdentityMapper;
+import uk.gov.di.ipv.stub.core.config.uatuser.PostcodeSharedClaims;
 import uk.gov.di.ipv.stub.core.config.uatuser.SharedClaims;
 import uk.gov.di.ipv.stub.core.config.uatuser.UKAddress;
 import uk.gov.di.ipv.stub.core.utils.HandlerHelper;
@@ -322,26 +323,29 @@ public class CoreStubHandler {
 
     public Route backendGenerateInitialClaimsSetPostCode =
             (Request request, Response response) -> {
-
                 var credentialIssuerId =
                         handlerHelper.findCredentialIssuer(
                                 Objects.requireNonNull(request.queryParams("cri")));
 
-                    var claimIdentity =
-                            new IdentityMapper()
-                                    .mapToAddressSharedClaims(Objects.requireNonNull(request.queryParams("postcode")));
+                var postcode = request.queryParams("postcode");
+                if (postcode == null || postcode.isBlank()) {
+                    throw new IllegalStateException("Postcode cannot be blank");
+                }
+
+                PostcodeSharedClaims claimIdentity =
+                        new IdentityMapper().mapToAddressSharedClaims(postcode);
 
                 State state = createNewState(credentialIssuerId);
                 LOGGER.info("Created State {} for {}", state.toJSONString(), credentialIssuerId);
 
                 // ClaimSets can go direct to JSON
                 response.type("application/json");
+                System.out.println("claimIdentity = " + claimIdentity);
                 return handlerHelper.createJWTClaimsSets(
                         state,
                         credentialIssuerId,
                         claimIdentity,
                         new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID));
-
             };
     public Route createBackendSessionRequest =
             (Request request, Response response) -> {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -320,6 +320,29 @@ public class CoreStubHandler {
                         new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID));
             };
 
+    public Route backendGenerateInitialClaimsSetPostCode =
+            (Request request, Response response) -> {
+
+                var credentialIssuerId =
+                        handlerHelper.findCredentialIssuer(
+                                Objects.requireNonNull(request.queryParams("cri")));
+
+                    var claimIdentity =
+                            new IdentityMapper()
+                                    .mapToAddressSharedClaims(Objects.requireNonNull(request.queryParams("postcode")));
+
+                State state = createNewState(credentialIssuerId);
+                LOGGER.info("Created State {} for {}", state.toJSONString(), credentialIssuerId);
+
+                // ClaimSets can go direct to JSON
+                response.type("application/json");
+                return handlerHelper.createJWTClaimsSets(
+                        state,
+                        credentialIssuerId,
+                        claimIdentity,
+                        new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID));
+
+            };
     public Route createBackendSessionRequest =
             (Request request, Response response) -> {
                 LOGGER.info("CreateBackendSessionRequest Start");

--- a/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
@@ -62,12 +62,15 @@
                 <a href="{{^isAddressCri}}/credential-issuer{{/isAddressCri}}{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}">
                 <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}"></a>
             </p>
-            <p>
-            <a href="{{#isAddressCri}}/credential-issuer?cri={{id}}{{/isAddressCri}}">
-                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
-            </p>
-        {{/cris}}
 
+			{{#isAddressCri}}
+				<p>
+					<a href="/credential-issuer?cri={{id}}">
+					<input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
+				</p>
+			{{/isAddressCri}}
+
+        {{/cris}}
     </main>
 </div>
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add a new routes to core-stub i.e. /backend/generateInitialClaimSetPostCode

Minor refactoring to allow backend/frontend journey to share the same code path.

### Why did it change
To enable starting a backend only journey for postcode claim

Tested for AddressCRI via -

Making a Get request to http://localhost:8085/backend/generateInitialClaimsSetPostCode?cri=address-cri-dev&postcode=
Which will return a complete ClaimSet (JSON) with the postcode claims populating address region with the postcode only

Post the JSON/ClaimsSet to http://localhost:8085/backend/createSessionRequest?cri=address-cri-dev

This will then create a JWT using the claimSet which is then signed and encrypted.
A JSON reply (AuthorizationRequest) will be returned in the format {"request":", "Data, client_id":"ipv-core-stub"}, which can then be posted to the session resource on the private api gateway.
Outputted in the logs will be the equivalent AuthorizationRequest URI which (if the cri front end is running) allow picking up the journey in the frontend for debugging.

For dev testing the following script was used for posting the JSON/ClaimsSet back.


- [OJ-979](https://govukverify.atlassian.net/browse/OJ-979)

