### PR TITLE
LIME-688 Add passporta dev environment var to core-stub template

### DIFF
--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -39,6 +39,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+  ApiKeyCriPassportDev:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_PASSPORTA_DEV" #pragma: allowlist secret
   ApiKeyCriAddressBuild:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -622,6 +626,8 @@ Resources:
             Value: !Ref CoreStubEnableBackendRoutes
           - Name: CORE_STUB_BASIC_AUTH
             Value: !Ref CoreStubBasicAuth
+          - Name: API_KEY_CRI_PASSPORTA_DEV
+            Value: !Ref ApiKeyCriPassportDev
           - Name: API_KEY_CRI_ADDRESS_BUILD
             Value: !Ref ApiKeyCriAddressBuild
           - Name: API_KEY_CRI_KBV_BUILD


### PR DESCRIPTION
## Proposed changes

### What changed

Added environment variable for passporta-dev apikey

### Why did it change

To enable passporta-dev pipeline stacks to use core-stub.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-688](https://govukverify.atlassian.net/browse/LIME-688)



[LIME-688]: https://govukverify.atlassian.net/browse/LIME-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ