### PR TITLE
PYIC-2565 Correct driving licence VC stub data

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -458,7 +458,8 @@
         "drivingPermit": [
           {
             "issuedBy": "DVLA",
-            "documentNumber": "PARKE710112PBFGA",
+            "issueDate": "2005-02-02",
+            "personalNumber": "PARKE710112PBFGA",
             "expiryDate": "2032-02-02"
           }
         ]
@@ -490,7 +491,8 @@
         "drivingPermit": [
           {
             "issuedBy": "DVA",
-            "documentNumber": "55667789",
+            "issueDate": "2005-02-02",
+            "personalNumber": "55667789",
             "expiryDate": "2032-02-02"
           }
         ]


### PR DESCRIPTION
## Proposed changes

### What changed

Correct driving licence VC stub data

### Why did it change

So it's in line with the VC spec - https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0024-identity-vc-for-checks.md

### Issue tracking
- [PYI-2565](https://govukverify.atlassian.net/browse/PYI-2565)

