### PR TITLE
PYIC-2433 Core Stub - fixed dns A to loadbalancer entries

### DIFF
--- a/di-ipv-core-stub/deploy/template.yaml
+++ b/di-ipv-core-stub/deploy/template.yaml
@@ -160,7 +160,6 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       Type: A
-      TTL: 900
       Name: !If
         - IsNonProd
         - !Sub "core.${Environment}.stubs.account.gov.uk"
@@ -169,12 +168,14 @@ Resources:
         - IsNonProd
         - !ImportValue BuildPublicHostedZoneId
         - !ImportValue RootPublicHostedZoneId
+      AliasTarget:
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt LoadBalancer.DNSName
 
   CorePassportDNSRecord:
     Type: AWS::Route53::RecordSet
     Properties:
       Type: A
-      TTL: 900
       Name: !If
         - IsNonProd
         - !Sub "passport-core.${Environment}.stubs.account.gov.uk"
@@ -183,6 +184,9 @@ Resources:
         - IsNonProd
         - !ImportValue BuildPublicHostedZoneId
         - !ImportValue RootPublicHostedZoneId
+      AliasTarget:
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt LoadBalancer.DNSName
 
   CoreStubSSLCert:
     Type: AWS::CertificateManager::Certificate


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-2433 Core Stub - fixed dns A to loadbalancer entries
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-2433 Core Stub - fixed dns A to loadbalancer entries
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2433](https://govukverify.atlassian.net/browse/PYIC-2433)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2433]: https://govukverify.atlassian.net/browse/PYIC-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ