### PR TITLE
LIME-257 Set warnings and errors in info responses for gracefull fail scenarios and simulate error responses when request contact data is incomplete

### DIFF
--- a/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/InMemoryDataStore.java
+++ b/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/InMemoryDataStore.java
@@ -70,6 +70,11 @@ public class InMemoryDataStore {
                 addResponse("GILT", "/SpecificResponse/fraud-ex-ci2-gilt.json");
                 addResponse("KENNEDY", "/SpecificResponse/fraud-ex-ci3-kennedy.json");
 
+                // Info response type but is a failure due to presence of warnings and errors
+                addResponse(
+                        "FRAUD_WARNINGS_ERRORS",
+                        "/SpecificResponse/authplus-info-fail-warnings-errors.json");
+
                 addResponse("REFER", "/GenericResponse/fraud-ex--refer.json");
                 for (Map.Entry<String, String[]> ci : Config.ciMap.entrySet()) {
                     addResponse(
@@ -79,6 +84,11 @@ public class InMemoryDataStore {
                 break;
             case PEP_CHECK_SOURCE:
                 addResponse("PEPS-NO-RULE", "/GenericResponse/fraud-ex--peps1-no-rule.json");
+
+                // Info response type but is a failure due to presence of warnings and errors
+                addResponse(
+                        "PEP_WARNINGS_ERRORS",
+                        "/SpecificResponse/pep-info-fail-warnings-errors.json");
 
                 addResponse("PEPS", "/GenericResponse/fraud-ex--peps1-rule.json");
                 for (Map.Entry<String, String[]> pep : Config.pepMap.entrySet()) {

--- a/experian-fraud-stub/src/main/resources/SpecificResponse/authplus-info-fail-warnings-errors.json
+++ b/experian-fraud-stub/src/main/resources/SpecificResponse/authplus-info-fail-warnings-errors.json
@@ -1,0 +1,94 @@
+{
+  "responseHeader": {
+    "requestType": "Authenticateplus-Standalone",
+    "clientReferenceId": "123c45d6-7d89-12db-b3aa-f4e56e78a9b0",
+    "expRequestId": "0",
+    "messageTime": "2023-01-05T13:20:44Z",
+    "overallResponse": {
+      "decision": "NODECISION",
+      "decisionText": "Check the response for details",
+      "decisionReasons": [
+        "Framework Mapper Error : Mapper exception."
+      ],
+      "recommendedNextActions": [],
+      "spareObjects": []
+    },
+    "responseCode": "R0201",
+    "responseType": "WARNING",
+    "responseMessage": "Workflow Complete.",
+    "tenantID": "X246M3WS"
+  },
+  "clientResponsePayload": {
+    "orchestrationDecisions": [
+      {
+        "sequenceId": "1",
+        "decisionSource": "Authenticateplus",
+        "decision": "NODECISION",
+        "decisionReasons": [
+          "Framework Mapper Error : Mapper exception."
+        ],
+        "score": 0,
+        "decisionText": "Check the response for details",
+        "nextAction": "Continue",
+        "decisionTime": "2023-01-05T13:20:45Z"
+      }
+    ],
+    "decisionElements": [
+      {
+        "serviceName": "Authenticateplus",
+        "warningsErrors": [
+          {
+            "responseType": "ERROR",
+            "responseMessage": "Stub Simulated AuthPlus Warning Error"
+          }
+        ]
+      }
+    ]
+  },
+  "originalRequestData": {
+    "application": {
+      "applicants": [
+        {
+          "applicantType": "MAIN_APPLICANT",
+          "consent": true,
+          "contactId": "MAINCONTACT_1",
+          "id": "APPLICANT_1",
+          "type": "INDIVIDUAL"
+        }
+      ]
+    },
+    "contacts": [
+      {
+        "addresses": [
+          {
+            "addressIdentifier": "ADDRESS_1",
+            "addressType": "CURRENT",
+            "buildingNumber": "3",
+            "id": "MAINAPPADDRESS_1",
+            "postTown": "",
+            "postal": "",
+            "street": ""
+          }
+        ],
+        "id": "MAINCONTACT_1",
+        "person": {
+          "names": [
+            {
+              "firstName": "",
+              "id": "MAINPERSONNAME_1",
+              "middleNames": "",
+              "surName": "",
+              "title": "null",
+              "type": "CURRENT"
+            }
+          ],
+          "personDetails": {
+            "dateOfBirth": ""
+          },
+          "personIdentifier": "MAINPERSON_1"
+        }
+      }
+    ],
+    "source": "WEB"
+  }
+}

--- a/experian-fraud-stub/src/main/resources/SpecificResponse/pep-info-fail-warnings-errors.json
+++ b/experian-fraud-stub/src/main/resources/SpecificResponse/pep-info-fail-warnings-errors.json
@@ -1,0 +1,61 @@
+{
+  "responseHeader": {
+    "requestType": "PepSanctions01",
+    "clientReferenceId": "123c45d6-7d89-12db-b3aa-f4e56e78a9b0",
+    "expRequestId": "0",
+    "messageTime": "2023-01-05T13:20:44Z",
+    "overallResponse": {
+      "decision": "NODECISION",
+      "decisionText": "Check the response for details",
+      "score": 0,
+      "decisionReasons": [
+        "Hunter Error"
+      ],
+      "recommendedNextActions": [],
+      "spareObjects": []
+    },
+    "responseCode": "R0201",
+    "responseType": "INFO",
+    "responseMessage": "Workflow Complete.",
+    "tenantID": "X246M3WS"
+  },
+  "clientResponsePayload": {
+    "orchestrationDecisions": [
+      {
+        "sequenceId": "1",
+        "decisionSource": "Hunter",
+        "decision": "NODECISION",
+        "decisionReasons": [
+          "Hunter Error"
+        ],
+        "score": 0,
+        "decisionText": "Check the response for details",
+        "nextAction": "Continue",
+        "decisionTime": "2023-01-01T09:00:50Z"
+      }
+    ],
+    "decisionElements": [
+      {
+        "serviceName": "Hunter",
+        "score": 0,
+        "appReference": "123c45d6-7d89-12db-b3aa-f4e56e78a9b0",
+        "rules": [],
+        "warningsErrors": [
+          {
+            "responseCode": "0001",
+            "responseType": "ERROR",
+            "responseMessage": "Stub Simulated - Generate submission error"
+          },
+          {
+            "responseCode": "0002",
+            "responseType": "ERROR",
+            "responseMessage": "Stub Simulated PEP Warning Error"
+          }
+        ],
+        "matches": [],
+        "dataCounts": [],
+        "scores": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Simulate pepCheck failing if a request contains multiple addresses via the presence of a warningError in the warnings errors array of the info response.

Simulate an Error response if request is missing the following
Firstname, Surname, DOB, Postcode with a building name or number is also needed.

Allow triggering an info response with a warningError set 
- Send a matching requestType using surname (surname ignored for none matching requestTypes)
- FRAUD_WARNINGS_ERRORS - for authplus
- PEP_WARNINGS_ERRORS - for pep

### Why did it change

This allows testing a failure scenario where an info responseType has returned but is deemed an error due the presence of a warning and error. In this case there will be a txn that can be captured and used in a VC if appropriate.

FraudCRI was changed to stop users with low decision scores proceeding to a pepCheck.
In the staging environment a test user was used to confirm the pep request had one address (third party api limitation), but this user no longer has a pepCheck performed due to a low score. To avoid relying on third-party data this test can now be replicated in build via the stub.

Changes to the stub response handling was enabling previously failing request to be handled. Formally these requests crashed the stub. A minimal set of validation is added to simulate correctly the Error responses that should appear.

### Issue tracking

- [LIME-257](https://govukverify.atlassian.net/browse/LIME-257)

[LIME-257]: https://govukverify.atlassian.net/browse/LIME-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ