### PR TITLE
PYIC-2950 Update F2F stub to call queue lambda

### DIFF
--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -56,6 +56,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/f2f/env/VC_TTL_SECONDS" #pragma: allowlist secret
+  F2fStubQueueUrl:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/f2f/env/F2F_STUB_QUEUE_URL" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -503,6 +507,10 @@ Resources:
             Value: !Ref VcIssuer
           - Name: VC_TTL_SECONDS
             Value: !Ref VcTtlSeconds
+          - Name: F2F_STUB_QUEUE_URL
+            Value: !Ref F2fStubQueueUrl
+          - Name: F2F_STUB_QUEUE_NAME
+            Value: !Sub stubQueue_F2FQueue_${Environment}
           Secrets:
             - Name: "VC_SIGNING_KEY"
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/f2f/env/VC_SIGNING_KEY"

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -47,7 +47,8 @@ public class CredentialIssuer {
                         new ViewHelper(),
                         authCodeService,
                         credentialService,
-                        requestedErrorResponseService);
+                        requestedErrorResponseService,
+                        vcGenerator);
         tokenHandler =
                 new TokenHandler(
                         authCodeService,

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -71,7 +71,7 @@ public class CredentialIssuer {
         Spark.post("/token", tokenHandler.issueAccessToken);
         if (getCriType().equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
             Spark.post("/credentials/issue", docAppCredentialHandler.getResource);
-        } else if (getCriType().equals(CriType.FACE_TO_FACE_CRI_TYPE)) {
+        } else if (getCriType().equals(CriType.F2F_CRI_TYPE)) {
             Spark.post("/credentials/issue", f2fHandler.getResource);
         } else {
             Spark.post("/credentials/issue", credentialHandler.getResource);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -23,6 +23,8 @@ public class CredentialIssuerConfig {
     public static String CLIENT_AUDIENCE = getConfigValue("CLIENT_AUDIENCE", null);
     public static final String DEV_DOMAIN =
             getConfigValue("DEV_DOMAIN", ".dev.identity.account.gov.uk");
+    public static final String F2F_STUB_QUEUE_URL = getConfigValue("F2F_STUB_QUEUE_URL", null);
+    public static final String F2F_STUB_QUEUE_NAME = getConfigValue("F2F_STUB_QUEUE_NAME", null);
 
     public static final String EVIDENCE_TYPE_PARAM = "type";
     public static final String EVIDENCE_TYPE_IDENTITY_CHECK = "IdentityCheck";

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
@@ -8,7 +8,7 @@ public enum CriType {
     VERIFICATION_CRI_TYPE("VERIFICATION"),
     USER_ASSERTED_CRI_TYPE("USER_ASSERTED"),
     DOC_CHECK_APP_CRI_TYPE("DOC_CHECK_APP"),
-    FACE_TO_FACE_CRI_TYPE("F2F");
+    F2F_CRI_TYPE("F2F");
 
     public final String value;
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FEnqueueLambdaRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FEnqueueLambdaRequest.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.stub.cred.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class F2FEnqueueLambdaRequest {
+    private String queueName;
+    private F2FQueueEvent queueEvent;
+}
+
+

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FEnqueueLambdaRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FEnqueueLambdaRequest.java
@@ -11,5 +11,3 @@ public class F2FEnqueueLambdaRequest {
     private String queueName;
     private F2FQueueEvent queueEvent;
 }
-
-

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FQueueEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FQueueEvent.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 public class F2FQueueEvent {
     private String sub;
     private String state;
+
     @JsonProperty("https://vocab.account.gov.uk/v1/credentialJWT")
     private String vcJwt;
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FQueueEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FQueueEvent.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -13,5 +15,5 @@ public class F2FQueueEvent {
     private String state;
 
     @JsonProperty("https://vocab.account.gov.uk/v1/credentialJWT")
-    private String vcJwt;
+    private List<String> vcJwt;
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FQueueEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FQueueEvent.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.stub.cred.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class F2FQueueEvent {
+    private String sub;
+    private String state;
+    @JsonProperty("https://vocab.account.gov.uk/v1/credentialJWT")
+    private String vcJwt;
+}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -63,6 +63,8 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static com.nimbusds.jose.shaded.json.parser.JSONParser.MODE_JSON_SIMPLE;
+import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.F2F_STUB_QUEUE_NAME;
+import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.F2F_STUB_QUEUE_URL;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getCriType;
 import static uk.gov.di.ipv.stub.cred.config.CriType.USER_ASSERTED_CRI_TYPE;
 
@@ -340,15 +342,16 @@ public class AuthorizeHandler {
                                 verifiableCredentialGenerator.generate(credential).serialize();
                         HTTPRequest httpRequest =
                                 new HTTPRequest(
-                                        HTTPRequest.Method.POST, URI.create("<lambda-endpoint>"));
+                                        HTTPRequest.Method.POST, URI.create(F2F_STUB_QUEUE_URL));
                         ObjectMapper objectMapper = new ObjectMapper();
                         F2FEnqueueLambdaRequest enqueueLambdaRequest =
                                 new F2FEnqueueLambdaRequest(
-                                        "stubQueue_F2FQueueBuild",
-                                        new F2FQueueEvent(userId, state, signedVcJwt));
+                                        F2F_STUB_QUEUE_NAME,
+                                        new F2FQueueEvent(userId, state, List.of(signedVcJwt)));
                         String body = objectMapper.writeValueAsString(enqueueLambdaRequest);
                         httpRequest.setQuery(body);
                         HTTPResponse httpResponse = httpRequest.send();
+                        System.out.println("F2F send VC to queue response");
                         System.out.println(httpResponse.getContentAsJSONObject().toString());
                     }
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -347,9 +347,6 @@ public class AuthorizeHandler {
                                         "stubQueue_F2FQueueBuild",
                                         new F2FQueueEvent(userId, state, signedVcJwt));
                         String body = objectMapper.writeValueAsString(enqueueLambdaRequest);
-                        //
-                        // httpRequest.setQuery("{\"queueName\":\"stubQueue_\",\"sub\":\"" + userId
-                        // + "\",state\":\"" + state + "}");
                         httpRequest.setQuery(body);
                         HTTPResponse httpResponse = httpRequest.send();
                         System.out.println(httpResponse.getContentAsJSONObject().toString());

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -190,8 +190,7 @@ public class AuthorizeHandler {
                         IS_VERIFICATION_TYPE_PARAM, criType.equals(CriType.VERIFICATION_CRI_TYPE));
                 frontendParams.put(
                         IS_DOC_CHECKING_TYPE_PARAM, criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE));
-                frontendParams.put(
-                        IS_F2F_TYPE, criType.equals(CriType.F2F_CRI_TYPE));
+                frontendParams.put(IS_F2F_TYPE, criType.equals(CriType.F2F_CRI_TYPE));
                 frontendParams.put(IS_USER_ASSERTED_TYPE, criType.equals(USER_ASSERTED_CRI_TYPE));
                 if (!criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
                     frontendParams.put(SHARED_CLAIMS, getSharedAttributes(queryParamsMap));
@@ -241,10 +240,11 @@ public class AuthorizeHandler {
                                 .getClaim(RequestParamConstants.REDIRECT_URI)
                                 .toString();
                 String userId = signedJWT.getJWTClaimsSet().getSubject();
-                String state = signedJWT
-                        .getJWTClaimsSet()
-                        .getClaim(RequestParamConstants.STATE)
-                        .toString();
+                String state =
+                        signedJWT
+                                .getJWTClaimsSet()
+                                .getClaim(RequestParamConstants.STATE)
+                                .toString();
 
                 try {
                     Map<String, Object> attributesMap =
@@ -331,23 +331,32 @@ public class AuthorizeHandler {
                             new Credential(
                                     credentialAttributesMap, gpgMap, userId, clientIdValue, exp);
 
-                    boolean F2F_SEND_VC_QUEUE = Objects.equals(queryParamsMap.value(RequestParamConstants.F2F_SEND_VC_QUEUE), "checked");
+                    boolean F2F_SEND_VC_QUEUE =
+                            Objects.equals(
+                                    queryParamsMap.value(RequestParamConstants.F2F_SEND_VC_QUEUE),
+                                    "checked");
                     if (F2F_SEND_VC_QUEUE) {
                         String signedVcJwt =
                                 verifiableCredentialGenerator.generate(credential).serialize();
-                        HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.POST, URI.create("<lambda-endpoint>"));
+                        HTTPRequest httpRequest =
+                                new HTTPRequest(
+                                        HTTPRequest.Method.POST, URI.create("<lambda-endpoint>"));
                         ObjectMapper objectMapper = new ObjectMapper();
-                        F2FEnqueueLambdaRequest enqueueLambdaRequest = new F2FEnqueueLambdaRequest(
-                                "stubQueue_F2FQueueBuild",
-                                new F2FQueueEvent(userId, state, signedVcJwt));
+                        F2FEnqueueLambdaRequest enqueueLambdaRequest =
+                                new F2FEnqueueLambdaRequest(
+                                        "stubQueue_F2FQueueBuild",
+                                        new F2FQueueEvent(userId, state, signedVcJwt));
                         String body = objectMapper.writeValueAsString(enqueueLambdaRequest);
-//                        httpRequest.setQuery("{\"queueName\":\"stubQueue_\",\"sub\":\"" + userId + "\",state\":\"" + state + "}");
+                        //
+                        // httpRequest.setQuery("{\"queueName\":\"stubQueue_\",\"sub\":\"" + userId
+                        // + "\",state\":\"" + state + "}");
                         httpRequest.setQuery(body);
                         HTTPResponse httpResponse = httpRequest.send();
                         System.out.println(httpResponse.getContentAsJSONObject().toString());
                     }
 
-                    AuthorizationSuccessResponse successResponse = generateAuthCode(state, redirectUri);
+                    AuthorizationSuccessResponse successResponse =
+                            generateAuthCode(state, redirectUri);
                     persistData(
                             queryParamsMap,
                             successResponse.getAuthorizationCode(),

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -74,6 +74,7 @@ public class AuthorizeHandler {
 
     public static final String CRI_STUB_DATA = "cri_stub_data";
     public static final String CRI_STUB_EVIDENCE_PAYLOADS = "cri_stub_evidence_payloads";
+    public static final String F2F_STUB_QUEUE_NAME_FIELD = "f2f_stub_queue_name";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizeHandler.class);
 
@@ -199,6 +200,7 @@ public class AuthorizeHandler {
                 }
                 frontendParams.put(CRI_STUB_DATA, criStubData);
                 frontendParams.put(CRI_STUB_EVIDENCE_PAYLOADS, criStubEvidencePayloads);
+                frontendParams.put(F2F_STUB_QUEUE_NAME_FIELD, F2F_STUB_QUEUE_NAME);
 
                 String error = request.attribute(ERROR_PARAM);
                 boolean hasError = error != null;
@@ -338,6 +340,7 @@ public class AuthorizeHandler {
                                     queryParamsMap.value(RequestParamConstants.F2F_SEND_VC_QUEUE),
                                     "checked");
                     if (F2F_SEND_VC_QUEUE) {
+                        String queueName = queryParamsMap.value(F2F_STUB_QUEUE_NAME_FIELD);
                         String signedVcJwt =
                                 verifiableCredentialGenerator.generate(credential).serialize();
                         HTTPRequest httpRequest =
@@ -346,7 +349,7 @@ public class AuthorizeHandler {
                         ObjectMapper objectMapper = new ObjectMapper();
                         F2FEnqueueLambdaRequest enqueueLambdaRequest =
                                 new F2FEnqueueLambdaRequest(
-                                        F2F_STUB_QUEUE_NAME,
+                                        queueName,
                                         new F2FQueueEvent(userId, state, List.of(signedVcJwt)));
                         String body = objectMapper.writeValueAsString(enqueueLambdaRequest);
                         httpRequest.setQuery(body);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -21,4 +21,5 @@ public class RequestParamConstants {
     public static final String REQUESTED_OAUTH_ERROR_ENDPOINT = "requested_oauth_error_endpoint";
     public static final String REQUESTED_OAUTH_ERROR_DESCRIPTION =
             "requested_oauth_error_description";
+    public static final String F2F_SEND_VC_QUEUE = "f2f_send_vc_queue";
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -959,6 +959,37 @@
           }
         ]
       }
+    },
+    {
+      "criType": "Face to Face Check (Stub)",
+      "label": "Kenneth Decerqueira (Valid Passport)",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "type": "GivenName",
+                "value": "Kenneth"
+              },
+              {
+                "type": "FamilyName",
+                "value": "Decerqueira"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1965-07-08"
+          }
+        ],
+        "passport": [
+          {
+            "expiryDate": "2030-01-01",
+            "documentNumber": "321654987"
+          }
+        ]
+      }
     }
   ]
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -201,6 +201,26 @@
           }
         ]
       }
+    },
+    {
+      "criType": "Face to Face Check (Stub)",
+      "label": "Passed f2f check",
+      "payload": {
+        "type": "IdentityCheck",
+        "strengthScore": 4,
+        "validityScore": 2,
+        "verificationScore": 3,
+        "checkDetails": [
+          {
+            "checkMethod": "vcrypt",
+            "identityCheckPolicy": "published"
+          },
+          {
+            "checkMethod": "bvr",
+            "biometricVerificationProcessLevel": 3
+          }
+        ]
+      }
     }
   ]
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -95,6 +95,20 @@
                                 </td>
                             </tr>
                         {{/shared_claims}}
+                        {{#isF2FType}}
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                        <div class="govuk-checkboxes__item">
+                                            <input class="govuk-checkboxes__input" type="checkbox" name="f2f_send_vc_queue" id="f2f_send_vc_queue" value="checked">
+                                            <label class="govuk-label govuk-checkboxes__label" for="f2f_send_vc_queue">
+                                                Send VC to async queue
+                                            </label>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        {{/isF2FType}}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">
                                 {{#hasError}}

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -105,6 +105,12 @@
                                                 Send VC to async queue
                                             </label>
                                         </div>
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="f2f_stub_queue_name">
+                                                Queue name:
+                                            </label>
+                                            <input type="text" class="govuk-textarea" id="f2f_stub_queue_name" name="f2f_stub_queue_name" value="{{f2f_stub_queue_name}}">
+                                        </div>
                                     </div>
                                 </td>
                             </tr>

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -32,6 +32,7 @@ import uk.gov.di.ipv.stub.cred.service.AuthCodeService;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.utils.ViewHelper;
+import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -88,6 +89,7 @@ class AuthorizeHandlerTest {
     private AuthorizeHandler authorizeHandler;
     private AuthCodeService mockAuthCodeService;
     private CredentialService mockCredentialService;
+    private VerifiableCredentialGenerator mockVcGenerator;
     private RequestedErrorResponseService requestedErrorResponseService =
             new RequestedErrorResponseService();
 
@@ -108,13 +110,15 @@ class AuthorizeHandlerTest {
         mockViewHelper = mock(ViewHelper.class);
         mockAuthCodeService = mock(AuthCodeService.class);
         mockCredentialService = mock(CredentialService.class);
+        mockVcGenerator = mock(VerifiableCredentialGenerator.class);
 
         authorizeHandler =
                 new AuthorizeHandler(
                         mockViewHelper,
                         mockAuthCodeService,
                         mockCredentialService,
-                        requestedErrorResponseService);
+                        requestedErrorResponseService,
+                        mockVcGenerator);
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added checkbox for F2F stub to allow pushing the VC onto the stub queue for it to be consumed by process-async-cri-credential. (Success response only for now)

<img width="1073" alt="Screenshot 2023-06-19 at 15 08 46" src="https://github.com/alphagov/di-ipv-stubs/assets/32681701/6f7e823d-941d-4299-8da8-1c9b32fe5b87">

### Why did it change

So we can easily test the end to end F2F journey and in particular for the automated tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2950](https://govukverify.atlassian.net/browse/PYIC-2950)


[PYIC-2950]: https://govukverify.atlassian.net/browse/PYIC-2950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ