### PR TITLE
PYIC-3238 enabling healthcheck - required, but port to 200

### DIFF
--- a/public-jwk-creator/deploy/template.yaml
+++ b/public-jwk-creator/deploy/template.yaml
@@ -326,7 +326,7 @@ Resources:
   LoadBalancerListenerTargetGroupECS:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      HealthCheckEnabled: FALSE
+      HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       Matcher:
         HttpCode: 200


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-3238 enabling healthcheck - required, but port to 200
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-3238 enabling healthcheck - required, but port to 200
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3238](https://govukverify.atlassian.net/browse/PYIC-3238)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3238]: https://govukverify.atlassian.net/browse/PYIC-3238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ