### PR TITLE
If activity history is missing then don't add score value to gpg45 map

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -407,9 +407,10 @@ public class AuthorizeHandler {
                         StringUtils.isNotBlank(validityValue) ? Integer.parseInt(validityValue) : 2;
                 gpg45Score.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, validityNum);
 
-                int activityHistoryNum =
-                        StringUtils.isNotBlank(activityValue) ? Integer.parseInt(activityValue) : 1;
-                gpg45Score.put(CredentialIssuerConfig.ACTIVITY_PARAM, activityHistoryNum);
+                if (StringUtils.isNotBlank(activityValue)) {
+                    gpg45Score.put(
+                            CredentialIssuerConfig.ACTIVITY_PARAM, Integer.parseInt(activityValue));
+                }
 
                 List<Map<String, Object>> checkDetailsValue = new ArrayList<>();
                 checkDetailsValue.add(Map.of("checkMethod", "vri"));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Only add an activity history score value to the gpg45 map if a string value is provided.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
DCMAW can now return a VC that doesn't contain a activityHistory value so we need to the stub to be able to do the same.
<!-- Describe the reason these changes were made - the "why" -->

