### PR TITLE
PYIC-2506 Core Cri Domain Cert set to Regional

### DIFF
--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -304,7 +304,7 @@ Resources:
   CoreStubRestApiDomain:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      CertificateArn: !Ref CoreStubSSLCert
+      RegionalCertificateArn: !Ref CoreStubSSLCert
       #CertificateArn: !Sub
       #   - "arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/${certId}"
       #   - certId: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, certId ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-2506 Core Cri Domain Cert set to Regional
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-2506 Core Cri Domain Cert set to Regional
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2506](https://govukverify.atlassian.net/browse/PYIC-2506)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2506]: https://govukverify.atlassian.net/browse/PYIC-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ