### PR TITLE
BAU Fix queue stub build - only needs npm install

### DIFF
--- a/.github/workflows/deploy-queue-stub-build.yml
+++ b/.github/workflows/deploy-queue-stub-build.yml
@@ -57,12 +57,6 @@ jobs:
           template: ./di-ipv-queue-stub/deploy-build/template.yaml
           profile: ${{ secrets.SIGNING_PROFILE_NAME }}
 
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: npm
-
       - name: npm install
         working-directory: ./di-ipv-queue-stub/enqueue-event
         run: npm ci

--- a/.github/workflows/deploy-queue-stub-staging.yml
+++ b/.github/workflows/deploy-queue-stub-staging.yml
@@ -57,12 +57,6 @@ jobs:
           template: ./di-ipv-queue-stub/deploy-staging/template.yaml
           profile: ${{ secrets.SIGNING_PROFILE_NAME }}
 
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: npm
-
       - name: npm install
         working-directory: ./di-ipv-queue-stub/enqueue-event
         run: npm ci


### PR DESCRIPTION
The setup-node action tries to cache the dependencies but can't find them - Node should already come bundled in the environment so we just need an install (hopefully)