### PR TITLE
Pyic 3295 secure the network access to the stub

### DIFF
--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -348,6 +348,10 @@ Resources:
       StageName: !Sub ${Environment}
       TracingEnabled: true
       DefinitionBody:
+        openapi: "3.0.3" # workaround to get `sam validate` to work
+        paths: # workaround to get `sam validate` to work
+          /foo:
+            bar: baz # workaround to get `sam validate` to work
         'Fn::Transform':
           Name: "AWS::Include"
           Parameters:

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -351,7 +351,7 @@ Resources:
         openapi: "3.0.3" # workaround to get `sam validate` to work
         paths: # workaround to get `sam validate` to work
           /foo:
-            bar: baz # workaround to get `sam validate` to work
+            options: {} # workaround to get `sam validate` to work
         'Fn::Transform':
           Name: "AWS::Include"
           Parameters:


### PR DESCRIPTION
## Proposed changes
Added a 'fake' openapi definition to make sam validate work

### What changed
added something into the definition body

### Why did it change
sam validate can't deal with the include transform as detailed here: https://github.com/aws/aws-sam-cli/issues/803
and I don't have the time/inclination to finish this PR to fix it properly:
https://github.com/aws/aws-sam-cli/pull/3882/files
