### PR TITLE
PYIC-3305 Add ability to trigger 404 from credential endpoint in DCMAW CRI stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -58,7 +58,11 @@ public class CredentialIssuer {
                         requestedErrorResponseService);
         credentialHandler = new CredentialHandler(credentialService, tokenService, vcGenerator);
         docAppCredentialHandler =
-                new DocAppCredentialHandler(credentialService, tokenService, vcGenerator);
+                new DocAppCredentialHandler(
+                        credentialService,
+                        tokenService,
+                        vcGenerator,
+                        requestedErrorResponseService);
         jwksHandler = new JwksHandler();
         f2fHandler = new F2FHandler(credentialService, tokenService);
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
@@ -1,6 +1,8 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.eclipse.jetty.http.HttpHeader;
 import org.slf4j.Logger;
@@ -10,6 +12,7 @@ import spark.Response;
 import spark.Route;
 import uk.gov.di.ipv.stub.cred.domain.Credential;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
@@ -27,30 +30,48 @@ public class DocAppCredentialHandler {
     private TokenService tokenService;
     private VerifiableCredentialGenerator verifiableCredentialGenerator;
 
+    private RequestedErrorResponseService requestedErrorResponseService;
+
     public DocAppCredentialHandler(
             CredentialService credentialService,
             TokenService tokenService,
-            VerifiableCredentialGenerator verifiableCredentialGenerator) {
+            VerifiableCredentialGenerator verifiableCredentialGenerator,
+            RequestedErrorResponseService requestedErrorResponseService) {
         this.credentialService = credentialService;
         this.tokenService = tokenService;
         this.verifiableCredentialGenerator = verifiableCredentialGenerator;
+        this.requestedErrorResponseService = requestedErrorResponseService;
     }
 
     public Route getResource =
             (Request request, Response response) -> {
-                String accessTokenString = request.headers(HttpHeader.AUTHORIZATION.toString());
+                String accessTokenHeaderValue =
+                        request.headers(HttpHeader.AUTHORIZATION.toString());
 
                 ValidationResult validationResult =
-                        tokenService.validateAccessToken(accessTokenString);
+                        tokenService.validateAccessToken(accessTokenHeaderValue);
 
                 if (!validationResult.isValid()) {
                     response.status(validationResult.getError().getHTTPStatusCode());
                     return validationResult.getError().getDescription();
                 }
 
+                String accessTokenValue =
+                        BearerAccessToken.parse(accessTokenHeaderValue).getValue();
+                UserInfoErrorResponse requestedUserInfoErrorResponse =
+                        requestedErrorResponseService.getUserInfoErrorByToken(accessTokenValue);
+                if (requestedUserInfoErrorResponse != null) {
+                    response.status(
+                            requestedUserInfoErrorResponse.getErrorObject().getHTTPStatusCode());
+                    return requestedUserInfoErrorResponse
+                            .getErrorObject()
+                            .toJSONObject()
+                            .toJSONString();
+                }
+
                 String verifiableCredential;
                 try {
-                    String resourceId = tokenService.getPayload(accessTokenString);
+                    String resourceId = tokenService.getPayload(accessTokenHeaderValue);
                     Credential credential = credentialService.getCredential(resourceId);
                     verifiableCredential =
                             verifiableCredentialGenerator.generate(credential).serialize();
@@ -60,7 +81,7 @@ public class DocAppCredentialHandler {
                     return String.format("Error: Unable to generate VC - '%s'", e.getMessage());
                 }
 
-                tokenService.revoke(accessTokenString);
+                tokenService.revoke(accessTokenHeaderValue);
 
                 response.type(JSON_RESPONSE_TYPE);
                 response.status(HttpServletResponse.SC_CREATED);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -21,6 +21,7 @@ public class RequestParamConstants {
     public static final String REQUESTED_OAUTH_ERROR_ENDPOINT = "requested_oauth_error_endpoint";
     public static final String REQUESTED_OAUTH_ERROR_DESCRIPTION =
             "requested_oauth_error_description";
+    public static final String REQUESTED_USERINFO_ERROR = "requested_userinfo_error";
     public static final String F2F_SEND_VC_QUEUE = "f2f_send_vc_queue";
     public static final String F2F_SEND_ERROR_QUEUE = "f2f_send_error_queue";
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
@@ -39,7 +39,7 @@ public class TokenHandler {
     private AuthCodeService authCodeService;
     private Validator validator;
     private ClientJwtVerifier clientJwtVerifier;
-    private final RequestedErrorResponseService requestedErrorResponseService;
+    private RequestedErrorResponseService requestedErrorResponseService;
 
     public TokenHandler(
             AuthCodeService authCodeService,
@@ -124,6 +124,9 @@ public class TokenHandler {
                 String payloadAssociatedWithCode = authCodeService.getPayload(code);
                 authCodeService.revoke(code);
                 tokenService.persist(accessToken, payloadAssociatedWithCode);
+
+                requestedErrorResponseService.persistUserInfoErrorAgainstToken(
+                        code, accessToken.toString());
 
                 response.status(HttpServletResponse.SC_OK);
                 return tokenResponse.toJSONObject().toJSONString();

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -511,6 +511,17 @@
                                         </label>
                                         <input class="govuk-input" id="requested_oauth_error_description" name="requested_oauth_error_description" type="text" value="This error was triggered manually in the stub CRI">
                                     </div>
+                                    {{#isDocCheckingType}}
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label" for="userinfo_error">
+                                            User Info (Credential) endpoint error
+                                        </label>
+                                        <select class="govuk-select" id="userinfo_error" name="requested_userinfo_error">
+                                            <option value="none" selected>none</option>
+                                            <option value="404">404</option>
+                                        </select>
+                                    </div>
+                                    {{/isDocCheckingType}}
                                 </fieldset>
                             </td>
                         </tr>

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import spark.Request;
 import spark.Response;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
@@ -50,6 +51,7 @@ public class DocAppCredentialHandlerTest {
     @Mock private CredentialService mockCredentialService;
     @Mock private TokenService mockTokenService;
     @Mock private VerifiableCredentialGenerator mockVerifiableCredentialGenerator;
+    @Mock private RequestedErrorResponseService mockRequestedErrorResponseService;
     @Mock private SignedJWT mockSignedJwt;
     private DocAppCredentialHandler resourceHandler;
     private AccessToken accessToken;
@@ -59,7 +61,10 @@ public class DocAppCredentialHandlerTest {
         accessToken = new BearerAccessToken();
         resourceHandler =
                 new DocAppCredentialHandler(
-                        mockCredentialService, mockTokenService, mockVerifiableCredentialGenerator);
+                        mockCredentialService,
+                        mockTokenService,
+                        mockVerifiableCredentialGenerator,
+                        mockRequestedErrorResponseService);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

New field on the DCMAW stub page to select a 404 error from the credential/user info endpoint. The error gets saved against the authorisation code first then against the access token when the token is retrieved, so that it can be fetched using the access token when retrieving the credential.

### Why did it change

So we can test handling 404s from DCMAW CRI

### Issue tracking

- [PYIC-3305](https://govukverify.atlassian.net/browse/PYIC-3305)



[PYIC-3305]: https://govukverify.atlassian.net/browse/PYIC-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ