### PR TITLE
LIME-257 Fix surnames overriding response type and use a copy of the response template to stop influencing responses to later requests.

### DIFF
--- a/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
+++ b/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.stub.fraud;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,11 +17,17 @@ public class Handler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Handler.class);
     private ObjectMapper mapper;
-    private InMemoryDataStore inMemoryDataStore;
+
+    public static final String FRAUD_CHECK_SOURCE = "fraud_check_source";
+    private InMemoryDataStore fraudCheckInMemoryDataStore;
+
+    public static final String PEP_CHECK_SOURCE = "pep_check_source";
+    private InMemoryDataStore pepCheckInMemoryDataStore;
 
     protected Handler() {
         mapper = new ObjectMapper();
-        inMemoryDataStore = new InMemoryDataStore(mapper);
+        fraudCheckInMemoryDataStore = new InMemoryDataStore(mapper, FRAUD_CHECK_SOURCE);
+        pepCheckInMemoryDataStore = new InMemoryDataStore(mapper, PEP_CHECK_SOURCE);
     }
 
     protected Route root = (Request request, Response response) -> "ok";
@@ -37,65 +44,45 @@ public class Handler {
                 List<Name> requestNames = requestContact.getPerson().getNames();
                 List<Address> requestAddress = requestContact.getAddresses();
 
-                IdentityVerificationResponse experianResponse =
-                        inMemoryDataStore.getResponseOrElse(
-                                requestNames.get(0).getSurName().toUpperCase(),
-                                inMemoryDataStore.getResponse("AUTH1"));
+                IdentityVerificationResponse modifiableResponse = null;
 
-                if (experianResponse
-                        .getResponseHeader()
-                        .getRequestType()
-                        .equals("PepSanctions01")) {
-                    experianResponse = inMemoryDataStore.getResponse("AUTH1");
-                }
-
-                if (fraudRequest.getHeader().getRequestType().equals("PepSanctions01")) {
-                    experianResponse =
-                            inMemoryDataStore.getResponseOrElse(
-                                    requestNames.get(0).getSurName().toUpperCase(),
-                                    inMemoryDataStore.getResponse("PEPS-NO-RULE"));
-                }
-
-                if (requestNames.get(0).getSurName().contains("NO_FILE_")) {
-                    experianResponse
-                            .getClientResponsePayload()
-                            .getDecisionElements()
-                            .get(0)
-                            .setScore(
-                                    Integer.valueOf(requestNames.get(0).getSurName().substring(8)));
-                }
-
-                LOGGER.debug("Stubbed experian response = " + experianResponse);
-
-                Random randGen = new Random();
-                experianResponse
-                        .getResponseHeader()
-                        .setClientReferenceId(UUID.randomUUID().toString());
-
-                experianResponse
-                        .getResponseHeader()
-                        .setExpRequestId(String.format("RB0000%08d", randGen.nextInt(99999999)));
-
-                Contact responseContact =
-                        experianResponse.getOriginalRequestData().getContacts().get(0);
-                Person responseContactPerson = responseContact.getPerson();
-
-                responseContact.setAddresses(requestAddress);
-
-                responseContactPerson.setNames(requestNames);
-                responseContactPerson.getPersonDetails().setDateOfBirth(requestDob);
-
-                // FraudCheck Error Simulation
+                // FraudCheck Simulation
                 if (fraudRequest
                         .getHeader()
                         .getRequestType()
                         .equals("Authenticateplus-Standalone")) {
+
+                    // Look for a response for specific user surname, fall back to AUTH1
+                    modifiableResponse =
+                            getModifiableResponse(
+                                    requestNames.get(0).getSurName().toUpperCase(),
+                                    "AUTH1",
+                                    FRAUD_CHECK_SOURCE);
+
+                    // Decision score set to suffix
+                    if (requestNames.get(0).getSurName().contains("NO_FILE_")) {
+                        modifiableResponse
+                                .getClientResponsePayload()
+                                .getDecisionElements()
+                                .get(0)
+                                .setScore(
+                                        Integer.valueOf(
+                                                requestNames.get(0).getSurName().substring(8)));
+                    }
+
+                    // Error response type in FraudCheck
                     if (requestNames.get(0).getSurName().equals("FRAUD_ERROR_RESPONSE")) {
-                        experianResponse.getResponseHeader().setResponseType(ResponseType.ERROR);
-                        experianResponse.getResponseHeader().setResponseCode("ERRSIMF1");
-                        experianResponse
+                        modifiableResponse.getResponseHeader().setResponseType(ResponseType.ERROR);
+                        modifiableResponse.getResponseHeader().setResponseCode("ERRSIMF1");
+                        modifiableResponse
                                 .getResponseHeader()
                                 .setResponseMessage("Simulated Fraud Error Response");
+                    }
+
+                    // HTTP response status code to fraudCheck
+                    if (requestNames.get(0).getSurName().contains("FSC_")) {
+                        response.status(
+                                Integer.valueOf(requestNames.get(0).getSurName().substring(4)));
                     }
 
                     if (requestNames.get(0).getSurName().equals("FRAUD_TECH_FAIL")) {
@@ -106,14 +93,28 @@ public class Handler {
                     }
                 }
 
-                // PepCheck Error Simulation
+                // PepCheck Simulation
                 if (fraudRequest.getHeader().getRequestType().equals("PepSanctions01")) {
+
+                    modifiableResponse =
+                            getModifiableResponse(
+                                    requestNames.get(0).getSurName().toUpperCase(),
+                                    "PEPS-NO-RULE",
+                                    PEP_CHECK_SOURCE);
+
+                    // Error response type in PEP Check
                     if (requestNames.get(0).getSurName().equals("PEP_ERROR_RESPONSE")) {
-                        experianResponse.getResponseHeader().setResponseType(ResponseType.ERROR);
-                        experianResponse.getResponseHeader().setResponseCode("ERRSIMP1");
-                        experianResponse
+                        modifiableResponse.getResponseHeader().setResponseType(ResponseType.ERROR);
+                        modifiableResponse.getResponseHeader().setResponseCode("ERRSIMP1");
+                        modifiableResponse
                                 .getResponseHeader()
                                 .setResponseMessage("Simulated PEP Error Response");
+                    }
+
+                    // HTTP response status code to fraudCheck
+                    if (requestNames.get(0).getSurName().contains("PSC_")) {
+                        response.status(
+                                Integer.valueOf(requestNames.get(0).getSurName().substring(4)));
                     }
 
                     if (requestNames.get(0).getSurName().equals("PEP_TECH_FAIL")) {
@@ -124,13 +125,33 @@ public class Handler {
                     }
                 }
 
+                LOGGER.debug("Stubbed experian response = " + modifiableResponse);
+
+                Random randGen = new Random();
+                modifiableResponse
+                        .getResponseHeader()
+                        .setClientReferenceId(UUID.randomUUID().toString());
+
+                modifiableResponse
+                        .getResponseHeader()
+                        .setExpRequestId(String.format("RB0000%08d", randGen.nextInt(99999999)));
+
+                Contact responseContact =
+                        modifiableResponse.getOriginalRequestData().getContacts().get(0);
+                Person responseContactPerson = responseContact.getPerson();
+
+                responseContact.setAddresses(requestAddress);
+
+                responseContactPerson.setNames(requestNames);
+                responseContactPerson.getPersonDetails().setDateOfBirth(requestDob);
+
                 if (requestNames.get(0).getSurName().equalsIgnoreCase("SERVER_FAILURE")) {
                     response.status(503);
                     return "";
                 } else {
                     response.header("Content-Type", "application/json");
-                    response.status(200);
-                    return mapper.writeValueAsString(experianResponse);
+                    // status code 200 by default
+                    return mapper.writeValueAsString(modifiableResponse);
                 }
             };
 
@@ -140,7 +161,7 @@ public class Handler {
 
                 IdentityVerificationResponse experianResponse =
                         mapper.readValue(request.body(), IdentityVerificationResponse.class);
-                inMemoryDataStore.addResponse(
+                fraudCheckInMemoryDataStore.addResponse(
                         experianResponse
                                 .getOriginalRequestData()
                                 .getContacts()
@@ -172,7 +193,8 @@ public class Handler {
 
                 String id = deletionRequest.get("fraudResponseId");
 
-                boolean responseRemoved = inMemoryDataStore.removeResponse(id.toUpperCase());
+                boolean responseRemoved =
+                        fraudCheckInMemoryDataStore.removeResponse(id.toUpperCase());
                 return responseRemoved
                         ? String.format("%s removed", id)
                         : String.format("%s does not exist", id);
@@ -184,6 +206,35 @@ public class Handler {
                 LOGGER.info("Fraud request ID: " + fraudResponseId);
 
                 response.header("Content-Type", "application/json");
-                return mapper.writeValueAsString(inMemoryDataStore.getResponse(fraudResponseId));
+                return mapper.writeValueAsString(
+                        fraudCheckInMemoryDataStore.getResponse(fraudResponseId));
             };
+
+    private IdentityVerificationResponse getModifiableResponse(
+            String surname, String getResponseId, String responseSource)
+            throws JsonProcessingException {
+
+        final IdentityVerificationResponse templateResponse;
+
+        switch (responseSource) {
+            case FRAUD_CHECK_SOURCE:
+                templateResponse =
+                        fraudCheckInMemoryDataStore.getResponseOrElse(
+                                surname, fraudCheckInMemoryDataStore.getResponse(getResponseId));
+                break;
+            case PEP_CHECK_SOURCE:
+                templateResponse =
+                        pepCheckInMemoryDataStore.getResponseOrElse(
+                                surname, pepCheckInMemoryDataStore.getResponse(getResponseId));
+                break;
+            default:
+                templateResponse = null;
+                LOGGER.error("ResponseSource {} is not handled", responseSource);
+                break;
+        }
+
+        // Return a modifiable clone of the templateResponse
+        return mapper.readValue(
+                mapper.writeValueAsString(templateResponse), IdentityVerificationResponse.class);
+    }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Separated handling of fraud and pep requests.

Make a copy of the response template and then make changes to the copy.

Added test surname FSC_ and PSC_  which when appended e.g. FSC_500 sets the response status code. (status code if not set defaults to 200)

### Why did it change

Separated requests to avoid special test surnames interacting and returning the incorrect response type.

Changes where being made directly to the template response, which work as long as all fields where overwritten each time but means some data was latched when it wasn't.

FSC_ / PSC_ to allow testing API behaviour to various http status codes in both request separately.

### Issue tracking

- [LIME-257](https://govukverify.atlassian.net/browse/LIME-257)
