### PR TITLE
work on making lambda run

### DIFF
--- a/update-ecs-env-vars/app.ts
+++ b/update-ecs-env-vars/app.ts
@@ -10,9 +10,9 @@ import {
     ListServicesCommandOutput, ListClustersCommand, DescribeClustersCommand
 } from "@aws-sdk/client-ecs";
 
-import { Context, EventBridgeEvent, Handler  } from "aws-lambda";
+import { Context, EventBridgeEvent } from "aws-lambda";
 
-export const handler = async (
+export const lambdaHandler = async (
   event: EventBridgeEvent<any, any>,
   context: Context
 ): Promise<object> => {

--- a/update-ecs-env-vars/deploy/template.yaml
+++ b/update-ecs-env-vars/deploy/template.yaml
@@ -44,7 +44,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: "../"
-      Handler: app.handler
+      Handler: app.lambdaHandler
       Runtime: nodejs18.x
       Architectures:
         - arm64

--- a/update-ecs-env-vars/tsconfig.json
+++ b/update-ecs-env-vars/tsconfig.json
@@ -11,9 +11,6 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
-        "outDir" : "./build",
-        "callbackWaitsForEmptyEventLoop" : true
     },
-    "lib": ["dom"],
-    "files" : ["./app.ts"]
+    "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
Lambda to update environment variables when SSM parameters changed

## Proposed changes
This defines a lambda function which updates the ECS Task definitions to change the environment variables on the containers when the corresponding parameters are changed in SSM

### What changed
see above

### Why did it change
The stubs containers use SSM environment variables where we would  normally use SSM parameters - this aligns them so that if the SSM parameter is changed it will be reflected in the stub without the need for a rebuild/deploy of the stub
