### PR TITLE
PYIC-2558 Elementary beginnings of Adding Basic Auth Handling To Core Stub

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -29,8 +29,8 @@ public class CoreStub {
 
     private void initRoutes() throws Exception {
         CoreStubHandler coreStubHandler = new CoreStubHandler(new HandlerHelper(getEcPrivateKey()));
-        BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
         if (CoreStubConfig.ENABLE_BASIC_AUTH) {
+            BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
             Spark.before(basicAuthHandler.authFilter);
         }
         Spark.get("/", coreStubHandler.serveHomePage);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -30,7 +30,9 @@ public class CoreStub {
     private void initRoutes() throws Exception {
         CoreStubHandler coreStubHandler = new CoreStubHandler(new HandlerHelper(getEcPrivateKey()));
         BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
-        Spark.before(basicAuthHandler.authFilter);
+        if (CoreStubConfig.ENABLE_BASIC_AUTH) {
+            Spark.before(basicAuthHandler.authFilter);
+        };
         Spark.get("/", coreStubHandler.serveHomePage);
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import spark.ExceptionHandler;
 import spark.Spark;
 import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
+import uk.gov.di.ipv.stub.core.handlers.BasicAuthHandler;
 import uk.gov.di.ipv.stub.core.handlers.CoreStubHandler;
 import uk.gov.di.ipv.stub.core.utils.HandlerHelper;
 import uk.gov.di.ipv.stub.core.utils.ViewHelper;
@@ -28,6 +29,8 @@ public class CoreStub {
 
     private void initRoutes() throws Exception {
         CoreStubHandler coreStubHandler = new CoreStubHandler(new HandlerHelper(getEcPrivateKey()));
+        BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
+        Spark.before(basicAuthHandler.authFilter);
         Spark.get("/", coreStubHandler.serveHomePage);
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -32,7 +32,7 @@ public class CoreStub {
         BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
         if (CoreStubConfig.ENABLE_BASIC_AUTH) {
             Spark.before(basicAuthHandler.authFilter);
-        };
+        }
         Spark.get("/", coreStubHandler.serveHomePage);
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
@@ -35,7 +35,7 @@ public class CoreStubConfig {
                             "http://localhost:" + CORE_STUB_PORT + "/callback"));
     public static final int CORE_STUB_MAX_SEARCH_RESULTS =
             Integer.parseInt(getConfigValue("CORE_STUB_MAX_SEARCH_RESULTS", "200"));
-    public static Map<String, UserAuth> CORE_STUB_BASIC_AUTH ;
+    public static UserAuth CORE_STUB_BASIC_AUTH;
     public static final String CORE_STUB_USER_DATA_PATH =
             getConfigValue("CORE_STUB_USER_DATA_PATH", "config/experian-uat-users-large.zip");
     public static final String CORE_STUB_CONFIG_FILE =
@@ -57,6 +57,9 @@ public class CoreStubConfig {
     public static final boolean CORE_STUB_ENABLE_BACKEND_ROUTES =
             Boolean.parseBoolean(getConfigValue("CORE_STUB_ENABLE_BACKEND_ROUTES", "true"));
 
+    public static final boolean ENABLE_BASIC_AUTH =
+            Boolean.parseBoolean(getConfigValue("ENABLE_BASIC_AUTH", "false"));
+
     public static final List<Identity> identities = new ArrayList<>();
     public static final List<CredentialIssuer> credentialIssuers = new ArrayList<>();
 
@@ -71,7 +74,7 @@ public class CoreStubConfig {
         return envValue;
     }
 
-    public static Map<String, UserAuth> getUserAuth() {
+    public static UserAuth getUserAuth() {
         if (CORE_STUB_BASIC_AUTH == null) {
             CORE_STUB_BASIC_AUTH = parseUserAuth();
         }
@@ -108,14 +111,12 @@ public class CoreStubConfig {
         }
     }
 
-    private static Map<String, UserAuth> parseUserAuth() {
+    private static UserAuth parseUserAuth() {
         String user_auth = getConfigValue("CORE_STUB_BASIC_AUTH", null);
         if (user_auth == null) {
-            return new HashMap<>();
+            return null;
         }
-
-        Type type = new TypeToken<Map<String, UserAuth>>() {}.getType();
-
+        Type type = new TypeToken<UserAuth>() {}.getType();
         return gson.fromJson(user_auth, type);
     }
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/UserAuth.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/UserAuth.java
@@ -3,4 +3,12 @@ package uk.gov.di.ipv.stub.core.config;
 public class UserAuth {
     private String username;
     private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/UserAuth.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/UserAuth.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.stub.core.config;
+
+public class UserAuth {
+    private String username;
+    private String password;
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
@@ -40,7 +40,7 @@ public class BasicAuthHandler {
     }
 
     private String[] extractCredentials(String encodedHeader) {
-            String decodedHeader = new String(Base64.getDecoder().decode(encodedHeader));
-            return decodedHeader.split(":");
+        String decodedHeader = new String(Base64.getDecoder().decode(encodedHeader));
+        return decodedHeader.split(":");
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
@@ -1,0 +1,4 @@
+package uk.gov.di.ipv.stub.core.handlers;
+
+public class BasicAuthHandler {
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
@@ -1,4 +1,46 @@
 package uk.gov.di.ipv.stub.core.handlers;
 
+import java.util.Base64;
+
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
+
 public class BasicAuthHandler {
+    private static int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_TYPE = "Basic";
+
+    public BasicAuthHandler() {
+        CoreStubConfig.getUserAuth();
+    }
+
+    public Filter authFilter = (Request request, Response response) -> {
+        if (!request.headers().contains(AUTHORIZATION_HEADER) || !authenticated(request)) {
+            response.header("WWW-Authenticate", AUTHORIZATION_TYPE);
+            Spark.halt(401, "Not Authenticated");
+        }
+    };
+
+    private Boolean authenticated(Request request) {
+        String authHeader = request.headers(AUTHORIZATION_HEADER);
+        String encodedHeader = authHeader.substring(authHeader.indexOf(AUTHORIZATION_TYPE) + AUTHORIZATION_TYPE.length() + 1).trim();
+        String[] submittedCredentials = extractCredentials(encodedHeader);
+
+        if (submittedCredentials != null && submittedCredentials.length == NUMBER_OF_AUTHENTICATION_FIELDS) {
+            String submittedUsername = submittedCredentials[0];
+            String submittedPassword = submittedCredentials[1];
+            String username = CoreStubConfig.CORE_STUB_BASIC_AUTH.getUsername();
+            String password = CoreStubConfig.CORE_STUB_BASIC_AUTH.getPassword();
+            return submittedUsername.equals(username) && submittedPassword.equals(password);
+        }
+        return false;
+    }
+
+    private String[] extractCredentials(String encodedHeader) {
+            String decodedHeader = new String(Base64.getDecoder().decode(encodedHeader));
+            return decodedHeader.split(":");
+    }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
@@ -9,7 +9,7 @@ import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
 import java.util.Base64;
 
 public class BasicAuthHandler {
-    private static int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
+    private static final int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String AUTHORIZATION_TYPE = "Basic";
 
@@ -27,13 +27,14 @@ public class BasicAuthHandler {
 
     private Boolean authenticated(Request request) {
         String authHeader = request.headers(AUTHORIZATION_HEADER);
+        int authTypeIndex = authHeader.indexOf(AUTHORIZATION_TYPE);
+
+        if (authHeader == null || authTypeIndex < 0) {
+            return false;
+        }
+
         String encodedHeader =
-                authHeader
-                        .substring(
-                                authHeader.indexOf(AUTHORIZATION_TYPE)
-                                        + AUTHORIZATION_TYPE.length()
-                                        + 1)
-                        .trim();
+                authHeader.substring(authTypeIndex + AUTHORIZATION_TYPE.length() + 1).trim();
         String[] submittedCredentials = extractCredentials(encodedHeader);
 
         if (submittedCredentials != null

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
@@ -1,12 +1,12 @@
 package uk.gov.di.ipv.stub.core.handlers;
 
-import java.util.Base64;
-
 import spark.Filter;
 import spark.Request;
 import spark.Response;
 import spark.Spark;
 import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
+
+import java.util.Base64;
 
 public class BasicAuthHandler {
     private static int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
@@ -17,19 +17,27 @@ public class BasicAuthHandler {
         CoreStubConfig.getUserAuth();
     }
 
-    public Filter authFilter = (Request request, Response response) -> {
-        if (!request.headers().contains(AUTHORIZATION_HEADER) || !authenticated(request)) {
-            response.header("WWW-Authenticate", AUTHORIZATION_TYPE);
-            Spark.halt(401, "Not Authenticated");
-        }
-    };
+    public Filter authFilter =
+            (Request request, Response response) -> {
+                if (!request.headers().contains(AUTHORIZATION_HEADER) || !authenticated(request)) {
+                    response.header("WWW-Authenticate", AUTHORIZATION_TYPE);
+                    Spark.halt(401, "Not Authenticated");
+                }
+            };
 
     private Boolean authenticated(Request request) {
         String authHeader = request.headers(AUTHORIZATION_HEADER);
-        String encodedHeader = authHeader.substring(authHeader.indexOf(AUTHORIZATION_TYPE) + AUTHORIZATION_TYPE.length() + 1).trim();
+        String encodedHeader =
+                authHeader
+                        .substring(
+                                authHeader.indexOf(AUTHORIZATION_TYPE)
+                                        + AUTHORIZATION_TYPE.length()
+                                        + 1)
+                        .trim();
         String[] submittedCredentials = extractCredentials(encodedHeader);
 
-        if (submittedCredentials != null && submittedCredentials.length == NUMBER_OF_AUTHENTICATION_FIELDS) {
+        if (submittedCredentials != null
+                && submittedCredentials.length == NUMBER_OF_AUTHENTICATION_FIELDS) {
             String submittedUsername = submittedCredentials[0];
             String submittedPassword = submittedCredentials[1];
             String username = CoreStubConfig.CORE_STUB_BASIC_AUTH.getUsername();


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-2558 Elementary beginnings of Adding Basic Auth Handling To CoreStub.
	
	modified:   src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
	modified:   src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
	new file:   src/main/java/uk/gov/di/ipv/stub/core/config/UserAuth.java
	new file:   src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-2558 Elementary beginnings of Adding Basic Auth Handling To CoreStub.

	modified:   src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
	modified:   src/main/java/uk/gov/di/ipv/stub/core/config/CoreStubConfig.java
	new file:   src/main/java/uk/gov/di/ipv/stub/core/config/UserAuth.java
	new file:   src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2558](https://govukverify.atlassian.net/browse/PYIC-2558)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2558]: https://govukverify.atlassian.net/browse/PYIC-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ