### PR TITLE
[PYIC-2679] Correct stub name data for test subject

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -492,6 +492,10 @@
                 "type": "GivenName"
               },
               {
+                "value": "Jane",
+                "type": "GivenName"
+              },
+              {
                 "value": "Par-ker",
                 "type": "FamilyName"
               }
@@ -523,6 +527,10 @@
             "nameParts": [
               {
                 "value": "Aliçe",
+                "type": "GivenName"
+              },
+              {
+                "value": "Jane",
                 "type": "GivenName"
               },
               {


### PR DESCRIPTION
## Proposed changes

### What changed

Added missing middle name for test subject

### Why did it change

Missed on original commit

### Issue tracking
- [PYI-2679](https://govukverify.atlassian.net/browse/PYIC-2679)

## Checklists

### Environment variables or secrets

- No environment variables or secrets were added or changed

### Other considerations

