### PR TITLE
BAU Add input field for custom evidence block

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -66,6 +66,7 @@ public class AuthorizeHandler {
     public static final String SHARED_CLAIMS = "shared_claims";
 
     public static final String CRI_STUB_DATA = "cri_stub_data";
+    public static final String CRI_STUB_EVIDENCE_PAYLOADS = "cri_stub_evidence_payloads";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizeHandler.class);
 
@@ -157,6 +158,7 @@ public class AuthorizeHandler {
                 }
 
                 Object criStubData = getCriStubData();
+                Object criStubEvidencePayloads = getCriStubEvidencePayloads();
 
                 CriType criType = getCriType();
                 LOGGER.info("criType: {}", criType.value);
@@ -179,6 +181,7 @@ public class AuthorizeHandler {
                     frontendParams.put(SHARED_CLAIMS, getSharedAttributes(queryParamsMap));
                 }
                 frontendParams.put(CRI_STUB_DATA, criStubData);
+                frontendParams.put(CRI_STUB_EVIDENCE_PAYLOADS, criStubEvidencePayloads);
 
                 String error = request.attribute(ERROR_PARAM);
                 boolean hasError = error != null;
@@ -257,6 +260,11 @@ public class AuthorizeHandler {
                                                         .BIOMETRICK_VERIFICATION_PARAM));
                     } else {
                         gpgMap = generateJsonPayload(evidenceJsonPayload);
+                        if (gpgMap.get(CredentialIssuerConfig.EVIDENCE_TXN_PARAM) == null) {
+                            gpgMap.put(
+                                    CredentialIssuerConfig.EVIDENCE_TXN_PARAM,
+                                    UUID.randomUUID().toString());
+                        }
                     }
 
                     String ciString =
@@ -565,6 +573,19 @@ public class AuthorizeHandler {
                                 .parse(
                                         AuthorizeHandler.class.getResourceAsStream(
                                                 "/data/criStubData.json"));
+
+        return js.get("data");
+    }
+
+    private Object getCriStubEvidencePayloads()
+            throws UnsupportedEncodingException,
+                    com.nimbusds.jose.shaded.json.parser.ParseException {
+        JSONObject js =
+                (JSONObject)
+                        new JSONParser(MODE_JSON_SIMPLE)
+                                .parse(
+                                        AuthorizeHandler.class.getResourceAsStream(
+                                                "/data/criStubEvidencePayloads.json"));
 
         return js.get("data");
     }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -74,11 +74,13 @@ public class AuthorizeHandler {
 
     private static final String RESOURCE_ID_PARAM = "resourceId";
     private static final String JSON_PAYLOAD_PARAM = "jsonPayload";
+    private static final String EVIDENCE_JSON_PAYLOAD_PARAM = "evidenceJsonPayload";
     private static final String IS_EVIDENCE_TYPE_PARAM = "isEvidenceType";
     private static final String IS_ACTIVITY_TYPE_PARAM = "isActivityType";
     private static final String IS_FRAUD_TYPE_PARAM = "isFraudType";
     private static final String IS_VERIFICATION_TYPE_PARAM = "isVerificationType";
     private static final String IS_DOC_CHECKING_TYPE_PARAM = "isDocCheckingType";
+    private static final String IS_USER_ASSERTED_TYPE = "isUserAssertedType";
     private static final String HAS_ERROR_PARAM = "hasError";
     private static final String ERROR_PARAM = "error";
     private static final String CRI_NAME_PARAM = "cri-name";
@@ -170,6 +172,9 @@ public class AuthorizeHandler {
                         IS_VERIFICATION_TYPE_PARAM, criType.equals(CriType.VERIFICATION_CRI_TYPE));
                 frontendParams.put(
                         IS_DOC_CHECKING_TYPE_PARAM, criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE));
+                frontendParams.put(
+                        IS_VERIFICATION_TYPE_PARAM, criType.equals(CriType.VERIFICATION_CRI_TYPE));
+                frontendParams.put(IS_USER_ASSERTED_TYPE, criType.equals(USER_ASSERTED_CRI_TYPE));
                 if (!criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
                     frontendParams.put(SHARED_CLAIMS, getSharedAttributes(queryParamsMap));
                 }
@@ -233,18 +238,26 @@ public class AuthorizeHandler {
                         credentialAttributesMap = combinedAttributeJson;
                     }
 
-                    Map<String, Object> gpgMap =
-                            generateGpg45Score(
-                                    getCriType(),
-                                    queryParamsMap.value(
-                                            CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM),
-                                    queryParamsMap.value(
-                                            CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM),
-                                    queryParamsMap.value(CredentialIssuerConfig.ACTIVITY_PARAM),
-                                    queryParamsMap.value(CredentialIssuerConfig.FRAUD_PARAM),
-                                    queryParamsMap.value(CredentialIssuerConfig.VERIFICATION_PARAM),
-                                    queryParamsMap.value(
-                                            CredentialIssuerConfig.BIOMETRICK_VERIFICATION_PARAM));
+                    Map<String, Object> gpgMap;
+                    String evidenceJsonPayload = queryParamsMap.value(EVIDENCE_JSON_PAYLOAD_PARAM);
+                    if (evidenceJsonPayload == null || evidenceJsonPayload.isEmpty()) {
+                        gpgMap =
+                                generateGpg45Score(
+                                        getCriType(),
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM),
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM),
+                                        queryParamsMap.value(CredentialIssuerConfig.ACTIVITY_PARAM),
+                                        queryParamsMap.value(CredentialIssuerConfig.FRAUD_PARAM),
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VERIFICATION_PARAM),
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig
+                                                        .BIOMETRICK_VERIFICATION_PARAM));
+                    } else {
+                        gpgMap = generateJsonPayload(evidenceJsonPayload);
+                    }
 
                     String ciString =
                             queryParamsMap

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -1,0 +1,87 @@
+{
+  "data": [
+    {
+      "criType": "Fraud Check (Stub)",
+      "label": "Passed fraud check (M1A)",
+      "payload": {
+        "type": "IdentityCheck",
+        "identityFraudScore": 2
+      }
+    },
+    {
+      "criType": "UK Passport (Stub)",
+      "label": "Passed passport check (M1A)",
+      "payload": {
+        "type": "IdentityCheck",
+        "validityScore": 2,
+        "strengthScore": 4
+      }
+    },
+    {
+      "criType": "Knowledge Based Verification (Stub)",
+      "label": "Passed verification (M1A) with checkDetails",
+      "payload": {
+        "type": "IdentityCheck",
+        "verificationScore": 2,
+        "checkDetails": [
+          {
+            "kbvResponseMode": "multiple_choice",
+            "kbvQuality": 3,
+            "checkMethod": "kbv"
+          },
+          {
+            "kbvResponseMode": "multiple_choice",
+            "kbvQuality": 3,
+            "checkMethod": "kbv"
+          },
+          {
+            "kbvResponseMode": "multiple_choice",
+            "kbvQuality": 2,
+            "checkMethod": "kbv"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Knowledge Based Verification (Stub)",
+      "label": "Failed verification with failedCheckDetails",
+      "payload": {
+        "type": "IdentityCheck",
+        "verificationScore": 0,
+        "failedCheckDetails": [
+          {
+            "kbvResponseMode": "multiple_choice",
+            "checkMethod": "kbv"
+          },
+          {
+            "kbvResponseMode": "multiple_choice",
+            "checkMethod": "kbv"
+          },
+          {
+            "kbvResponseMode": "multiple_choice",
+            "checkMethod": "kbv"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "DOC Checking App (Stub)",
+      "label": "Passed DCMAW (M1B) with checkDetails",
+      "payload": {
+        "type": "IdentityCheck",
+        "validityScore": 2,
+        "strengthScore": 3,
+        "activityHistoryScore": "1",
+        "checkDetails": [
+          {
+            "checkMethod": "vri"
+          },
+          {
+            "biometricVerificationProcessLevel": 2,
+            "checkMethod": "bvr"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -66,19 +66,88 @@
     },
     {
       "criType": "DOC Checking App (Stub)",
-      "label": "Passed DCMAW (M1B) with checkDetails",
+      "label": "Passed DCMAW driving licence check (M1B)",
       "payload": {
         "type": "IdentityCheck",
         "validityScore": 2,
         "strengthScore": 3,
-        "activityHistoryScore": "1",
+        "activityHistoryScore": 1,
         "checkDetails": [
           {
             "checkMethod": "vri"
           },
           {
-            "biometricVerificationProcessLevel": 2,
-            "checkMethod": "bvr"
+            "checkMethod": "bvr",
+            "biometricVerificationProcessLevel": 2
+          }
+        ]
+      }
+    },
+    {
+      "criType": "DOC Checking App (Stub)",
+      "label": "Failed DCMAW NFC chipped passport check",
+      "payload": {
+        "type": "IdentityCheck",
+        "validityScore": 0,
+        "strengthScore": 4,
+        "ci": [
+          "D06",
+          "D05"
+        ],
+        "failedCheckDetails": [
+          {
+            "checkMethod": "vcrypt",
+            "identityCheckPolicy": "published"
+          },
+          {
+            "checkMethod": "bvr",
+            "biometricVerificationProcessLevel": 3
+          }
+        ]
+      }
+    },
+    {
+      "criType": "DOC Checking App (Stub)",
+      "label": "Failed DCMAW driving licence biometric check",
+      "payload": {
+        "type": "IdentityCheck",
+        "validityScore": 0,
+        "strengthScore": 3,
+        "activityHistoryScore": 0,
+        "ci": [
+          "D06",
+          "D05"
+        ],
+        "failedCheckDetails": [
+          {
+            "checkMethod": "vri",
+            "identityCheckPolicy": "published"
+          },
+          {
+            "checkMethod": "bvr",
+            "biometricVerificationProcessLevel": 3
+          }
+        ]
+      }
+    },
+    {
+      "criType": "DOC Checking App (Stub)",
+      "label": "Failed DCMAW driving licence liveness/likeness check",
+      "payload": {
+        "type": "IdentityCheck",
+        "validityScore": 0,
+        "strengthScore": 3,
+        "activityHistoryScore": 0,
+        "ci": [],
+        "failedCheckDetails": [
+          {
+            "checkMethod": "vri",
+            "identityCheckPolicy": "published",
+            "activityFrom": "2019-01-01"
+          },
+          {
+            "checkMethod": "bvr",
+            "biometricVerificationProcessLevel": 3
           }
         ]
       }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -226,6 +226,20 @@
                 </div>
             {{/isVerificationType}}
 
+            {{^isUserAssertedType}}
+                <div class="govuk-form-group">
+                    <h1 class="govuk-label-wrapper">
+                        <label class="govuk-label govuk-label--l" for="evidenceJsonPayload">
+                           Override evidence block
+                        </label>
+                    </h1>
+                    <div class="govuk-hint">
+                        Set a custom evidence block in JSON format
+                    </div>
+                    <textarea class="govuk-textarea" id="evidenceJsonPayload" name="evidenceJsonPayload" rows="5"></textarea>
+                </div>
+            {{/isUserAssertedType}}
+
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -230,12 +230,10 @@
                 <div class="govuk-form-group">
                     <h1 class="govuk-label-wrapper">
                         <label class="govuk-label govuk-label--l" for="evidenceJsonPayload">
-                           Override evidence block
+                           Override evidence block (optional)
                         </label>
                     </h1>
-                    <div class="govuk-hint">
-                        Set a custom evidence block in JSON format
-                    </div>
+                    <div class="govuk-form-group" id="custom_evidence_block"></div><br>
                     <textarea class="govuk-textarea" id="evidenceJsonPayload" name="evidenceJsonPayload" rows="5"></textarea>
                 </div>
             {{/isUserAssertedType}}
@@ -380,6 +378,26 @@
             var val = $(event.target).val();
             var {payload} = filtered.find(x => x.label === val)
             $("#jsonPayload").val(JSON.stringify(payload, undefined, 4))
+        });
+    });
+
+    var evidenceDropdownData = {{{cri_stub_evidence_payloads}}}
+    var evidenceBlocksFiltered = evidenceDropdownData.filter(x => x.criType === "{{cri-name}}")
+    $(document).ready(function() {
+        var select = $('<select class="govuk-select" id="custom_evidence" name="sort">')
+        select.append($("<option selected disabled hidden value=''>").text('Select from dropdown...'))
+        $(evidenceBlocksFiltered).each(function() {
+            select.append($("<option>")
+            .prop('value', this.label)
+            .text(this.label));
+        });
+
+        var label = $('<label class="govuk-label" for="sort">').text("Select evidence block: ");
+        $('#custom_evidence_block').append(label).append(select);
+        $("#custom_evidence").on("change", function(event) {
+            var val = $(event.target).val();
+            var {payload} = evidenceBlocksFiltered.find(x => x.label === val)
+            $("#evidenceJsonPayload").val(JSON.stringify(payload, undefined, 4))
         });
     });
 </script>


### PR DESCRIPTION
## Proposed changes

### What changed

Add input field for custom evidence payload in the CRI stubs (every CRI except address) and allow choosing from a dropdown
<img width="1011" alt="Screenshot 2022-12-21 at 12 16 18" src="https://user-images.githubusercontent.com/32681701/208904612-5258ef04-f5d6-403b-b013-78a3c833b5c4.png">

### Why did it change

Allows us to override the evidence params with a custom json evidence payload so we can test with new fields like checkDetails

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

