### PR TITLE
BAU: Add activityHistoryScore to fraud CRI stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -9,6 +9,22 @@
       }
     },
     {
+      "criType": "Fraud Check (Stub)",
+      "label": "Passed fraud check with activity history (M1B)",
+      "payload": {
+        "type": "IdentityCheck",
+        "identityFraudScore": 2,
+        "activityHistoryScore": 1,
+        "checkDetails": [
+          {
+            "checkMethod": "data",
+            "identityCheckPolicy": "published",
+            "activityFrom": "2019-01-01"
+          }
+        ]
+      }
+    },
+    {
       "criType": "UK Passport (Stub)",
       "label": "Passed passport check (M1A)",
       "payload": {

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -242,17 +242,31 @@
                         {{#isFraudType}}
                             <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">
-                                    <div class="govuk-form-group">
-                                        <h1 class="govuk-label-wrapper">
-                                            <label class="govuk-label govuk-label--l" for="fraud">
-                                                GPG45 Fraud
-                                            </label>
-                                        </h1>
-                                        <label class="govuk-label" for="fraud">
-                                            Fraud
-                                        </label>
-                                        <input class="govuk-input govuk-input--width-2" id="fraud" name="identityFraudScore" type="number" min="0" max="5" step="1">
-                                    </div>
+                                    <fieldset class="govuk-fieldset">
+                                        <div class="govuk-date-input" id="gpg45">
+                                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                                <h1 class="govuk-fieldset__heading">
+                                                    GPG45 Evidence
+                                                </h1>
+                                            </legend>
+                                            <div class="govuk-date-input__item">
+                                                <div class="govuk-form-group">
+                                                    <label class="govuk-label" for="fraud">
+                                                        Fraud
+                                                    </label>
+                                                    <input class="govuk-input govuk-input--width-2" id="fraud" name="identityFraudScore" type="number" min="0" max="5" step="1">
+                                                </div>
+                                            </div>
+                                            <div class="govuk-date-input__item">
+                                                <div class="govuk-form-group">
+                                                    <label class="govuk-label govuk-date-input__label" for="activity">
+                                                        Activity
+                                                    </label>
+                                                    <input class="govuk-input govuk-input--width-2" id="activity" name="activityHistoryScore" type="number" min="0" max="5" step="1">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </fieldset>
                                 </td>
                             </tr>
                         {{/isFraudType}}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add activityHistoryScore to fraud CRI stub

### Why did it change

The actual fraud CRI is going to start returning an activity history score. This change makes it easy to mock this behaviour.
