### PR TITLE
Setting 30 seconds delay to prevent race condition

### DIFF
--- a/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
@@ -143,7 +143,8 @@ export const handler: Handler = async (
 
     let sendSqsMessageInput:SendMessageCommandInput = {
         QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(queueBody)
+        MessageBody: JSON.stringify(queueBody),
+        DelaySeconds: 30
     }
 
     let sendSqsMessageCommand = new SendMessageCommand(sendSqsMessageInput);


### PR DESCRIPTION
in automated testing.

Set each message to have a wait time - maybe better to have this as a parameter in the request?