### PR TITLE
BAU Update driving licence VC checkDetails to be an array

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -473,14 +473,15 @@ public class AuthorizeHandler {
                             CredentialIssuerConfig.ACTIVITY_PARAM, Integer.parseInt(activityValue));
                 }
 
-                Map<String, Object> checkDetailsValue =
+                List<Map<String, Object>> checkDetailsValue = new ArrayList<>();
+                checkDetailsValue.add(
                         Map.of(
                                 "identityCheckPolicy",
                                 "published",
                                 "activityFrom",
                                 "1982-05-23",
                                 "checkMethod",
-                                "data");
+                                "data"));
 
                 if (validityNum < 2) {
                     gpg45Score.put(

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -160,11 +160,13 @@
         "validityScore": 2,
         "strengthScore": 3,
         "activityHistoryScore": 1,
-        "checkDetails": {
-          "identityCheckPolicy": "published",
-          "activityFrom": "1982-05-23",
-          "checkMethod": "data"
-        }
+        "checkDetails": [
+          {
+            "identityCheckPolicy": "published",
+            "activityFrom": "1982-05-23",
+            "checkMethod": "data"
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
## Proposed changes

### What changed

Update driving licence VC checkDetails to be an array

### Why did it change

`checkDetails` should be an array as per the VC schema
