### PR TITLE
[PYIC-2672] Pass state from JWT in auth error responses

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -65,16 +65,13 @@ public class RequestedErrorResponseService {
 
             JWTClaimsSet jwtClaimsSet =
                     getSignedJWT(
-                            queryParamsMap.value(RequestParamConstants.REQUEST),
-                            clientConfig.getEncryptionPrivateKey())
-                        .getJWTClaimsSet();
+                                    queryParamsMap.value(RequestParamConstants.REQUEST),
+                                    clientConfig.getEncryptionPrivateKey())
+                            .getJWTClaimsSet();
 
-            String redirectUri = jwtClaimsSet
-                    .getClaim(RequestParamConstants.REDIRECT_URI)
-                    .toString();
-            String state = jwtClaimsSet
-                    .getClaim(RequestParamConstants.STATE)
-                    .toString();
+            String redirectUri =
+                    jwtClaimsSet.getClaim(RequestParamConstants.REDIRECT_URI).toString();
+            String state = jwtClaimsSet.getClaim(RequestParamConstants.STATE).toString();
 
             return new AuthorizationErrorResponse(
                     URI.create(redirectUri),

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.stub.cred.service;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationErrorResponse;
 import com.nimbusds.oauth2.sdk.ErrorObject;
@@ -62,15 +63,16 @@ public class RequestedErrorResponseService {
             String clientIdValue = queryParamsMap.value(RequestParamConstants.CLIENT_ID);
             ClientConfig clientConfig = CredentialIssuerConfig.getClientConfig(clientIdValue);
 
-            String redirectUri =
-                    getSignedJWT(
-                                    queryParamsMap.value(RequestParamConstants.REQUEST),
-                                    clientConfig.getEncryptionPrivateKey())
-                            .getJWTClaimsSet()
+            JWTClaimsSet jwtClaimsSet = getSignedJWT(
+                    queryParamsMap.value(RequestParamConstants.REQUEST),
+                    clientConfig.getEncryptionPrivateKey())
+                    .getJWTClaimsSet();
+
+            String redirectUri = jwtClaimsSet
                             .getClaim(RequestParamConstants.REDIRECT_URI)
                             .toString();
-
-            String state = queryParamsMap.value(RequestParamConstants.STATE);
+            String state = jwtClaimsSet
+                    .getClaim(RequestParamConstants.STATE).toString();
 
             return new AuthorizationErrorResponse(
                     URI.create(redirectUri),

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -63,16 +63,18 @@ public class RequestedErrorResponseService {
             String clientIdValue = queryParamsMap.value(RequestParamConstants.CLIENT_ID);
             ClientConfig clientConfig = CredentialIssuerConfig.getClientConfig(clientIdValue);
 
-            JWTClaimsSet jwtClaimsSet = getSignedJWT(
-                    queryParamsMap.value(RequestParamConstants.REQUEST),
-                    clientConfig.getEncryptionPrivateKey())
-                    .getJWTClaimsSet();
+            JWTClaimsSet jwtClaimsSet =
+                    getSignedJWT(
+                            queryParamsMap.value(RequestParamConstants.REQUEST),
+                            clientConfig.getEncryptionPrivateKey())
+                        .getJWTClaimsSet();
 
             String redirectUri = jwtClaimsSet
-                            .getClaim(RequestParamConstants.REDIRECT_URI)
-                            .toString();
+                    .getClaim(RequestParamConstants.REDIRECT_URI)
+                    .toString();
             String state = jwtClaimsSet
-                    .getClaim(RequestParamConstants.STATE).toString();
+                    .getClaim(RequestParamConstants.STATE)
+                    .toString();
 
             return new AuthorizationErrorResponse(
                     URI.create(redirectUri),

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -389,7 +389,7 @@ class AuthorizeHandlerTest {
         verify(mockResponse)
                 .redirect(
                         VALID_REDIRECT_URI
-                                + "?error=invalid_request&iss=Credential+Issuer+Stub&error_description=An+error+description");
+                                + "?iss=Credential+Issuer+Stub&state=test-state&error=invalid_request&error_description=An+error+description");
     }
 
     private String createExpectedErrorQueryStringParams(ErrorObject error) {


### PR DESCRIPTION
Pass state from JWT claims in auth error responses

## Proposed changes

### What changed

- Derive state from JWTClaimSet and include in AuthorizationErrorResponse generation
- Test coverage for new query params

### Why did it change

- Required to test mobile browser app bug

### Issue tracking

- [PYI-2672](https://govukverify.atlassian.net/browse/PYI-2672)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
