### PR TITLE
[PYIC-2686] Add Address and Fraud data for Mobile App E2E test identities

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -389,6 +389,55 @@
       }
     },
     {
+      "criType": "Address (Stub)",
+      "label": "Joe Shmoe Valid Address",
+      "payload": {
+        "address": [
+          {
+            "buildingName": "122",
+            "streetName": "BURNS CRESCENT",
+            "postalCode": "EH1 9GP",
+            "addressLocality": "EDINBURGH",
+            "validFrom": "1995-01-02"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Fraud Check (Stub)",
+      "label": "Joe Shmoe (Valid) Fraud",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Joe Shmoe",
+                "type": "GivenName"
+              },
+              {
+                "value": "Doe The Ball",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1985-02-08"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "122",
+            "streetName": "BURNS CRESCENT",
+            "postalCode": "EH1 9GP",
+            "addressLocality": "EDINBURGH",
+            "validFrom": "1995-01-02"
+          }
+        ]
+      }
+    },
+    {
       "criType": "DOC Checking App (Stub)",
       "label": "Alice Doe (Valid) NFC Passport",
       "payload": {
@@ -424,6 +473,63 @@
             "icaoIssuerCode": "GBR",
             "documentNumber": "123456789",
             "expiryDate": "2022-02-02"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Address (Stub)",
+      "label": "Alice Doe Valid Address",
+      "payload": {
+        "address": [
+          {
+            "buildingName": "221C",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 6XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1980-01-02"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Fraud Check (Stub)",
+      "label": "Alice Doe (Valid) Fraud",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Alice",
+                "type": "GivenName"
+              },
+              {
+                "value": "Jane",
+                "type": "GivenName"
+              },
+              {
+                "value": "Laura",
+                "type": "GivenName"
+              },
+              {
+                "value": "Doe",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1970-01-01"
+          }
+        ],
+        "address": [
+          {
+            "buildingName": "221C",
+            "streetName": "BAKER STREET",
+            "postalCode": "NW1 6XE",
+            "addressLocality": "LONDON",
+            "validFrom": "1980-01-02"
           }
         ]
       }


### PR DESCRIPTION
## Proposed changes

### What changed

Add Address and Fraud data for Mobile App E2E test identities

### Why did it change

Required to address Mobile app e2e tests failing

### Issue tracking
- [PYI-2686](https://govukverify.atlassian.net/browse/PYIC-2686)

## Checklists

### Environment variables or secrets

- No environment variables or secrets were added or changed

### Other considerations