### PR TITLE
PYIC-3286 Uodate getContraIndicatorCredential to construct CI response for specific user from CIMITStub table.

### DIFF
--- a/di-ipv-cimit-stub/README.md
+++ b/di-ipv-cimit-stub/README.md
@@ -34,3 +34,7 @@ Sample getContraIndicatorCredential GET request should look like
   "user_id": "value3"
 }
 ```
+
+## Environment variables
+
+* IS_LOCAL - This only needs to be assigned when running locally.

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -127,6 +127,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           CIMIT_PARAM_BASE_PATH: "/stubs/core/cimit/"
+          CIMIT_STUB_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt CimitStubTable.Arn ] ]
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -137,6 +138,10 @@ Resources:
         - VPCAccessPolicy: { }
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/cimit/*
+        - DynamoDBReadPolicy:
+            TableName: !Ref CimitStubTable
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
 
   GetContraIndicatorsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -205,6 +210,37 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
 
+  DynamoDBKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: "dynamodb.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource: "*"
+            Condition:
+              StringEquals:
+                "kms:CallerAccount": !Sub "${AWS::AccountId}"
+                "kms:ViaService":
+                  - "dynamodb.amazonaws.com"
+                  - !Sub "lambda.${AWS::Region}.amazonaws.com"
+
+  # kms key for DynamoDB
   DynamoDBKmsKey:
     Type: AWS::KMS::Key
     Properties:

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -127,7 +127,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           CIMIT_PARAM_BASE_PATH: "/stubs/core/cimit/"
-          CIMIT_STUB_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt CimitStubTable.Arn ] ]
+          CIMIT_STUB_TABLE_NAME: !Ref CimitStubTable
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -209,36 +209,6 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
-
-  DynamoDBKmsKey:
-    Type: AWS::KMS::Key
-    Properties:
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - kms:*
-            Resource: "*"
-          - Effect: Allow
-            Principal:
-              Service: "dynamodb.amazonaws.com"
-            Action:
-              - "kms:Encrypt*"
-              - "kms:Decrypt*"
-              - "kms:ReEncrypt*"
-              - "kms:GenerateDataKey*"
-              - "kms:Describe*"
-            Resource: "*"
-            Condition:
-              StringEquals:
-                "kms:CallerAccount": !Sub "${AWS::AccountId}"
-                "kms:ViaService":
-                  - "dynamodb.amazonaws.com"
-                  - !Sub "lambda.${AWS::Region}.amazonaws.com"
 
   # kms key for DynamoDB
   DynamoDBKmsKey:

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
@@ -154,9 +154,9 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
 
     private List<Map<String, Object>> getContraIndicators(String userId) {
         List<Map<String, Object>> contraIndicators = new ArrayList<>();
-        Map<String, Object> contraIndicator = new LinkedHashMap<>();
         List<CimitStubItem> cimitStubItems = cimitStubItemService.getCIsForUserId(userId);
         for (CimitStubItem cimitStubItem : cimitStubItems) {
+            Map<String, Object> contraIndicator = new LinkedHashMap<>();
             contraIndicator.put("code", cimitStubItem.getContraIndicatorCode());
             contraIndicator.put("issuanceDate", cimitStubItem.getIssuanceDate());
             contraIndicator.put("mitigation", getMitigations(cimitStubItem.getMitigations()));
@@ -167,8 +167,8 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
 
     private List<Map<String, Object>> getMitigations(List<String> mitigationCodes) {
         List<Map<String, Object>> mitigations = new ArrayList<>();
-        Map<String, Object> mitigation = new LinkedHashMap<>();
         for (String mitigationCode : mitigationCodes) {
+            Map<String, Object> mitigation = new LinkedHashMap<>();
             mitigation.put("code", mitigationCode);
             mitigations.add(mitigation);
         }

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -109,6 +109,32 @@ class GetContraIndicatorCredentialHandlerTest {
         assertClaimsJWTIsValid(contraIndicatorsVC);
     }
 
+    @Test
+    void shouldFailForWrongCimitKey() throws IOException {
+        when(mockConfigService.getCimitSigningKey()).thenReturn("Invalid_cimit_key");
+        when(mockConfigService.getCimitComponentId()).thenReturn(CIMIT_COMPONENT_ID);
+
+        GetCiCredentialRequest getCiCredentialRequest =
+                GetCiCredentialRequest.builder()
+                        .govukSigninJourneyId("govuk_signin_journey_id")
+                        .ipAddress("ip_address")
+                        .userId(USER_ID)
+                        .build();
+
+        var response =
+                makeRequest(
+                        classToTest,
+                        mapper.writeValueAsString(getCiCredentialRequest),
+                        mockContext,
+                        String.class);
+
+        verify(mockConfigService).getCimitSigningKey();
+        verify(mockConfigService).getCimitComponentId();
+
+        assertNotNull(response);
+        assertTrue(response.equals("Failure"));
+    }
+
     private <T extends String> T makeRequest(
             RequestStreamHandler handler, String request, Context context, Class<T> classType)
             throws IOException {

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -2,7 +2,13 @@ package uk.gov.di.ipv.core.getcontraindicatorcredential;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.getcontraindicatorcredential.domain.GetCiCredentialRequest;
+import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
+import uk.gov.di.ipv.core.library.service.CimitStubItemService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
@@ -18,26 +26,43 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.SECURITY_CHECK_CREDENTIAL_VC_TYPE;
 
 @ExtendWith({SystemStubsExtension.class, MockitoExtension.class})
 class GetContraIndicatorCredentialHandlerTest {
 
+    public static final String USER_ID = "user_id";
     private static final String CIMIT_PRIVATE_KEY =
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM+QJXk0PI339EyYkt6tjgfS+RcOMQNO";
+    private static final String CIMIT_PUBLIC_JWK =
+            "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
+
     private static final String CIMIT_COMPONENT_ID = "https://cimit.stubs.account.gov.uk";
 
     private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String CI_V_03 = "V03";
+    public static final String MITIGATION_M_01 = "M01";
+
     @Mock private Context mockContext;
     @Mock private ConfigService mockConfigService;
+    @Mock private CimitStubItemService mockCimitStubItemService;
     @InjectMocks private GetContraIndicatorCredentialHandler classToTest;
 
     @BeforeEach
     void setUp() {
-        classToTest = new GetContraIndicatorCredentialHandler(mockConfigService);
+        classToTest =
+                new GetContraIndicatorCredentialHandler(
+                        mockConfigService, mockCimitStubItemService);
     }
 
     @SystemStub
@@ -45,15 +70,25 @@ class GetContraIndicatorCredentialHandlerTest {
             new EnvironmentVariables("CIMIT_COMPONENT_ID", "https://cimit.stubs.account.gov.uk");
 
     @Test
-    void shouldReturnSignedJwtWhenProvidedValidRequest() throws IOException {
+    void shouldReturnSignedJwtWhenProvidedValidRequest()
+            throws IOException, ParseException, JOSEException {
         when(mockConfigService.getCimitSigningKey()).thenReturn(CIMIT_PRIVATE_KEY);
         when(mockConfigService.getCimitComponentId()).thenReturn(CIMIT_COMPONENT_ID);
+        List<CimitStubItem> cimitStubItems = new ArrayList<>();
+        cimitStubItems.add(
+                CimitStubItem.builder()
+                        .userId(USER_ID)
+                        .contraIndicatorCode(CI_V_03)
+                        .issuanceDate(Instant.now())
+                        .mitigations(List.of(MITIGATION_M_01))
+                        .build());
+        when(mockCimitStubItemService.getCIsForUserId(USER_ID)).thenReturn(cimitStubItems);
 
         GetCiCredentialRequest getCiCredentialRequest =
                 GetCiCredentialRequest.builder()
                         .govukSigninJourneyId("govuk_signin_journey_id")
                         .ipAddress("ip_address")
-                        .userId("user_id")
+                        .userId(USER_ID)
                         .build();
 
         var response =
@@ -68,6 +103,10 @@ class GetContraIndicatorCredentialHandlerTest {
 
         assertNotNull(response);
         assertTrue(!response.equals("Failure"));
+
+        final String contraIndicatorsVC = new String(response.getBytes(), StandardCharsets.UTF_8);
+
+        assertClaimsJWTIsValid(contraIndicatorsVC);
     }
 
     private <T extends String> T makeRequest(
@@ -78,5 +117,28 @@ class GetContraIndicatorCredentialHandlerTest {
             handler.handleRequest(inputStream, outputStream, context);
             return mapper.readValue(outputStream.toString(), classType);
         }
+    }
+
+    private void assertClaimsJWTIsValid(String request)
+            throws ParseException, JsonProcessingException, JOSEException {
+        SignedJWT signedJWT = SignedJWT.parse(request);
+        JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
+
+        assertEquals(USER_ID, signedJWT.getJWTClaimsSet().getClaim("sub"));
+        assertEquals(CIMIT_COMPONENT_ID, signedJWT.getJWTClaimsSet().getClaim("iss"));
+
+        JsonNode vc = claimsSet.get("vc");
+        assertEquals(2, vc.size());
+        assertEquals(SECURITY_CHECK_CREDENTIAL_VC_TYPE, vc.get("type").get(0).asText());
+        JsonNode contraIndicators = vc.get("evidence").get(0).get("contraIndicator");
+        assertEquals(1, contraIndicators.size());
+        JsonNode firstCINode = contraIndicators.get(0);
+        assertEquals(CI_V_03, firstCINode.get("code").asText());
+        JsonNode mitigations = firstCINode.get("mitigation");
+        assertEquals(1, mitigations.size());
+        assertEquals(MITIGATION_M_01, mitigations.get(0).get("code").asText());
+
+        ECDSAVerifier verifier = new ECDSAVerifier(ECKey.parse(CIMIT_PUBLIC_JWK));
+        assertTrue(signedJWT.verify(verifier));
     }
 }

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.core.library.config;
 
 public enum EnvironmentVariable {
-    CIMIT_PARAM_BASE_PATH
+    CIMIT_PARAM_BASE_PATH,
+    IS_LOCAL,
+    CIMIT_STUB_TABLE_NAME
 }

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/items/CimitStubItem.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/items/CimitStubItem.java
@@ -1,6 +1,9 @@
 package uk.gov.di.ipv.core.library.persistence.items;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
@@ -9,11 +12,13 @@ import java.time.Instant;
 import java.util.List;
 
 @DynamoDbBean
+@AllArgsConstructor
+@NoArgsConstructor
 @Data
+@Builder
 public class CimitStubItem implements DynamodbItem {
     private String userId;
     private String contraIndicatorCode;
-
     private Instant issuanceDate;
     private long ttl;
 

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/CimitStubItemService.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/CimitStubItemService.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.core.library.service;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
 
@@ -10,7 +8,6 @@ import java.util.List;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CIMIT_STUB_TABLE_NAME;
 
 public class CimitStubItemService {
-    private static final Logger LOGGER = LogManager.getLogger();
 
     private final DataStore<CimitStubItem> dataStore;
 

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/CimitStubItemService.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/CimitStubItemService.java
@@ -1,0 +1,38 @@
+package uk.gov.di.ipv.core.library.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
+
+import java.util.List;
+
+import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CIMIT_STUB_TABLE_NAME;
+
+public class CimitStubItemService {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final DataStore<CimitStubItem> dataStore;
+
+    private final ConfigService configService;
+
+    public CimitStubItemService(ConfigService configService) {
+        this.configService = configService;
+        boolean isRunningLocally = this.configService.isRunningLocally();
+        dataStore =
+                new DataStore<>(
+                        this.configService.getEnvironmentVariable(CIMIT_STUB_TABLE_NAME),
+                        CimitStubItem.class,
+                        DataStore.getClient(isRunningLocally),
+                        isRunningLocally);
+    }
+
+    public CimitStubItemService(DataStore<CimitStubItem> dataStore, ConfigService configService) {
+        this.dataStore = dataStore;
+        this.configService = configService;
+    }
+
+    public List<CimitStubItem> getCIsForUserId(String userId) {
+        return dataStore.getItems(userId);
+    }
+}

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -6,6 +6,7 @@ import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CIMIT_PARAM_BASE_PATH;
+import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IS_LOCAL;
 
 public class ConfigService {
 
@@ -41,5 +42,9 @@ public class ConfigService {
 
     protected String resolvePath(String path, String... pathProperties) {
         return String.format(path, (Object[]) pathProperties);
+    }
+
+    public boolean isRunningLocally() {
+        return Boolean.parseBoolean(getEnvironmentVariable(IS_LOCAL));
     }
 }

--- a/di-ipv-cimit-stub/lib/src/test/java/uk/gov/di/ipv/core/library/persistence/DataStoreTest.java
+++ b/di-ipv-cimit-stub/lib/src/test/java/uk/gov/di/ipv/core/library/persistence/DataStoreTest.java
@@ -1,0 +1,81 @@
+package uk.gov.di.ipv.core.library.persistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.DescribeTableEnhancedResponse;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataStoreTest {
+    private static final String TEST_TABLE_NAME = "test-table";
+
+    @Mock private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
+    @Mock private DynamoDbTable<CimitStubItem> mockDynamoDbTable;
+    @Mock private PageIterable<CimitStubItem> mockPageIterable;
+    @Mock private DynamoDbIndex<CimitStubItem> mockIndex;
+    @Mock private SdkIterable<Page<CimitStubItem>> mockIterable;
+    @Mock private ConfigService mockConfigService;
+
+    private CimitStubItem cimitStubItem;
+    private DataStore<CimitStubItem> dataStore;
+
+    private final long ttl = 7200;
+
+    @BeforeEach
+    void setUp() {
+        when(mockDynamoDbEnhancedClient.table(
+                        anyString(), ArgumentMatchers.<TableSchema<CimitStubItem>>any()))
+                .thenReturn(mockDynamoDbTable);
+
+        cimitStubItem = CimitStubItem.builder().userId("test-user").build();
+
+        dataStore =
+                new DataStore<>(
+                        TEST_TABLE_NAME, CimitStubItem.class, mockDynamoDbEnhancedClient, false);
+    }
+
+    @Test
+    void shouldGetItemFromDynamoDbTableViaPartitionKeyAndSortKey() {
+        TableDescription tableDescription =
+                TableDescription.builder().tableName(TEST_TABLE_NAME).build();
+        DescribeTableResponse describeTableResponse =
+                DescribeTableResponse.builder().table(tableDescription).build();
+        when(mockDynamoDbTable.describeTable())
+                .thenReturn(
+                        new DescribeTableEnhancedResponse.Builder()
+                                .response(describeTableResponse)
+                                .build());
+
+        dataStore.getItem("partition-key-12345", "sort-key-12345");
+
+        ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
+
+        verify(mockDynamoDbEnhancedClient)
+                .table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<CimitStubItem>>any());
+        verify(mockDynamoDbTable).getItem(keyCaptor.capture());
+        assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
+        assertEquals("sort-key-12345", keyCaptor.getValue().sortKeyValue().get().s());
+    }
+}

--- a/di-ipv-cimit-stub/lib/src/test/java/uk/gov/di/ipv/core/library/service/CimitStubItemServiceTest.java
+++ b/di-ipv-cimit-stub/lib/src/test/java/uk/gov/di/ipv/core/library/service/CimitStubItemServiceTest.java
@@ -1,0 +1,53 @@
+package uk.gov.di.ipv.core.library.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CimitStubItemServiceTest {
+
+    private static final String USER_ID = "user-id-1";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private ConfigService mockConfigService;
+
+    @Mock private DataStore<CimitStubItem> mockDataStore;
+
+    private CimitStubItemService classToTest;
+
+    @BeforeEach
+    void setUp() {
+        classToTest = new CimitStubItemService(mockDataStore, mockConfigService);
+    }
+
+    @Test
+    void shouldReturnCredentialIssuersFromDataStoreForSpecificUserId() {
+        String ciCode = "V03";
+        List<CimitStubItem> cimitStubItems =
+                List.of(
+                        CimitStubItem.builder()
+                                .userId(USER_ID)
+                                .contraIndicatorCode(ciCode)
+                                .build());
+
+        when(mockDataStore.getItems(USER_ID)).thenReturn(cimitStubItems);
+
+        var result = classToTest.getCIsForUserId(USER_ID);
+
+        assertTrue(
+                result.stream()
+                        .map(CimitStubItem::getContraIndicatorCode)
+                        .anyMatch(item -> ciCode.equals(item)));
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Amend CIMIT getContraIndicator* stubs to construct response for user from CIMIT stub state table

### What changed
- added CimitStubItemService service with operation getCIsForUserId
- updated getContraIndicatorCredential lambda handler to construct CI response for specific user from CIMITStub table.
- updated tests.
- 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3286](https://govukverify.atlassian.net/browse/PYIC-3286)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
