### PR TITLE
LIME-257 Allow simulating "ResponseType.Error" replies and network failures

### DIFF
--- a/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
+++ b/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
@@ -8,6 +8,7 @@ import spark.Response;
 import spark.Route;
 import uk.gov.di.ipv.stub.fraud.gateway.dto.request.*;
 import uk.gov.di.ipv.stub.fraud.gateway.dto.response.IdentityVerificationResponse;
+import uk.gov.di.ipv.stub.fraud.gateway.dto.response.ResponseType;
 
 import java.util.*;
 
@@ -83,6 +84,45 @@ public class Handler {
 
                 responseContactPerson.setNames(requestNames);
                 responseContactPerson.getPersonDetails().setDateOfBirth(requestDob);
+
+                // FraudCheck Error Simulation
+                if (fraudRequest
+                        .getHeader()
+                        .getRequestType()
+                        .equals("Authenticateplus-Standalone")) {
+                    if (requestNames.get(0).getSurName().equals("FRAUD_ERROR_RESPONSE")) {
+                        experianResponse.getResponseHeader().setResponseType(ResponseType.ERROR);
+                        experianResponse.getResponseHeader().setResponseCode("ERRSIMF1");
+                        experianResponse
+                                .getResponseHeader()
+                                .setResponseMessage("Simulated Fraud Error Response");
+                    }
+
+                    if (requestNames.get(0).getSurName().equals("FRAUD_TECH_FAIL")) {
+                        response.status(
+                                408); // Request Timeout (closest response to an abrupt socket
+                        // close)
+                        return "";
+                    }
+                }
+
+                // PepCheck Error Simulation
+                if (fraudRequest.getHeader().getRequestType().equals("PepSanctions01")) {
+                    if (requestNames.get(0).getSurName().equals("PEP_ERROR_RESPONSE")) {
+                        experianResponse.getResponseHeader().setResponseType(ResponseType.ERROR);
+                        experianResponse.getResponseHeader().setResponseCode("ERRSIMP1");
+                        experianResponse
+                                .getResponseHeader()
+                                .setResponseMessage("Simulated PEP Error Response");
+                    }
+
+                    if (requestNames.get(0).getSurName().equals("PEP_TECH_FAIL")) {
+                        response.status(
+                                408); // Request Timeout (closest response to an abrupt socket
+                        // close)
+                        return "";
+                    }
+                }
 
                 if (requestNames.get(0).getSurName().equalsIgnoreCase("SERVER_FAILURE")) {
                     response.status(503);


### PR DESCRIPTION
## Proposed changes

### What changed

Allow sending ResponseType error replies to FraudCheck or PEPCheck request.

Allow simulating a network failure for either a FraudCheck or PEPCheck request.

The following replies can be requested via setting the surname of the test user to one of the following.

```
FRAUD_ERROR_RESPONSE - Error response to fraud check request
FRAUD_TECH_FAIL.     - 408 status code response to fraud check request.
PEP_ERROR_RESPONSE.  - Error response to pep request
PEP_TECH_FAIL.       - 408 status code response to pep check request.
```
### Why did it change

FraudCRI behaviour is changing such that checks that are requested are recorded in the VC and VC AuditEvent. The check may appear in checkDetails or failedCheckDetails depending on the inferred check and type of failure.

### Issue tracking

- [LIME-257](https://govukverify.atlassian.net/browse/LIME-257)
- [PR-294 RFC-0024](https://github.com/alphagov/digital-identity-architecture/pull/294)