### PR TITLE
OJ-1702: add deployment for toy stub

### DIFF
--- a/.github/workflows/cri-toy-stub.yml
+++ b/.github/workflows/cri-toy-stub.yml
@@ -1,0 +1,106 @@
+name: Toy CRI Stub - Secure Pipeline build, push & Ship
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - di-ipv-credential-issuer-stub/deploy/toy/*
+      - di-ipv-credential-issuer-stub/gradle/**
+      - di-ipv-credential-issuer-stub/src/**
+      - di-ipv-credential-issuer-stub/*
+      - .github/workflows/cri-toy-stub.yml
+  workflow_dispatch:
+
+jobs:
+  dockerBuildAndPush:
+    name: Docker build and push
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-west-2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Checkout config repo
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/di-ipv-config
+          token: ${{ secrets.IPV_CONFIG_PAT }}
+          path: ./di-ipv-config
+          fetch-depth: '0'
+          ref: 'refs/heads/main'
+
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.CRI_TOY_GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Create tag
+        id: create-tag
+        run: |
+          IMAGE_TAG="${{ github.sha }}-$(date +'%Y-%m-%d-%H%M%S')"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Copy Core Config into place
+        id: copy-config-to-stub
+        run: cp -rpfv ./di-ipv-config/stubs/di-ipv-credential-issuer-stub ./di-ipv-credential-issuer-stub/config
+
+      - name: Build, tag, sign and push image to Amazon ECR
+        working-directory: ./di-ipv-credential-issuer-stub
+        env:
+          CONTAINER_SIGN_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.CRI_TOY_ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@v2
+
+      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
+        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
+
+      - name: SAM Validate
+        working-directory: ./di-ipv-credential-issuer-stub/deploy/toy
+        run: sam validate --region ${{ env.AWS_REGION }}
+
+      - name: SAM Package
+        working-directory: ./di-ipv-credential-issuer-stub/deploy/toy
+        env:
+          ARTIFACT_BUCKET: ${{ secrets.CRI_TOY_ARTIFACT_BUCKET_NAME }}
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
+
+      - name: Update SAM template with ECR image
+        working-directory: ./di-ipv-credential-issuer-stub/deploy/toy
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.CRI_TOY_ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" cf-template.yaml
+
+      - name: Compress Template
+        working-directory: ./di-ipv-credential-issuer-stub/deploy/toy
+        run: zip template.zip cf-template.yaml
+
+      - name: Upload Compressed CloudFormation artifacts to S3
+        working-directory: ./di-ipv-credential-issuer-stub/deploy/toy
+        env:
+          ARTIFACT_BUCKET: ${{ secrets.CRI_TOY_ARTIFACT_BUCKET_NAME }}
+        run: aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"

--- a/di-ipv-credential-issuer-stub/deploy/toy/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/toy/template.yaml
@@ -1,0 +1,653 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  This creates the necessary components to deploy IPV Toy Credential Issuer
+  Stub onto ECS Fargate within the dev platform VPC and private subnets
+  (provided as parameters).
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to.
+    Type: String
+    AllowedPattern: ((production)|(build)|(dev.*))
+  VpcStackName:
+    Description: >
+      The name of the stack that defines the VPC in which this container will
+      run.
+    Type: String
+  PermissionsBoundary:
+    Description: "The ARN of the permissions boundary to apply when creating IAM roles"
+    Type: String
+    Default: "none"
+
+  JbpConfigOpenJdkJre:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+  JavaOpts:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/JAVA_OPTS" #pragma: allowlist secret
+  CredentialIssuerPort:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/CREDENTIAL_ISSUER_PORT" #pragma: allowlist secret
+  CredentialIssuerName:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/CREDENTIAL_ISSUER_NAME" #pragma: allowlist secret
+  CredentialIssuerType:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
+  ClientConfigFile:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
+  ClientAudience:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/CLIENT_AUDIENCE" #pragma: allowlist secret
+  VcIssuer:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/VC_ISSUER" #pragma: allowlist secret
+  VcTtlSeconds:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/credential-issuer/toy/env/VC_TTL_SECONDS" #pragma: allowlist secret
+
+Conditions:
+  IsDevelopment: !Not
+    - !Or
+      - !Equals [ !Ref Environment, "build"]
+      - !Equals [ !Ref Environment, "production"]
+  IsCoreDev: !Or
+    - !Equals [ !Ref AWS::AccountId, "130355686670"]
+    - !Equals [ !Ref AWS::AccountId, "175872367215"]
+  IsNotDevelopment: !Not [ !Condition IsDevelopment ]
+  IsProduction: !Equals [ !Ref Environment, "production" ]
+  IsNonProd: !Not
+    - !Or
+      - !Condition IsDevelopment
+      - !Condition IsProduction
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+
+# Mapping using aws account id - keeps things simple
+# if this is built out differently.
+Mappings:
+  EnvironmentConfiguration:
+    "130355686670": # Old Core Development
+      fargateCPUsize: "256"
+      fargateRAMsize: "512"
+      desiredTaskCount: 1
+      environment: dev
+      platform: core
+    "175872367215": # New Core Development
+      fargateCPUsize: "256"
+      fargateRAMsize: "512"
+      desiredTaskCount: 1
+      environment: dev
+      platform: core
+    "826978934233": #Core Stubs Build
+      fargateCPUsize: "256"
+      fargateRAMsize: "512"
+      desiredTaskCount: 1
+      environment: build
+      platform: core-stubs
+    "616199614141": #Stubs Build
+      fargateCPUsize: "256"
+      fargateRAMsize: "512"
+      desiredTaskCount: 1
+      environment: build
+      platform: stubs
+    "388905755587": #Stubs Prod
+      fargateCPUsize: "4096"
+      fargateRAMsize: "8192"
+      desiredTaskCount: 1
+      environment: production
+      platform: stubs
+  SecurityGroups:
+    PrefixListIds:
+      dynamodb: "pl-b3a742da"
+      s3: "pl-7ca54015"
+
+Resources:
+  # ssl cert
+  CriStubSSLCert:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !If
+        - IsCoreDev
+        - !Sub "toy-${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "toy-cri.${Environment}.stubs.account.gov.uk", toy-cri.stubs.account.gov.uk]
+      DomainValidationOptions:
+        - DomainName: !If
+            - IsCoreDev
+            - !Sub "toy-${Environment}.core.dev.stubs.account.gov.uk"
+            - !If [IsNonProd, !Sub "toy-cri.${Environment}.stubs.account.gov.uk", toy-cri.stubs.account.gov.uk]
+          HostedZoneId: !If
+            - IsCoreDev
+            - !ImportValue DevPublicHostedZoneId
+            - !If [IsNonProd, !ImportValue BuildPublicHostedZoneId, !ImportValue RootPublicHostedZoneId]
+      ValidationMethod: DNS
+
+  # api domain entries / mapping
+  CriStubApiDomain:
+    Type: AWS::ApiGatewayV2::DomainName
+    Properties:
+      DomainName: !If
+        - IsCoreDev
+        - !Sub "toy-${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "toy-cri.${Environment}.stubs.account.gov.uk", toy-cri.stubs.account.gov.uk]
+      DomainNameConfigurations:
+        - CertificateArn: !Ref CriStubSSLCert
+          EndpointType: REGIONAL
+          SecurityPolicy: TLS_1_2
+
+  CriStubApiMapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
+    Properties:
+      DomainName: !If
+        - IsCoreDev
+        - !Sub "toy-${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "toy-cri.${Environment}.stubs.account.gov.uk", toy-cri.stubs.account.gov.uk]
+      ApiId: !Ref ApiGwHttpEndpoint
+      Stage: "$default"
+    DependsOn:
+      - CriStubApiDomain
+      - APIStageDefault
+
+  # dns rcord
+  CriStubDNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Type: A
+      Name: !If
+        - IsCoreDev
+        - !Sub "toy-${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "toy-cri.${Environment}.stubs.account.gov.uk", toy-cri.stubs.account.gov.uk]
+      HostedZoneId: !If
+        - IsCoreDev
+        - !ImportValue DevPublicHostedZoneId
+        - !If [IsNonProd, !ImportValue BuildPublicHostedZoneId, !ImportValue RootPublicHostedZoneId]
+      AliasTarget:
+        DNSName: !GetAtt CriStubApiDomain.RegionalDomainName
+        HostedZoneId: !GetAtt CriStubApiDomain.RegionalHostedZoneId
+
+  # Security Groups for the ECS service and load balancer
+  LoadBalancerSG:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: >-
+        Cri Stub LoadBalancer Security Group
+      SecurityGroupIngress:
+        - CidrIp:
+            Fn::ImportValue: !Sub ${VpcStackName}-VpcCidr
+          Description: Allow vpc cidr ingress to port 80
+          FromPort: 80
+          IpProtocol: tcp
+          ToPort: 80
+      VpcId:
+        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+
+  LoadBalancerSGEgressToECSSecurityGroup:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    Properties:
+      GroupId: !GetAtt LoadBalancerSG.GroupId
+      Description: >-
+        Egress between the Cri Stub load balancer and
+        the cri Stub ECS security group
+      DestinationSecurityGroupId: !GetAtt CriStubECSSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 8080
+      ToPort: 8080
+
+  CriStubECSSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: >-
+        Cri Stub ECS Security Group outbound permissions ruleset
+      SecurityGroupEgress:
+        - DestinationPrefixListId: !FindInMap [SecurityGroups, PrefixListIds, dynamodb]
+          Description: Allow outbound traffic to dynamodb vpc endpoint
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - DestinationPrefixListId: !FindInMap [SecurityGroups, PrefixListIds, s3]
+          Description: Allow outbound traffic to s3 vpc endpoint
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - DestinationSecurityGroupId:
+            Fn::ImportValue:  !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
+          Description: Allow outbound traffic to AWS Services vpc endpoint security group
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - CidrIp:
+            Fn::ImportValue: !Sub ${VpcStackName}-VpcCidr
+          Description: Allow outbound traffic from vpc cidr to port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+        - CidrIp: 0.0.0.0/0
+          Description: Allow outbound traffic to everywhere 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      SecurityGroupIngress:
+        - CidrIp:
+            Fn::ImportValue: !Sub ${VpcStackName}-VpcCidr
+          Description: Allow inbound traffic from vpc cidr to port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      VpcId:
+        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+
+  CriStubECSSecurityGroupIngressFromLoadBalancer:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      IpProtocol: tcp
+      Description: >-
+        Cri Stub ECS permits inbound from the Cri Stub
+        load balancer.
+      FromPort: 8080
+      ToPort: 8080
+      GroupId: !GetAtt CriStubECSSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt LoadBalancerSG.GroupId
+
+  # http api gateway - which does nothing other than route everything to LB
+  ApiGwHttpEndpoint:
+    Type: "AWS::ApiGatewayV2::Api"
+    Properties:
+      Name: !Sub ${AWS::StackName}-toy-cri-api-gw
+      ProtocolType: HTTP
+
+  ApiGwHttpEndpointIntegration:
+    Type: "AWS::ApiGatewayV2::Integration"
+    Properties:
+      ApiId: !Ref ApiGwHttpEndpoint
+      IntegrationType: HTTP_PROXY
+      ConnectionId:
+        Fn::ImportValue: !Sub "${VpcStackName}-VpcLinkId"
+      ConnectionType: VPC_LINK
+      IntegrationMethod: ANY
+      IntegrationUri: !Ref LoadBalancerListener
+      PayloadFormatVersion: "1.0"
+
+  APIGWRoute:
+    Type: "AWS::ApiGatewayV2::Route"
+    Properties:
+      ApiId: !Ref ApiGwHttpEndpoint
+      RouteKey: "ANY /{proxy+}"
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ApiGwHttpEndpointIntegration
+
+  APIStageDefault:
+    Type: "AWS::ApiGatewayV2::Stage"
+    Properties:
+      ApiId: !Ref ApiGwHttpEndpoint
+      StageName: $default
+      AutoDeploy: true
+      AccessLogSettings:
+        DestinationArn: !GetAtt APIGWAccessLogsGroup.Arn
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip": "$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path": "$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency"
+          }
+
+  APIGWAccessLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !If
+        - IsCoreDev
+        - !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-toy-cri-api-gw-accesslogs
+        - !Sub /aws/apigateway/${AWS::StackName}-toy-cri-api-gw-accesslogs
+      RetentionInDays: 14
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  # Private Application Load Balancer
+  LoadBalancer:
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Properties:
+      Scheme: internal
+      SecurityGroups:
+        - !GetAtt LoadBalancerSG.GroupId
+      Subnets:
+        - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+        - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+      Type: application
+      #checkov:skip=CKV_AWS_91:ALB access logging is disabled in developer environments to make them easier to manage.
+      LoadBalancerAttributes:
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: true
+        - !If
+          - IsNotDevelopment
+          - Key: access_logs.s3.enabled
+            Value: true
+          - !Ref AWS::NoValue
+        - !If
+          - IsNotDevelopment
+          - Key: access_logs.s3.bucket
+            Value: !Join
+              - "-"
+              - - "ipv"
+                - !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, platform ]
+                - !Ref Environment
+                - "access"
+                - "logs"
+          - !Ref AWS::NoValue
+        - !If
+          - IsNotDevelopment
+          - Key: access_logs.s3.prefix
+            Value: cri-stubs
+          - !Ref AWS::NoValue
+        - !If
+          - IsNotDevelopment
+          - Key: deletion_protection.enabled
+            Value: false
+          - !Ref AWS::NoValue
+
+  LoadBalancerListenerTargetGroupECS:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckEnabled: TRUE
+      HealthCheckProtocol: HTTP
+      Matcher:
+        HttpCode: 404
+      Port: 8080
+      Protocol: HTTP
+      TargetType: ip
+      VpcId:
+        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+
+  LoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      # checkov:skip=CKV_AWS_2:Certificate generation must be resolved before the listener can use HTTPS.
+      # checkov:skip=CKV_AWS_103:The load balancer cannot use TLS v1.2 until HTTPS is enabled
+      LoadBalancerArn: !Ref LoadBalancer
+      Protocol: HTTP
+      Port: 80
+      DefaultActions:
+        - TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+          Type: forward
+
+  # ECS cluster, service, task and autoscaling definition
+  CriStubCluster:
+    Type: "AWS::ECS::Cluster"
+    Properties:
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  CriStubService:
+    Type: "AWS::ECS::Service"
+    Properties:
+      Cluster: !Ref CriStubCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+      DeploymentController:
+        Type: ECS
+      DesiredCount: !FindInMap
+        - EnvironmentConfiguration
+        - !Ref AWS::AccountId
+        - desiredTaskCount
+      EnableECSManagedTags: false
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: 8080
+          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !GetAtt CriStubECSSecurityGroup.GroupId
+          Subnets:
+            - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+            - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+      TaskDefinition: !Ref ECSServiceTaskDefinition
+    DependsOn:
+      - LoadBalancerListener
+
+  CriStubAutoScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 1
+      MinCapacity: 1
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref CriStubCluster
+          - !GetAtt CriStubService.Name
+      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  CriStubAutoScalingPolicy:
+    DependsOn: CriStubAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: CriStubAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref CriStubCluster
+          - !GetAtt CriStubService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        TargetValue: 70
+        ScaleInCooldown: 300
+        ScaleOutCooldown: 60
+
+  ECSAccessLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/ecs/${AWS::StackName}-CriStub-ECS
+      RetentionInDays: 14
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  ECSServiceTaskDefinition:
+    Type: "AWS::ECS::TaskDefinition"
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: CONTAINER-IMAGE-PLACEHOLDER
+          Name: app
+          Environment:
+          - Name: JBP_CONFIG_OPEN_JDK_JRE
+            Value: !Ref JbpConfigOpenJdkJre
+          - Name: JAVA_OPTS
+            Value: !Ref JavaOpts
+          - Name: CREDENTIAL_ISSUER_PORT
+            Value: !Ref CredentialIssuerPort
+          - Name: CREDENTIAL_ISSUER_NAME
+            Value: !Ref CredentialIssuerName
+          - Name: CREDENTIAL_ISSUER_TYPE
+            Value: !Ref CredentialIssuerType
+          - Name: CLIENT_CONFIG_FILE
+            Value: !Ref ClientConfigFile
+          - Name: CLIENT_AUDIENCE
+            Value: !Ref ClientAudience
+          - Name: VC_ISSUER
+            Value: !Ref VcIssuer
+          - Name: VC_TTL_SECONDS
+            Value: !Ref VcTtlSeconds
+          Secrets:
+            - Name: "VC_SIGNING_KEY"
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/toy/env/VC_SIGNING_KEY"
+          PortMappings:
+            - ContainerPort: 8080
+              Protocol: tcp
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref ECSAccessLogsGroup
+              awslogs-region: !Sub ${AWS::Region}
+              awslogs-stream-prefix: !Sub cri-stub-${Environment}
+      Cpu: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, fargateCPUsize ]
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
+      Memory: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, fargateRAMsize ]
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      TaskRoleArn: !GetAtt ECSTaskRole.Arn
+
+  ECSTaskExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+      Policies:
+        - PolicyName: PullCriStubImage
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:BatchGetImage"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:GetAuthorizationToken"
+                Resource:
+                  - "*"
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - !GetAtt "ECSAccessLogsGroup.Arn"
+                  - !Sub "${ECSAccessLogsGroup.Arn}:*"
+        - PolicyName: CriStubGetSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "secretsmanager:GetSecretValue" #pragma: allowlist secret
+                Resource:
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/stubs/cri/*"
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/stubs/credential-issuer/*"
+        - PolicyName: CriStubGetSSMParams
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:GetParameters'
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+
+  ECSTaskRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+      Policies:
+        - PolicyName: CriStubGetSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "secretsmanager:GetSecretValue" #pragma: allowlist secret
+                Resource:
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/stubs/cri/*"
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/stubs/credential-issuer/*"
+        - PolicyName: CriStubGetSSMParams
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:GetParameters'
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+
+  # kms key for logging
+  LoggingKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: !Sub "logs.${AWS::Region}.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource: "*"
+            Condition:
+              ArnLike:
+                "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+Outputs:
+  CriStubEnvironment:
+    Description: Cri Stub Environment
+    Value: !Ref Environment
+  CriStubDomain:
+    Description: Cri Stub DNS Domain
+    Value: !Ref CriStubDNSRecord
+  CriStubApiDomain:
+    Description: Cri Stub API Domain
+    Value: !Ref CriStubApiDomain


### PR DESCRIPTION
## Proposed change
see: https://govukverify.atlassian.net/browse/OJ-1403
see: https://govukverify.atlassian.net/browse/OJ-1702

Toy CRI requires a stub, in order to be able to do an end-to-end journey. This PR is specifically for the build environment

### What changed

Added template for and github actions Toy CRI


- [OJ-1702](https://govukverify.atlassian.net/browse/OJ-1702)

## Checklists

### Environment variables or secrets

[OJ-1702]: https://govukverify.atlassian.net/browse/OJ-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ