### PR TITLE
PYIC-2449 Allow egress from ecs port 443 to all

### DIFF
--- a/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
@@ -232,6 +232,11 @@ Resources:
           FromPort: 443
           IpProtocol: tcp
           ToPort: 443
+        - CidrIp: 0.0.0.0/0
+          Description: Allow outbound traffic to everywhere 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
       SecurityGroupIngress:
         - CidrIp:
             Fn::ImportValue: !Sub ${VpcStackName}-VpcCidr


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-2449 Allow egress from ecs port 443 to all
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-2449 Allow egress from ecs port 443 to all
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2449](https://govukverify.atlassian.net/browse/PYIC-2449)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2449]: https://govukverify.atlassian.net/browse/PYIC-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ