### PR TITLE
OJ-1439: Added api key for address cri build

### DIFF
--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -43,6 +43,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+  ApiKeyCriAddressBuild:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_ADDRESS_BUILD"
   JavaOpts:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -546,6 +550,8 @@ Resources:
             Value: !Ref CoreStubEnableBackendRoutes
           - Name: CORE_STUB_BASIC_AUTH
             Value: !Ref CoreStubBasicAuth
+          - Name: API_KEY_CRI_ADDRESS_BUILD
+            Value: !Ref ApiKeyCriAddressBuild
           - Name: ENABLE_BASIC_AUTH
             Value: !Ref EnableBasicAuth
           Secrets:


### PR DESCRIPTION
## Proposed changes

API gateway calls to non dev environments are protected by an API-KEY

### What changed

This PR adds the API-KEY for the Address build environment

### Why did it change

Requests against the new AWS stubs in build were failing because of non-existent API-KEY

- [OJ-1439](https://govukverify.atlassian.net/browse/OJ-1439)



[OJ-1439]: https://govukverify.atlassian.net/browse/OJ-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ