### PR TITLE
OJ-990: Verify the signature returned by vc

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -42,6 +42,9 @@ public class CoreStubConfig {
             getConfigValue("CORE_STUB_CONFIG_FILE", "/app/config/cris-dev.yaml");
     public static final String CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64 =
             getConfigValue("CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64", null);
+
+    public static final String CORE_STUB_SIGNING_PUBLIC_JWK =
+            getConfigValue("CORE_STUB_SIGNING_PUBLIC_JWK", null);
     public static final String CORE_STUB_JWT_ISS_CRI_URI =
             getConfigValue(
                     "CORE_STUB_JWT_ISS_CRI_URI",

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -43,8 +43,6 @@ public class CoreStubConfig {
     public static final String CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64 =
             getConfigValue("CORE_STUB_SIGNING_PRIVATE_KEY_JWK_BASE64", null);
 
-    public static final String CORE_STUB_SIGNING_PUBLIC_JWK =
-            getConfigValue("CORE_STUB_SIGNING_PUBLIC_JWK", null);
     public static final String CORE_STUB_JWT_ISS_CRI_URI =
             getConfigValue(
                     "CORE_STUB_JWT_ISS_CRI_URI",

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -12,6 +12,7 @@ public record CredentialIssuer(
         boolean sendIdentityClaims,
         String expectedAlgo,
         String publicEncryptionJwkBase64,
+        String publicVCSigningVerificationJwkBase64,
         String apiKeyEnvVar) {
     public boolean isAddressCri() {
         return this.id.contains("address");

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
@@ -14,6 +14,9 @@ public class CredentialIssuerMapper {
         URI audience = URI.create((String) map.get("audience"));
         boolean sendIdentityClaims = Boolean.TRUE.equals(map.get("sendIdentityClaims"));
         String publicEncryptionJwkBase64 = (String) map.get("publicEncryptionJwkBase64");
+        String publicVCSigningVerificationJwkBase64 =
+                (String) map.get("publicVCSigningVerificationJwkBase64");
+
         String apiKeyEnvVar = (String) map.get("apiKeyEnvVar");
         return new CredentialIssuer(
                 id,
@@ -25,6 +28,7 @@ public class CredentialIssuerMapper {
                 sendIdentityClaims,
                 "ES256",
                 publicEncryptionJwkBase64,
+                publicVCSigningVerificationJwkBase64,
                 apiKeyEnvVar);
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -150,12 +150,13 @@ public class CoreStubHandler {
                 var signedJWT =
                         SignedJWT.parse(
                                 handlerHelper.getUserInfo(accessToken, credentialIssuer, state));
-                handlerHelper.checkSignatureFormat(signedJWT);
-                if (!handlerHelper.verifySignedJwt(signedJWT, credentialIssuer)) {
-                    throw new IllegalStateException(
-                            "Unable to verify the returned JWT, format may be invalid.");
+                if (handlerHelper.checkES256SignatureFormat(signedJWT)) {
+                    if (!handlerHelper.verifySignedJwt(signedJWT, credentialIssuer)) {
+                        throw new IllegalStateException(
+                                "Unable to verify the returned JWT, format may be invalid.");
+                    }
+                    LOGGER.info("🚀 Successfully verified signedJWT is in concat format");
                 }
-                LOGGER.info("🚀 Successfully verified signedJWT is in concat format");
 
                 var userInfo = signedJWT.getJWTClaimsSet().toString();
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -147,12 +147,17 @@ public class CoreStubHandler {
                         handlerHelper.exchangeCodeForToken(
                                 authorizationCode, credentialIssuer, state);
                 LOGGER.info("access token value: " + accessToken.getValue());
-                var userInfo =
+                var signedJWT =
                         SignedJWT.parse(
-                                        handlerHelper.getUserInfo(
-                                                accessToken, credentialIssuer, state))
-                                .getJWTClaimsSet()
-                                .toString();
+                                handlerHelper.getUserInfo(accessToken, credentialIssuer, state));
+                handlerHelper.checkSignatureFormat(signedJWT);
+                if (!handlerHelper.verifySignedJwt(signedJWT)) {
+                    throw new IllegalStateException(
+                            "Unable to verify the returned JWT, format may be invalid.");
+                }
+                LOGGER.info("🚀 Successfully verified signedJWT is in concat format");
+
+                var userInfo = signedJWT.getJWTClaimsSet().toString();
 
                 String data = "{\"result\": \"hidden\"}";
                 if (CoreStubConfig.CORE_STUB_SHOW_VC) {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -151,7 +151,7 @@ public class CoreStubHandler {
                         SignedJWT.parse(
                                 handlerHelper.getUserInfo(accessToken, credentialIssuer, state));
                 handlerHelper.checkSignatureFormat(signedJWT);
-                if (!handlerHelper.verifySignedJwt(signedJWT)) {
+                if (!handlerHelper.verifySignedJwt(signedJWT, credentialIssuer)) {
                     throw new IllegalStateException(
                             "Unable to verify the returned JWT, format may be invalid.");
                 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -404,9 +404,16 @@ public class HandlerHelper {
         }
     }
 
-    public boolean verifySignedJwt(SignedJWT signedJWT)
+    public boolean verifySignedJwt(SignedJWT signedJWT, CredentialIssuer credentialIssuer)
             throws JOSEException, java.text.ParseException {
         return signedJWT.verify(
-                new ECDSAVerifier(ECKey.parse(CoreStubConfig.CORE_STUB_SIGNING_PUBLIC_JWK)));
+                new ECDSAVerifier(
+                        ECKey.parse(
+                                base64Decode(
+                                        credentialIssuer.publicVCSigningVerificationJwkBase64()))));
+    }
+
+    private String base64Decode(String value) {
+        return new String(Base64.getDecoder().decode(value));
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -398,10 +398,8 @@ public class HandlerHelper {
                         Base64.getDecoder().decode(credentialIssuer.publicEncryptionJwkBase64())));
     }
 
-    public void checkSignatureFormat(SignedJWT signedJWT) throws JOSEException {
-        if (signedJWT.getSignature().decode().length != ECDSA.getSignatureByteArrayLength(ES256)) {
-            throw new IllegalStateException("Concat format expected, DER format suspected");
-        }
+    public boolean checkES256SignatureFormat(SignedJWT signedJWT) throws JOSEException {
+        return signedJWT.getSignature().decode().length == ECDSA.getSignatureByteArrayLength(ES256);
     }
 
     public boolean verifySignedJwt(SignedJWT signedJWT, CredentialIssuer credentialIssuer)

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -13,7 +13,9 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.EncryptedJWT;
@@ -62,6 +64,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class HandlerHelper {
     private class JWTSigner {
@@ -392,5 +396,17 @@ public class HandlerHelper {
         return RSAKey.parse(
                 new String(
                         Base64.getDecoder().decode(credentialIssuer.publicEncryptionJwkBase64())));
+    }
+
+    public void checkSignatureFormat(SignedJWT signedJWT) throws JOSEException {
+        if (signedJWT.getSignature().decode().length != ECDSA.getSignatureByteArrayLength(ES256)) {
+            throw new IllegalStateException("Concat format expected, DER format suspected");
+        }
+    }
+
+    public boolean verifySignedJwt(SignedJWT signedJWT)
+            throws JOSEException, java.text.ParseException {
+        return signedJWT.verify(
+                new ECDSAVerifier(ECKey.parse(CoreStubConfig.CORE_STUB_SIGNING_PUBLIC_JWK)));
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR is to verify that the SignedJWT by ECDSA algorithm returned is in the expected concat format
The verification keys are configured here https://github.com/alphagov/di-ipv-config/pull/958

### What changed

This as result of https://github.com/alphagov/di-ipv-cri-lib/pull/64 which makes the VC return compliant SignedJWT format according to [RFC 7518, section 3.4: Digital Signature with ECDSA](https://www.rfc-editor.org/rfc/rfc7518#section-3.4)

### Why did it change

SignedJWT formally returned DER format which is non-compliant with respect to the above named specification. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-990](https://govukverify.atlassian.net/browse/OJ-990)

## Checklists

see: https://github.com/alphagov/di-ipv-cri-lib/pull/64 is merged


