### PR TITLE
OJ-1439:  Added api-keys for pre-prod aws build

### DIFF
--- a/di-ipv-core-stub/deploy/cri-preprod/template.yaml
+++ b/di-ipv-core-stub/deploy/cri-preprod/template.yaml
@@ -30,6 +30,14 @@ Parameters:
       The name of the stack that defines the VPC in which this container will
       run.
     Type: String
+  ApiKeyCriAddressBuild:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri-preprod/env/API_KEY_CRI_ADDRESS_BUILD"
+  ApiKeyCriKbvBuild:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri-preprod/env/API_KEY_CRI_KBV_BUILD"
   CodeSigningConfigArn:
     Type: String
     Description: >
@@ -545,6 +553,10 @@ Resources:
             Value: !Ref CoreStubEnableBackendRoutes
           - Name: CORE_STUB_BASIC_AUTH
             Value: !Ref CoreStubBasicAuth
+          - Name: API_KEY_CRI_ADDRESS_BUILD
+            Value: !Ref ApiKeyCriAddressBuild
+          - Name: API_KEY_CRI_KBV_BUILD
+            Value: !Ref ApiKeyCriKbvBuild
           - Name: ENABLE_BASIC_AUTH
             Value: !Ref EnableBasicAuth
           Secrets:


### PR DESCRIPTION
## Proposed changes

Added Api-keys for AWS pre-prod

### What changed

Set up pre-prod environment for AWS stub

### Why did it change

Replacing PAAS stub with AWS stub as time goes on

- [OJ-1439](https://govukverify.atlassian.net/browse/OJ-1439)



[OJ-1439]: https://govukverify.atlassian.net/browse/OJ-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ