### PR TITLE
BAU: Fix validation for fraud with activity

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -85,11 +85,7 @@ public class Validator {
                     Integer.parseInt(fraudValue);
 
                     return areStringsNullOrEmpty(
-                            Arrays.asList(
-                                    strengthValue,
-                                    validityValue,
-                                    activityValue,
-                                    verificationValue));
+                            Arrays.asList(strengthValue, validityValue, verificationValue));
                 } catch (NumberFormatException e) {
                     return new ValidationResult(
                             false,

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
@@ -112,6 +112,13 @@ class ValidatorTest {
     }
 
     @Test
+    void shouldReturnSuccessfulValidationOnValidFraudWithActivityGpg() {
+        ValidationResult result =
+                Validator.verifyGpg45(CriType.FRAUD_CRI_TYPE, null, null, "1", "1", null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
     void shouldReturnFailedValidationIfInvalidNumberParamProvidedInFraud() {
         ValidationResult result =
                 Validator.verifyGpg45(CriType.FRAUD_CRI_TYPE, null, null, null, "abc", null);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix validation for fraud with activity

### Why did it change
The fraud CRI now allows submission of an activity score. The validation on the scores provided needs updating to allow a value here, otherwise the CRI will return an OAuth error to core.
