### PR TITLE
PYIC-3114: Temporarily list build container build dir content for diagnosis

### DIFF
--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -2,6 +2,7 @@ FROM openjdk:17-jdk-slim AS build
 COPY . /home/gradle
 WORKDIR /home/gradle
 RUN ./gradlew build --no-daemon --stacktrace
+RUN ls -lR /home/gradle/build
 
 
 FROM openjdk:17-jdk-slim


### PR DESCRIPTION

## Proposed changes

### What changed
List build container build contents for diagnosis of failing build

### Why did it change
Diagnose github actions issue

### Issue tracking


- [PYIC-3114](https://govukverify.atlassian.net/browse/PYIC-3114)

## Checklists

### Environment variables or secrets


### Other considerations


[PYIC-3114]: https://govukverify.atlassian.net/browse/PYIC-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ