### PR TITLE
PYIC-2502 Add stub VC payloads for driving licence

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -427,6 +427,74 @@
           }
         ]
       }
+    },
+    {
+      "criType": "Driving Licence (Stub)",
+      "label": "Alice Parker (Valid) DVLA Licence",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Alice",
+                "type": "GivenName"
+              },
+              {
+                "value": "Jane",
+                "type": "GivenName"
+              },
+              {
+                "value": "Parker",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1970-01-01"
+          }
+        ],
+        "drivingPermit": [
+          {
+            "issuedBy": "DVLA",
+            "documentNumber": "PARKE710112PBFGA",
+            "expiryDate": "2032-02-02"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Driving Licence (Stub)",
+      "label": "Bob Parker (Valid) DVA Licence",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Bob",
+                "type": "GivenName"
+              },
+              {
+                "value": "Parker",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1970-11-09"
+          }
+        ],
+        "drivingPermit": [
+          {
+            "issuedBy": "DVA",
+            "documentNumber": "55667789",
+            "expiryDate": "2032-02-02"
+          }
+        ]
+      }
     }
   ]
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -151,6 +151,21 @@
           }
         ]
       }
+    },
+    {
+      "criType": "Driving Licence (Stub)",
+      "label": "Passed driving licence check",
+      "payload": {
+        "type": "IdentityCheck",
+        "validityScore": 1,
+        "strengthScore": 3,
+        "activityHistoryScore": 1,
+        "checkDetails": {
+          "identityCheckPolicy": "published",
+          "activityFrom": "1982-05-23",
+          "checkMethod": "data"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add stub data and evidence payloads for the driving licence CRI. We might need to tweak/add to these going forward

### Why did it change

So we can test the driving licence CRI stub

### Issue tracking
- [PYIC-2502](https://govukverify.atlassian.net/browse/PYIC-2502)



[PYIC-2502]: https://govukverify.atlassian.net/browse/PYIC-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ