### PR TITLE
tweaking the scaling policy/instance size for load testing

### DIFF
--- a/di-ipv-core-stub/deploy/alb-only/template.yaml
+++ b/di-ipv-core-stub/deploy/alb-only/template.yaml
@@ -435,7 +435,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-core-stub/deploy/cri-preprod/template.yaml
+++ b/di-ipv-core-stub/deploy/cri-preprod/template.yaml
@@ -494,7 +494,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-core-stub/deploy/cri-rest-api/template.yaml
+++ b/di-ipv-core-stub/deploy/cri-rest-api/template.yaml
@@ -625,7 +625,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -495,7 +495,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-core-stub/deploy/passport/template.yaml
+++ b/di-ipv-core-stub/deploy/passport/template.yaml
@@ -506,7 +506,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/activity-history/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/activity-history/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/address/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/dcmaw/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/dcmaw/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/driving-license/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/driving-license/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/kbv/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
@@ -460,7 +460,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-orchestrator-stub/deploy-build/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-build/template.yaml
@@ -479,7 +479,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 

--- a/di-ipv-orchestrator-stub/deploy-staging/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-staging/template.yaml
@@ -479,7 +479,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 90
+        TargetValue: 70
         ScaleInCooldown: 300
         ScaleOutCooldown: 60
 


### PR DESCRIPTION
Set the scaling threshold to be 70% instead of 90%