### PR TITLE
LIME-248: Allowing decision score to be set via surname

### DIFF
--- a/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
+++ b/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
@@ -56,9 +56,12 @@ public class Handler {
                 }
 
                 if (requestNames.get(0).getSurName().contains("NO_FILE_")) {
-                    experianResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(
-                            Integer.valueOf(requestNames.get(0).getSurName().substring(8))
-                    );
+                    experianResponse
+                            .getClientResponsePayload()
+                            .getDecisionElements()
+                            .get(0)
+                            .setScore(
+                                    Integer.valueOf(requestNames.get(0).getSurName().substring(8)));
                 }
 
                 LOGGER.debug("Stubbed experian response = " + experianResponse);

--- a/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
+++ b/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
@@ -55,6 +55,12 @@ public class Handler {
                                     inMemoryDataStore.getResponse("PEPS-NO-RULE"));
                 }
 
+                if (requestNames.get(0).getSurName().contains("NO_FILE_")) {
+                    experianResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(
+                            Integer.valueOf(requestNames.get(0).getSurName().substring(8))
+                    );
+                }
+
                 LOGGER.debug("Stubbed experian response = " + experianResponse);
 
                 Random randGen = new Random();


### PR DESCRIPTION
## Proposed changes

### What changed

Added additional conditions for testing decision scores

### Why did it change

To allow easier testing of no file found

