### PR TITLE
LIME-238 Align core-stub with field name change in test data

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -57,7 +57,7 @@ public class IdentityMapper {
                         map.get("houseName"),
                         map.get("street"),
                         map.get("district"),
-                        map.get("posttown"),
+                        map.get("postTown"),
                         map.get("postcode"),
                         addressValidFrom,
                         null);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Changed the field name for posttown to postTown in the UKAddress/IdentityMapper

### Why did it change

To restore mapping of towns in test data, which are currently empty due to looking for the previous field name

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-238](https://govukverify.atlassian.net/browse/LIME-238)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-238]: https://govukverify.atlassian.net/browse/LIME-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ