### PR TITLE
added permissions for higher environments to unblock pipeline

### DIFF
--- a/di-ipv-queue-stub/deploy-build/template.yaml
+++ b/di-ipv-queue-stub/deploy-build/template.yaml
@@ -249,6 +249,9 @@ Resources:
                 - "arn:aws:iam::457601271792:root" # Build account id
                 - "arn:aws:iam::130355686670:root" # OldDev account id
                 - "arn:aws:iam::175872367215:root" # Dev account id
+                - "arn:aws:iam::335257547869:root" # Staging account id
+                - "arn:aws:iam::991138514218:root" # Integration account id
+                - "arn:aws:iam::075701497069:root" # Prod account id
             Action:
               - "kms:Decrypt"
             Resource: "*"
@@ -275,6 +278,9 @@ Resources:
                 - "arn:aws:iam::457601271792:root" # Build account id
                 - "arn:aws:iam::130355686670:root" # OldDev account id
                 - "arn:aws:iam::175872367215:root" # Dev account id
+                - "arn:aws:iam::335257547869:root" # Staging account id
+                - "arn:aws:iam::991138514218:root" # Integration account id
+                - "arn:aws:iam::075701497069:root" # Prod account id
             Action:
               - "kms:Verify"
             Resource: "*"
@@ -352,6 +358,9 @@ Resources:
                 - "arn:aws:iam::457601271792:root" # Build account id
                 - "arn:aws:iam::130355686670:root" # OldDev account id
                 - "arn:aws:iam::175872367215:root" # Dev account id
+                - "arn:aws:iam::335257547869:root" # Staging account id
+                - "arn:aws:iam::991138514218:root" # Integration account id
+                - "arn:aws:iam::075701497069:root" # Prod account id
          #- Sid: "AllowKeyAccess"
          #  Effect: Allow
          #  Action:

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
@@ -60,11 +60,14 @@ export const handler: Handler = async (
             queueUrl = createQueueCommandOutput.QueueUrl;
             let addQueuePermissionCommandInput: AddPermissionCommandInput = {
                 QueueUrl: queueUrl,
-                Label: "add read and delete from dev and build perms",
+                Label: "add read and delete from dev, build, staging, prod perms",
                 AWSAccountIds: [
                     "457601271792",
                     "130355686670",
-                    "175872367215"
+                    "175872367215",
+                    "335257547869",
+                    "991138514218",
+                    "075701497069"
                 ],
                 Actions: [
                     "ReceiveMessage",


### PR DESCRIPTION
F2F team turned off their SQS policies which broke the core-back pipeline, this fixes as we have pointed core-back to one we control, this PR is to give core-back accounts permissions to read/delete from the SQS in stubs-build