### PR TITLE
removed the perms boundary to make ECS actions work

### DIFF
--- a/update-ecs-env-vars/deploy/template.yaml
+++ b/update-ecs-env-vars/deploy/template.yaml
@@ -19,10 +19,10 @@ Parameters:
   #  Description: "The ARN of the permissions boundary to apply when creating IAM roles"
   #  Type: String
   #  Default: "none"
-  ProgrammaticPermissionsBoundary:
-    Description: "The ARN of the programmatic permissions boundary to apply when creating IAM roles"
-    Type: String
-    Default: "none"
+  #ProgrammaticPermissionsBoundary:
+  #  Description: "The ARN of the programmatic permissions boundary to apply when creating IAM roles"
+  #  Type: String
+  #  Default: "none"
   CodeSigningConfigArn:
     Type: String
     Description: >
@@ -31,11 +31,11 @@ Parameters:
 
 Conditions:
 
-  UsePermissionsBoundary:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref ProgrammaticPermissionsBoundary
-          - "none"
+  #UsePermissionsBoundary:
+  #  Fn::Not:
+  #    - Fn::Equals:
+  #        - !Ref ProgrammaticPermissionsBoundary
+  #        - "none"
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -89,10 +89,10 @@ Resources:
                 "ssmParamPrefix" : "/stubs/tobytesting/thistest/" } ]
       KmsKeyArn: !GetAtt LambdaKmsKey.Arn
       ReservedConcurrentExecutions: 1
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref ProgrammaticPermissionsBoundary
-        - !Ref AWS::NoValue
+      #PermissionsBoundary: !If
+      #  - UsePermissionsBoundary
+      #  - !Ref ProgrammaticPermissionsBoundary
+      #  - !Ref AWS::NoValue
       CodeSigningConfigArn: !If
         - UseCodeSigning
         - !Ref CodeSigningConfigArn


### PR DESCRIPTION
The permissions boundary does not allow the actions required to update the ECS task definition, this is removing it to allow the update task definition to work as intended