### PR TITLE
BAU Correct driving licence evidence validity score

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -157,7 +157,7 @@
       "label": "Passed driving licence check",
       "payload": {
         "type": "IdentityCheck",
-        "validityScore": 1,
+        "validityScore": 2,
         "strengthScore": 3,
         "activityHistoryScore": 1,
         "checkDetails": {


### PR DESCRIPTION
Correct driving licence evidence validity score - for the M1B profile it should be validity=2 not 1