### PR TITLE
PYIC-2433 Changed passport private api key to work via secrets manager.

### DIFF
--- a/di-ipv-core-stub/deploy/template.yaml
+++ b/di-ipv-core-stub/deploy/template.yaml
@@ -115,10 +115,14 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/passport/env/MAX_JAR_TTL_MINS"
+    # PassportPrivateApiKey:
+    #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    #    Type: AWS::SSM::Parameter::Value<String>
+    #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY"
   PassportPrivateApiKey:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY"
+    Description: "Environment Variables for ECS - Retrieved from Secrets Manager"
+    Type: String
+    Default: '{{resolve:secretsmanager:/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY}}'
 
 Conditions:
   IsDevelopment: !Not


### PR DESCRIPTION
	modified:   di-ipv-core-stub/deploy/template.yaml

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-2433 Changed passport private api key to work via secrets manager.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-2433 Changed passport private api key to work via secrets manager.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2433](https://govukverify.atlassian.net/browse/PYIC-2433)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2433]: https://govukverify.atlassian.net/browse/PYIC-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ