### PR TITLE
BAU: Handle subject value from JWT in f2f handler

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandler.java
@@ -1,22 +1,26 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.eclipse.jetty.http.HttpHeader;
+import spark.QueryParamsMap;
 import spark.Request;
 import spark.Response;
 import spark.Route;
+import uk.gov.di.ipv.stub.cred.config.ClientConfig;
+import uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
+import uk.gov.di.ipv.stub.cred.utils.JwtHelper;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 import uk.gov.di.ipv.stub.cred.validation.Validator;
 
 import javax.servlet.http.HttpServletResponse;
 
 import java.util.Objects;
-import java.util.UUID;
 
 public class F2FHandler {
 
@@ -39,11 +43,20 @@ public class F2FHandler {
 
                 tokenService.revoke(accessTokenString);
 
+                QueryParamsMap queryParamsMap = request.queryMap();
+                String requestValue = queryParamsMap.value(RequestParamConstants.REQUEST);
+                String clientIdValue = queryParamsMap.value(RequestParamConstants.CLIENT_ID);
+                ClientConfig clientConfig = CredentialIssuerConfig.getClientConfig(clientIdValue);
+                SignedJWT signedJWT =
+                        JwtHelper.getSignedJWT(
+                                requestValue, clientConfig.getEncryptionPrivateKey());
+
+                String subject = signedJWT.getJWTClaimsSet().getSubject();
+
                 response.type(JSON_RESPONSE_TYPE);
                 response.status(HttpServletResponse.SC_ACCEPTED);
 
-                var userInfo =
-                        new UserInfo(new Subject("urn:fdc:gov.uk:2022:" + UUID.randomUUID()));
+                var userInfo = new UserInfo(new Subject(subject));
                 userInfo.setClaim("https://vocab.account.gov.uk/v1/credentialStatus", "pending");
 
                 return userInfo.toJSONString();

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/JwtHelper.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/JwtHelper.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.stub.cred.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+
+public class JwtHelper {
+    public static SignedJWT getSignedJWT(String request, PrivateKey encryptionPrivateKey)
+            throws java.text.ParseException {
+        try {
+            JWEObject jweObject = getJweObject(request, encryptionPrivateKey);
+            return jweObject.getPayload().toSignedJWT();
+        } catch (java.text.ParseException
+                | NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | JOSEException e) {
+            return SignedJWT.parse(request);
+        }
+    }
+
+    public static JWEObject getJweObject(String requestParam, PrivateKey encryptionPrivateKey)
+            throws java.text.ParseException, NoSuchAlgorithmException, InvalidKeySpecException,
+                    JOSEException {
+        JWEObject encryptedJweObject = JWEObject.parse(requestParam);
+        RSADecrypter rsaDecrypter = new RSADecrypter(encryptionPrivateKey);
+        encryptedJweObject.decrypt(rsaDecrypter);
+        return encryptedJweObject;
+    }
+}

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandlerTest.java
@@ -1,5 +1,10 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
@@ -10,24 +15,38 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import spark.QueryParamsMap;
 import spark.Request;
 import spark.Response;
+import uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig;
+import uk.gov.di.ipv.stub.cred.fixtures.TestFixtures;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.util.UUID;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
 
-import static org.hamcrest.CoreMatchers.startsWithIgnoringCase;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static uk.gov.di.ipv.stub.cred.handlers.AuthorizeHandler.SHARED_CLAIMS;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 public class F2FHandlerTest {
     private static final String JSON_RESPONSE_TYPE = "application/json;charset=UTF-8";
+    private static final String VALID_REDIRECT_URI = "https://valid.example.com";
+    public static final String VALID_RESPONSE_TYPE = "code";
 
     @Mock private Response mockResponse;
     @Mock private Request mockRequest;
@@ -35,14 +54,21 @@ public class F2FHandlerTest {
     private F2FHandler resourceHandler;
     private AccessToken accessToken;
 
+    @SystemStub
+    private final EnvironmentVariables environmentVariables =
+            new EnvironmentVariables("CLIENT_CONFIG", TestFixtures.CLIENT_CONFIG);
+
     @BeforeEach
     void setup() {
+        CredentialIssuerConfig.resetClientConfigs();
         accessToken = new BearerAccessToken();
         resourceHandler = new F2FHandler(mockTokenService);
     }
 
     @Test
     public void shouldReturn200AndUserInfoWhenValidRequestReceived() throws Exception {
+        QueryParamsMap queryParamsMap = toQueryParamsMap(testGetResourceQueryParams());
+        when(mockRequest.queryMap()).thenReturn(queryParamsMap);
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn(UUID.randomUUID().toString());
         when(mockRequest.headers("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
@@ -53,9 +79,7 @@ public class F2FHandlerTest {
 
         UserInfo docAppUserInfo = new UserInfo(jsonResponse);
 
-        assertThat(
-                docAppUserInfo.getSubject().getValue(),
-                startsWithIgnoringCase("urn:fdc:gov.uk:2022:"));
+        assertEquals("subject", docAppUserInfo.getSubject().getValue());
         assertEquals(
                 "pending",
                 docAppUserInfo.getClaim("https://vocab.account.gov.uk/v1/credentialStatus"));
@@ -96,5 +120,70 @@ public class F2FHandlerTest {
 
         assertEquals("Client authentication failed", result);
         verify(mockResponse).status(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    private QueryParamsMap toQueryParamsMap(Map<String, String[]> queryParams) {
+        HttpServletRequest mockHttpRequest = mock(HttpServletRequest.class);
+        when(mockHttpRequest.getParameterMap()).thenReturn(queryParams);
+        return new QueryParamsMap(mockHttpRequest);
+    }
+
+    private Map<String, String[]> testGetResourceQueryParams() throws Exception {
+        Map<String, String[]> queryParams = new HashMap<>();
+        queryParams.put(RequestParamConstants.REQUESTED_OAUTH_ERROR, new String[] {"none"});
+        queryParams.put(RequestParamConstants.CLIENT_ID, new String[] {"clientIdValid"});
+        queryParams.put(
+                RequestParamConstants.REQUEST,
+                new String[] {
+                    signedRequestJwt(validRequestJWT(VALID_RESPONSE_TYPE, VALID_REDIRECT_URI))
+                            .serialize()
+                });
+        return queryParams;
+    }
+
+    private SignedJWT signedRequestJwt(JWTClaimsSet claimsSet) throws Exception {
+        ECDSASigner ecdsaSigner = new ECDSASigner(getPrivateKey());
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);
+        signedJWT.sign(ecdsaSigner);
+
+        return signedJWT;
+    }
+
+    private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        return (ECPrivateKey)
+                KeyFactory.getInstance("EC")
+                        .generatePrivate(
+                                new PKCS8EncodedKeySpec(
+                                        Base64.getDecoder().decode(TestFixtures.EC_PRIVATE_KEY_1)));
+    }
+
+    private JWTClaimsSet validRequestJWT(String responseType, String redirectUri) {
+        Instant instant = Instant.now();
+
+        Map<String, Object> sharedClaims = new LinkedHashMap<>();
+        sharedClaims.put("addresses", Collections.singletonList("123 random street, M13 7GE"));
+        sharedClaims.put(
+                "names",
+                List.of(
+                        Map.of(
+                                "nameParts",
+                                Arrays.asList(
+                                        Map.of("value", "Test"),
+                                        Map.of("value", "Testing"),
+                                        Map.of("value", "Tested")))));
+        sharedClaims.put("birthDate", List.of(Map.of("value", "01/01/1980")));
+
+        return new JWTClaimsSet.Builder()
+                .issuer("issuer")
+                .audience("audience")
+                .subject("subject")
+                .claim("redirect_uri", redirectUri)
+                .claim("response_type", responseType)
+                .claim("state", "test-state")
+                .expirationTime(Date.from(instant.plus(1L, ChronoUnit.HOURS)))
+                .notBeforeTime(Date.from(instant))
+                .issueTime(Date.from(instant))
+                .claim(SHARED_CLAIMS, sharedClaims)
+                .build();
     }
 }


### PR DESCRIPTION
Handle subject value and return as part of userinfo JSON in the f2f handler

## Proposed changes

### What changed

- F2F handler now considers subject value from JWT request
- Moves generic JWT helper code into shared class

### Why did it change

Required in f2f stub response

### Issue tracking

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
