### PR TITLE
LIME-364 - Added Fraud, Driving Permit, and Passport parameters to template.yaml.

### DIFF
--- a/di-ipv-core-stub/README.MD
+++ b/di-ipv-core-stub/README.MD
@@ -39,7 +39,7 @@ API_KEY_CRI_KBV_STAGING | API key for a CRI environment, set by hand with `cf` c
 API_KEY_CRI_KBV_INTEGRATION | API key for a CRI environment, set by hand with `cf` cli ||
 API_KEY_CRI_FRAUD_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
 API_KEY_CRI_DL_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
-API_KEY_CRI_PASSPORT_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_PASSPORTA_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
 
 ## Running locally
 

--- a/di-ipv-core-stub/README.MD
+++ b/di-ipv-core-stub/README.MD
@@ -38,6 +38,8 @@ API_KEY_CRI_KBV_BUILD | API key for a CRI environment, set by hand with `cf` cli
 API_KEY_CRI_KBV_STAGING | API key for a CRI environment, set by hand with `cf` cli ||
 API_KEY_CRI_KBV_INTEGRATION | API key for a CRI environment, set by hand with `cf` cli ||
 API_KEY_CRI_FRAUD_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_DL_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
+API_KEY_CRI_PASSPORT_BUILD | API key for a CRI environment, set by hand with `cf` cli ||
 
 ## Running locally
 

--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -47,6 +47,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/API_KEY_CRI_KBV_BUILD" #pragma: allowlist secret
+  ApiKeyCriFraudBuild:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_FRAUD_BUILD" #pragma: allowlist secret
+  ApiKeyCriDrivingPermitBuild:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_DL_BUILD" #pragma: allowlist secret
+  ApiKeyCriPassportBuild:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORT_BUILD" #pragma: allowlist secret
   ApiKeyCriAddressStaging:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -55,6 +67,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/API_KEY_CRI_KBV_STAGING" #pragma: allowlist secret
+  ApiKeyCriFraudStaging:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_FRAUD_STAGING" #pragma: allowlist secret
+  ApiKeyCriDrivingPermitStaging:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_DL_STAGING" #pragma: allowlist secret
+  ApiKeyCriPassportStaging:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORT_STAGING" #pragma: allowlist secret
   ApiKeyCriAddressIntegration:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -63,6 +87,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/API_KEY_CRI_KBV_INTEGRATION" #pragma: allowlist secret
+  ApiKeyCriFraudIntegration:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_FRAUD_INTEGRATION" #pragma: allowlist secret
+  ApiKeyCriDrivingPermitIntegration:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_DL_INTEGRATION" #pragma: allowlist secret
+  ApiKeyCriPassportIntegration:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORT_INTEGRATION" #pragma: allowlist secret
   JavaOpts:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -580,14 +616,32 @@ Resources:
             Value: !Ref ApiKeyCriAddressBuild
           - Name: API_KEY_CRI_KBV_BUILD
             Value: !Ref ApiKeyCriKbvBuild
+          - Name: API_KEY_CRI_FRAUD_BUILD
+            Value: !Ref ApiKeyCriFraudBuild
+          - Name: API_KEY_CRI_DL_BUILD
+            Value: !Ref ApiKeyCriDrivingPermitBuild
+          - Name: API_KEY_CRI_PASSPORT_BUILD
+            Value: !Ref ApiKeyCriPassportBuild
           - Name: API_KEY_CRI_ADDRESS_STAGING
             Value: !Ref ApiKeyCriAddressStaging
           - Name: API_KEY_CRI_KBV_STAGING
             Value: !Ref ApiKeyCriKbvStaging
+          - Name: API_KEY_CRI_FRAUD_STAGING
+            Value: !Ref ApiKeyCriFraudStaging
+          - Name: API_KEY_CRI_DL_STAGING
+            Value: !Ref ApiKeyCriDrivingPermitStaging
+          - Name: API_KEY_CRI_PASSPORT_STAGING
+            Value: !Ref ApiKeyCriPassportStaging
           - Name: API_KEY_CRI_ADDRESS_INTEGRATION
             Value: !Ref ApiKeyCriAddressIntegration
           - Name: API_KEY_CRI_KBV_INTEGRATION
             Value: !Ref ApiKeyCriKbvIntegration
+          - Name: API_KEY_CRI_FRAUD_INTEGRATION
+            Value: !Ref ApiKeyCriFraudIntegration
+          - Name: API_KEY_CRI_DL_INTEGRATION
+            Value: !Ref ApiKeyCriDrivingPermitIntegration
+          - Name: API_KEY_CRI_PASSPORT_INTEGRATION
+            Value: !Ref ApiKeyCriPassportIntegration
           - Name: ENABLE_BASIC_AUTH
             Value: !Ref EnableBasicAuth
           Secrets:

--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -58,7 +58,7 @@ Parameters:
   ApiKeyCriPassportBuild:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORT_BUILD" #pragma: allowlist secret
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORTA_BUILD" #pragma: allowlist secret
   ApiKeyCriAddressStaging:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -78,7 +78,7 @@ Parameters:
   ApiKeyCriPassportStaging:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORT_STAGING" #pragma: allowlist secret
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORTA_STAGING" #pragma: allowlist secret
   ApiKeyCriAddressIntegration:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -98,7 +98,7 @@ Parameters:
   ApiKeyCriPassportIntegration:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORT_INTEGRATION" #pragma: allowlist secret
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORTA_INTEGRATION" #pragma: allowlist secret
   JavaOpts:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -620,7 +620,7 @@ Resources:
             Value: !Ref ApiKeyCriFraudBuild
           - Name: API_KEY_CRI_DL_BUILD
             Value: !Ref ApiKeyCriDrivingPermitBuild
-          - Name: API_KEY_CRI_PASSPORT_BUILD
+          - Name: API_KEY_CRI_PASSPORTA_BUILD
             Value: !Ref ApiKeyCriPassportBuild
           - Name: API_KEY_CRI_ADDRESS_STAGING
             Value: !Ref ApiKeyCriAddressStaging
@@ -630,7 +630,7 @@ Resources:
             Value: !Ref ApiKeyCriFraudStaging
           - Name: API_KEY_CRI_DL_STAGING
             Value: !Ref ApiKeyCriDrivingPermitStaging
-          - Name: API_KEY_CRI_PASSPORT_STAGING
+          - Name: API_KEY_CRI_PASSPORTA_STAGING
             Value: !Ref ApiKeyCriPassportStaging
           - Name: API_KEY_CRI_ADDRESS_INTEGRATION
             Value: !Ref ApiKeyCriAddressIntegration
@@ -640,7 +640,7 @@ Resources:
             Value: !Ref ApiKeyCriFraudIntegration
           - Name: API_KEY_CRI_DL_INTEGRATION
             Value: !Ref ApiKeyCriDrivingPermitIntegration
-          - Name: API_KEY_CRI_PASSPORT_INTEGRATION
+          - Name: API_KEY_CRI_PASSPORTA_INTEGRATION
             Value: !Ref ApiKeyCriPassportIntegration
           - Name: ENABLE_BASIC_AUTH
             Value: !Ref EnableBasicAuth


### PR DESCRIPTION
## Proposed changes

### What changed

- Build
  - added Fraud to API and environment parameters
  - added Driving Permit to API and environment parameters
  - added Passport to API and environment parameters
- Staging
  - added Fraud to API and environment parameters
  - added Driving Permit to API and environment parameters
  - added Passport to API and environment parameters
- Integration
  - added Fraud to API and environment parameters
  - added Driving Permit to API and environment parameters
  - added Passport to API and environment parameters

### Issue tracking

- [LIME-364](https://govukverify.atlassian.net/browse/LIME-364)


[LIME-364]: https://govukverify.atlassian.net/browse/LIME-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ