### PR TITLE
PYIC-3059: Add gpg45 scoring boxes to the f2f stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -529,6 +529,37 @@ public class AuthorizeHandler {
                     gpg45Score.put(CredentialIssuerConfig.CHECK_DETAILS_PARAM, checkDetailsValue);
                 }
             }
+            case F2F_CRI_TYPE -> {
+                int strengthNum =
+                        StringUtils.isNotBlank(validityValue) ? Integer.parseInt(strengthValue) : 3;
+                gpg45Score.put(CredentialIssuerConfig.EVIDENCE_STRENGTH_PARAM, strengthNum);
+                int validityNum =
+                        StringUtils.isNotBlank(validityValue) ? Integer.parseInt(validityValue) : 2;
+                gpg45Score.put(CredentialIssuerConfig.EVIDENCE_VALIDITY_PARAM, validityNum);
+
+                if (StringUtils.isNotBlank(verificationValue)) {
+                    gpg45Score.put(
+                            CredentialIssuerConfig.VERIFICATION_PARAM,
+                            Integer.parseInt(verificationValue));
+                }
+
+                List<Map<String, Object>> checkDetailsValue = new ArrayList<>();
+                checkDetailsValue.add(
+                        Map.of(
+                                "identityCheckPolicy",
+                                "published",
+                                "activityFrom",
+                                "1982-05-23",
+                                "checkMethod",
+                                "data"));
+
+                if (validityNum < 2) {
+                    gpg45Score.put(
+                            CredentialIssuerConfig.FAILED_CHECK_DETAILS_PARAM, checkDetailsValue);
+                } else {
+                    gpg45Score.put(CredentialIssuerConfig.CHECK_DETAILS_PARAM, checkDetailsValue);
+                }
+            }
         }
         return gpg45Score;
     }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -114,6 +114,43 @@
                                     </div>
                                 </td>
                             </tr>
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                   <fieldset class="govuk-fieldset">
+                                        <div class="govuk-date-input" id="gpg45">
+                                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                                <h1 class="govuk-fieldset__heading">
+                                                    GPG45 Evidence
+                                                </h1>
+                                            </legend>
+                                            <div class="govuk-date-input__item">
+                                                <div class="govuk-form-group">
+                                                    <label class="govuk-label" for="strength">
+                                                        Strength
+                                                    </label>
+                                                    <input class="govuk-input govuk-input--width-2" id="strength" name="strengthScore" type="number" min="0" max="5" step="1">
+                                                </div>
+                                            </div>
+                                            <div class="govuk-date-input__item">
+                                                <div class="govuk-form-group">
+                                                    <label class="govuk-label govuk-date-input__label" for="validity">
+                                                        Validity
+                                                    </label>
+                                                    <input class="govuk-input govuk-input--width-2" id="validity" name="validityScore" type="number" min="0" max="5" step="1">
+                                                </div>
+                                            </div>
+                                            <div class="govuk-date-input__item">
+                                                <div class="govuk-form-group">
+                                                    <label class="govuk-label govuk-date-input__label" for="verification">
+                                                        Verification
+                                                    </label>
+                                                    <input class="govuk-input govuk-input--width-2" id="verification" name="verificationScore" type="number" min="0" max="5" step="1">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                </td>
+                            </tr>
                         {{/isF2FType}}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add gpg45 scoring boxes to the f2f stub

### Why did it change

Enhancing the f2f stub so we no longer have to rely on the override evidence block 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3059](https://govukverify.atlassian.net/browse/PYIC-3059)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3059]: https://govukverify.atlassian.net/browse/PYIC-3059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ