### PR TITLE
Pyic 3295 secure the network access to the stub

### DIFF
--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -57,6 +57,15 @@ Resources:
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
+      #Events:
+      #  ApiEvent:
+      #    Type: Api
+      #    Properties:
+      #      Method: POST
+      #      Path: /
+      #      RestApiId: !Ref RestApiGateway
+
+
 
   # lambda to stub cimit postMitigations
   PostMitigationsFunction:
@@ -89,6 +98,13 @@ Resources:
       Policies:
         - VPCAccessPolicy: { }
       AutoPublishAlias: live
+      #Events:
+      #  ApiEvent:
+      #    Type: Api
+      #    Properties:
+      #      Method: POST
+      #      Path: /
+      #      RestApiId: !Ref RestApiGateway
 
   # lambda to stub cimit putContraIndicators
   PutContraIndicatorsFunction:
@@ -123,6 +139,13 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/*
       AutoPublishAlias: live
+      #Events:
+      #  ApiEvent:
+      #    Type: Api
+      #    Properties:
+      #      Method: POST
+      #      Path: /
+      #      RestApiId: !Ref RestApiGateway
 
   # lambda to stub cimit getContraIndicatorCredential
   GetContraIndicatorCredentialFunction:
@@ -163,6 +186,13 @@ Resources:
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
+      #Events:
+      #  ApiEvent:
+      #    Type: Api
+      #    Properties:
+      #      Method: POST
+      #      Path: /
+      #      RestApiId: !Ref RestApiGateway
 
   # lambda to stub management
   StubManagementFunction:
@@ -204,6 +234,20 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref CimitStubTable
       AutoPublishAlias: live
+      Events:
+        ApiEventPostCis:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /user/*/cis
+            RestApiId: !Ref RestApiGateway
+        ApiEventPostMitigations:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /user/*/mitigations/*
+            RestApiId: !Ref RestApiGateway
+
 
   GetContraIndicatorsFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -247,6 +247,18 @@ Resources:
             Method: POST
             Path: /user/*/mitigations/*
             RestApiId: !Ref RestApiGateway
+        ApiEventPutCis:
+          Type: Api
+          Properties:
+            Method: PUT
+            Path: /user/*/cis
+            RestApiId: !Ref RestApiGateway
+        ApiEventPutMitigations:
+          Type: Api
+          Properties:
+            Method: PUT
+            Path: /user/*/mitigations/*
+            RestApiId: !Ref RestApiGateway
 
 
   GetContraIndicatorsFunctionLogGroup:

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -1,4 +1,3 @@
-#file: noinspection YAMLSchemaValidation
 AWSTemplateFormatVersion: "2010-09-09"
 
 Transform: AWS::Serverless-2016-10-31
@@ -20,6 +19,7 @@ Parameters:
     Description: The name of the environment to deploy to.
     Type: String
     AllowedPattern: ((production)|(build)|(dev.*))
+
 Resources:
   # lambda to stub cimit getContraIndicators
   GetContraIndicatorsFunction:
@@ -56,6 +56,7 @@ Resources:
             TableName: !Ref CimitStubTable
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
+      AutoPublishAlias: live
 
   # lambda to stub cimit postMitigations
   PostMitigationsFunction:
@@ -87,6 +88,7 @@ Resources:
           - !GetAtt CimitLambdaSecurityGroup.GroupId
       Policies:
         - VPCAccessPolicy: { }
+      AutoPublishAlias: live
 
   # lambda to stub cimit putContraIndicators
   PutContraIndicatorsFunction:
@@ -120,6 +122,7 @@ Resources:
         - VPCAccessPolicy: { }
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/*
+      AutoPublishAlias: live
 
   # lambda to stub cimit getContraIndicatorCredential
   GetContraIndicatorCredentialFunction:
@@ -159,6 +162,7 @@ Resources:
             TableName: !Ref CimitStubTable
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
+      AutoPublishAlias: live
 
   # lambda to stub management
   StubManagementFunction:
@@ -199,6 +203,7 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:
             TableName: !Ref CimitStubTable
+      AutoPublishAlias: live
 
   GetContraIndicatorsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -362,6 +367,13 @@ Resources:
         UsagePlan:
           CreateUsagePlan: PER_API
           UsagePlanName: "CIMIT Usage Plan"
+        ResourcePolicy:
+          CustomStatements:
+            - Action: 'execute-api:Invoke'
+              Effect: Allow
+              Principal: '*'
+              Resource:
+                - 'execute-api:/*'
       AccessLogSetting:
         DestinationArn: !GetAtt RestApiLogGroup.Arn
         Format: >-

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -1,3 +1,4 @@
+#file: noinspection YAMLSchemaValidation
 AWSTemplateFormatVersion: "2010-09-09"
 
 Transform: AWS::Serverless-2016-10-31
@@ -19,7 +20,6 @@ Parameters:
     Description: The name of the environment to deploy to.
     Type: String
     AllowedPattern: ((production)|(build)|(dev.*))
-
 Resources:
   # lambda to stub cimit getContraIndicators
   GetContraIndicatorsFunction:

--- a/di-ipv-cimit-stub/openAPI/cimit-external.yaml
+++ b/di-ipv-cimit-stub/openAPI/cimit-external.yaml
@@ -23,3 +23,206 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: "{\"healthcheck\": \"ok\"}"
+  /user/{userId}/cis:
+    post:
+      description: insert new CIs to the Cimit Stub DynamoDB Table
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CisRequestBody"
+      responses:
+        200:
+          description: "Success response "
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        requestParameters: "header"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "input": “{ \"userId\": \"$input.params('userId')\", \"code\": \"$input.body('code')\", \"issuanceDate\": \"$input.body('issuanceDate')\", \"mitigations\": \"$input.body('mitigations')\ "}"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: '{"result": "success"}'
+
+    put:
+      description: Update CIs to the Cimit Stub DynamoDB Table
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CisRequestBody"
+      responses:
+        200:
+          description: "Success response "
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        requestParameters: "header"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "input": “{ \"userId\": \"$input.params('userId')\", \"code\": \"$input.body('code')\", \"issuanceDate\": \"$input.body('issuanceDate')\", \"mitigations\": \"$input.body('mitigations')\ "}"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: '{"result": "success"}'
+
+  /user/{userId}/mitigations/{ci}:
+    post:
+      description: insert mitigations to the Cimit Stub DynamoDB Table
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          description: The ID of the user
+          schema:
+            type: string
+        - name: ci
+          in: path
+          required: true
+          description: The ContraIndicator (CI) value
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MitigationsRequestBody"
+      responses:
+        200:
+          description: "Success response "
+          content:
+            text/plain:
+              schema:
+                type: string
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        requestParameters: "header"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "input": “{\"userId\": \"$input.params('userId')\", \"ci\": \"$input.params('ci')\", \"mitigations\": \"$input.body\"}"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: '"success"'
+    put:
+      description: Update mitigations to the Cimit Stub DynamoDB Table
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          description: The ID of the user
+          schema:
+            type: string
+        - name: ci
+          in: path
+          required: true
+          description: The ContraIndicator (CI) value
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MitigationsRequestBody"
+      responses:
+        200:
+          description: "Success response "
+          content:
+            text/plain:
+              schema:
+                type: string
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        requestParameters: "header"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "input": “{\"userId\": \"$input.params('userId')\", \"ci\": \"$input.params('ci')\", \"mitigations\": \"$input.body\"}"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: '"success"'
+components:
+  schemas:
+    CisRequestBody:
+      description: Request body for CIs (ContraIndicator) updates or additions
+      type: object
+      properties:
+        code:
+          type: string
+          description: The code for CIs data
+        issuanceDate:
+          type: string
+          format: date-time
+          description: An ISO Date representing the issuance dae of the CIS data. If not set, use system data (optional)
+        mitigations:
+          type: array
+          items:
+            type: string
+          description: An array of mitigations (optional)
+    MitigationsRequestBody:
+      description: Request body for mitigations updates or additions
+      type: array
+      items:
+        type: string


### PR DESCRIPTION
Added permissions for API gw to invoke lambda

## Proposed changes
Not sure how this was working for POST before, but it should be working now for POST and PUT - other lambdas will need to be completed in the same way.


### What changed
API Definition and cloudformation template
