### PR TITLE
PYIC-2802: Return jti claim in VCs set to UUID

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -23,6 +23,7 @@ import java.util.*;
 import static com.nimbusds.jwt.JWTClaimNames.AUDIENCE;
 import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
+import static com.nimbusds.jwt.JWTClaimNames.JWT_ID;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getCriType;
@@ -102,6 +103,7 @@ public class VerifiableCredentialGenerator {
                                 CredentialIssuerConfig.getClientConfig(credential.getClientId())
                                         .getAudienceForVcJwt())
                         .claim(NOT_BEFORE, now.getEpochSecond())
+                        .claim(JWT_ID, UUID.randomUUID().toString())
                         .claim(VC_CLAIM, vc);
         if (!Objects.isNull(credential.getExp())) {
             claim = claim.claim(EXPIRATION_TIME, credential.getExp());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return jti claim in VCs set to UUID (again)

### Why did it change

As per [ADR 77](https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0079-unique-identifier-for-verifiable-credential.md) this adds a jti claim to VCs returned by the CRI stub. The value is a UUID.

This is a second attempt at doing this. Initially I was just setting the value with `UUID.randomUUID()`. The problem with this is the value was a UUID object rather than a string. When serialized to go over the wire it was getting converted to an empty JSON object, rather than a string. This was correctly rejected by core-back.

This correctly sets the value in the VC specifically as a string, allowing it to be serialized correctly.

This was initially missed as the test exercising the generation of the VC wasn't serializing/deserializing the VC. I've added this step, which has required some adjusting of the expected values. Parsing of a JWT will set the audience value as a list, even if there is only one value. Also, the expiration and not before times are in milliseconds, rather than seconds.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-2802](https://govukverify.atlassian.net/browse/PYI-2802)
