### PR TITLE
PYIC-3386: Add cross account perms to cimit stubs

### DIFF
--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -61,6 +61,13 @@ Conditions:
           - !Ref CodeSigningConfigArn
           - "none"
 
+Mappings:
+  CoreAccounts:
+    dev:
+      accountId: "175872367215"
+    build:
+      accountId: "457601271792"
+
 Resources:
   # lambda to stub cimit getContraIndicators
   GetContraIndicatorsFunction:
@@ -100,6 +107,20 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
 
+  GetContraIndicatorsFunctionCoreDevInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GetContraIndicatorsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev, accountId ]
+
+  GetContraIndicatorsFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GetContraIndicatorsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
   # lambda to stub cimit postMitigations
   PostMitigationsFunction:
     Type: AWS::Serverless::Function
@@ -131,6 +152,20 @@ Resources:
       Policies:
         - VPCAccessPolicy: { }
       AutoPublishAlias: live
+
+  PostMitigationsFunctionCoreDevInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PostMitigationsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev, accountId ]
+
+  PostMitigationsFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PostMitigationsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
   # lambda to stub cimit putContraIndicators
   PutContraIndicatorsFunction:
@@ -173,6 +208,20 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
 
+  PutContraIndicatorsFunctionCoreDevInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PutContraIndicatorsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev, accountId ]
+
+  PutContraIndicatorsFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PutContraIndicatorsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
   # lambda to stub cimit getContraIndicatorCredential
   GetContraIndicatorCredentialFunction:
     Type: AWS::Serverless::Function
@@ -212,6 +261,20 @@ Resources:
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
+
+  GetContraIndicatorCredentialFunctionCoreDevInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GetContraIndicatorCredentialFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev, accountId ]
+
+  GetContraIndicatorCredentialFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GetContraIndicatorCredentialFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
   # lambda to stub management
   StubManagementFunction:
@@ -278,8 +341,6 @@ Resources:
             RestApiId: !Ref RestApiGateway
             Path: /user/{userId}/mitigations/{ci}
             Method: PUT
-
-
 
   GetContraIndicatorsFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add cross account perms to cimit stubs

### Why did it change

When the cimit stub is deployed to the stubs accounts (build and prod), they will need to be given a lambda invoke permission, with the core accounts as the principal. Otherwise core won’t be able to call them.

This hasn’t been a problem before as we’ve been testing entirely in the dev account, so no cross account access.

We should give the stubs build and prod deploy the perms to allow dev and build core envs to invoke them. This will allow a more flexible approach (we can hook up to whatever stub we want from either core account), whilst keeping the stub reasonably locked down. Another approach is to give our AWS org permissions to invoke the lambdas, but that leaves them open to anyone at GDS.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3386](https://govukverify.atlassian.net/browse/PYI-3386)
