### PR TITLE
BAU Set activity history for fraud stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -499,8 +499,13 @@ public class AuthorizeHandler {
             }
             case ACTIVITY_CRI_TYPE -> gpg45Score.put(
                     CredentialIssuerConfig.ACTIVITY_PARAM, Integer.parseInt(activityValue));
-            case FRAUD_CRI_TYPE -> gpg45Score.put(
-                    CredentialIssuerConfig.FRAUD_PARAM, Integer.parseInt(fraudValue));
+            case FRAUD_CRI_TYPE -> {
+                gpg45Score.put(CredentialIssuerConfig.FRAUD_PARAM, Integer.parseInt(fraudValue));
+                if (StringUtils.isNotBlank(activityValue)) {
+                    gpg45Score.put(
+                            CredentialIssuerConfig.ACTIVITY_PARAM, Integer.parseInt(activityValue));
+                }
+            }
             case VERIFICATION_CRI_TYPE -> gpg45Score.put(
                     CredentialIssuerConfig.VERIFICATION_PARAM, Integer.parseInt(verificationValue));
             case DOC_CHECK_APP_CRI_TYPE -> {


### PR DESCRIPTION
We noticed the fraud CRI stub was not actually setting the activity history score from the input field - this fixes that