### PR TITLE
BAU Correct value for F2F_STUB_QUEUE_NAME var

### DIFF
--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -510,7 +510,7 @@ Resources:
           - Name: F2F_STUB_QUEUE_URL
             Value: !Ref F2fStubQueueUrl
           - Name: F2F_STUB_QUEUE_NAME
-            Value: !Sub stubQueue_F2FQueue_${Environment}
+            Value: !If [IsCoreDev, !Sub "stubQueue_F2FQueue_${Environment}", "stubQueue_F2FQueue_build"]
           Secrets:
             - Name: "VC_SIGNING_KEY"
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/f2f/env/VC_SIGNING_KEY"


### PR DESCRIPTION
## Proposed changes

### What changed

Correct value for F2F_STUB_QUEUE_NAME var so it points to the build queue by default

### Why did it change

We want to point to stubs build queue for non-dev environments (not stubs production)
