### PR TITLE
BAU Update GitHub workflows to have a timeout of 15 minutes

### DIFF
--- a/.github/workflows/cimit-stub.yml
+++ b/.github/workflows/cimit-stub.yml
@@ -12,6 +12,7 @@ jobs:
   buildAndPush:
     name: Build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -16,6 +16,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -16,6 +16,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/core-passport-stub.yml
+++ b/.github/workflows/core-passport-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-activity-history-stub.yml
+++ b/.github/workflows/cri-activity-history-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-address-stub.yml
+++ b/.github/workflows/cri-address-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-claimed-identity-stub.yml
+++ b/.github/workflows/cri-claimed-identity-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-dcmaw-stub.yml
+++ b/.github/workflows/cri-dcmaw-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-driving-license-stub.yml
+++ b/.github/workflows/cri-driving-license-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-error-testing-1-stub.yml
+++ b/.github/workflows/cri-error-testing-1-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-error-testing-2-stub.yml
+++ b/.github/workflows/cri-error-testing-2-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-f2f-stub.yml
+++ b/.github/workflows/cri-f2f-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-fraud-stub.yml
+++ b/.github/workflows/cri-fraud-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-kbv-stub.yml
+++ b/.github/workflows/cri-kbv-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-passport-stub.yml
+++ b/.github/workflows/cri-passport-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/cri-toy-stub.yml
+++ b/.github/workflows/cri-toy-stub.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/deploy-orch-build-stub.yml
+++ b/.github/workflows/deploy-orch-build-stub.yml
@@ -12,6 +12,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/deploy-orch-integration-stub.yml
+++ b/.github/workflows/deploy-orch-integration-stub.yml
@@ -12,6 +12,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/deploy-orch-staging-stub.yml
+++ b/.github/workflows/deploy-orch-staging-stub.yml
@@ -12,6 +12,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/deploy-queue-stub-build.yml
+++ b/.github/workflows/deploy-queue-stub-build.yml
@@ -12,6 +12,7 @@ jobs:
   buildAndPush:
     name: Build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/deploy-queue-stub-staging.yml
+++ b/.github/workflows/deploy-queue-stub-staging.yml
@@ -12,6 +12,7 @@ jobs:
   buildAndPush:
     name: Build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/deploy-update-ecs-env-vars.yml
+++ b/.github/workflows/deploy-update-ecs-env-vars.yml
@@ -12,6 +12,7 @@ jobs:
   buildAndPush:
     name: Build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/public-jwk-creator.yml
+++ b/.github/workflows/public-jwk-creator.yml
@@ -15,6 +15,7 @@ jobs:
   dockerBuildAndPush:
     name: Docker build and push
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/template_checks.yml
+++ b/.github/workflows/template_checks.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   RunCloudformationLinter:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,6 +33,7 @@ jobs:
           done
   RunCheckov:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Set GitHub action timeouts to 15 minutes.

## Proposed changes

### What changed

Set GitHub action timeouts to 15 minutes.

### Why did it change

E-mail from Alex Wilson entitled “GitHub Actions Storage/Duration Limits” on 15th August 2023 to the whole of DI requests that all projects should “Include job timeouts on all your GitHub workflows of 15m (or more if appropriate for longer build processes)“ in order to control costs of GitHub Actions.

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
