### PR TITLE
BAU: Fix cimit GetContraIndicatorCredential stub return json wrapper.…

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.getcontraindicatorcredential.domain.GetCiCredentialRequest;
+import uk.gov.di.ipv.core.getcontraindicatorcredential.domain.GetCiCredentialResponse;
 import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
 import uk.gov.di.ipv.core.library.service.CimitStubItemService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -34,14 +35,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.vc.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.core.library.vc.VerifiableCredentialConstants.VC_EVIDENCE;
+
 public class GetContraIndicatorCredentialHandler implements RequestStreamHandler {
 
     private static final Logger LOGGER = LogManager.getLogger();
     public static final String SECURITY_CHECK_CREDENTIAL_VC_TYPE = "SecurityCheckCredential";
     public static final String TYPE = "type";
-    public static final String VC_EVIDENCE = "evidence";
-    public static final String CONTRA_INDICATORS = "ci";
-    public static final String VC = "vc";
+    public static final String CONTRA_INDICATORS = "contraIndicator";
     public static final String CODE = "code";
     public static final String FAILURE_RESPONSE = "Failure";
     public static final String MITIGATION = "mitigation";
@@ -92,7 +94,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
                 response = FAILURE_RESPONSE;
             }
         }
-        mapper.writeValue(output, response);
+        mapper.writeValue(output, new GetCiCredentialResponse(response));
     }
 
     private SignedJWT generateJWT(Map<String, Object> claimsSetValues)
@@ -125,7 +127,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
                 .claim(
                         JWTClaimNames.EXPIRATION_TIME,
                         claimsSetValues.get(JWTClaimNames.EXPIRATION_TIME))
-                .claim(VC, claimsSetValues.get(VC))
+                .claim(VC_CLAIM, claimsSetValues.get(VC_CLAIM))
                 .build();
     }
 
@@ -141,7 +143,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
                 OffsetDateTime.now().toEpochSecond(),
                 JWTClaimNames.EXPIRATION_TIME,
                 OffsetDateTime.now().plusSeconds(15 * 60).toEpochSecond(),
-                VC,
+                VC_CLAIM,
                 generateVC(userId));
     }
 

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/domain/GetCiCredentialResponse.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/domain/GetCiCredentialResponse.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.core.getcontraindicatorcredential.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class GetCiCredentialResponse {
+    private String vc;
+}

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
@@ -26,8 +26,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static uk.gov.di.ipv.core.putcontraindicators.domain.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.core.putcontraindicators.domain.VerifiableCredentialConstants.VC_EVIDENCE;
+import static uk.gov.di.ipv.core.library.vc.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.core.library.vc.VerifiableCredentialConstants.VC_EVIDENCE;
 
 public class ContraIndicatorsService {
     private static final Logger LOGGER = LogManager.getLogger();

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/vc/VerifiableCredentialConstants.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/vc/VerifiableCredentialConstants.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.putcontraindicators.domain;
+package uk.gov.di.ipv.core.library.vc;
 
 public class VerifiableCredentialConstants {
     private VerifiableCredentialConstants() {


### PR DESCRIPTION
… Also fixed vc's evidence field now called contraIndicator instead of ci.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
- Fix cimit GetContraIndicatorCredential stub return json wrapper instead String. (core-back side done PYIC-3033 (e34398))
- Revert back previous change to vc object evidence field now called 'contraIndicator' instead of 'ci'.

### What changed
- Fix cimit GetContraIndicatorCredential stub return json wrapper. 
- Also fixed vc's evidence field now called contraIndicator instead of ci.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-XXXX](https://govukverify.atlassian.net/browse/PYI-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
