### PR TITLE
PYIC 3382 Update CRI pages to have field for mitigated CI's and for base URL of the CIMIT stub management API for DCMAW CRI.

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -381,6 +381,32 @@
                                 </div>
                             </td>
                         </tr>
+                        {{#isDocCheckingType}}
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <div class="govuk-form-group">
+                                        <h1 class="govuk-label-wrapper">
+                                            <label class="govuk-label govuk-label--l" for="ciMitigated">
+                                                Mitigations (optional)
+                                            </label>
+                                        </h1>
+                                        <div id="ci-miti-more-detail-hint" class="govuk-hint">
+                                            Please provide a comma-separated mitigated CI list e.g. A01,D02
+                                        </div>
+                                        <textarea class="govuk-textarea" id="ciMitigated" name="ciMitigated" rows="1" aria-describedby="ci-miti-more-detail-hint"></textarea>
+                                        <div id="ci-miti-base-url-hint" class="govuk-hint">
+                                            Please provide base URL of the CIMIT stub management API e.g for dev-> https://cimit-dev-{user}.core.dev.stubs.account.gov.uk,
+                                            for build-> https://cimit.stubs.account.gov.uk
+                                        </div>
+                                        <textarea class="govuk-textarea" id="ciMitiBaseUrl" name="ciMitiBaseUrl" rows="1" aria-describedby="ci-miti-base-url-hint"></textarea>
+                                        <div id="ci-miti-api-key-hint" class="govuk-hint">
+                                            Please provide corresponding API key
+                                        </div>
+                                        <textarea class="govuk-textarea" id="ciMitiApiKey" name="ciMitiApiKey" rows="1" aria-describedby="ci-miti-api-key-hint"></textarea>
+                                    </div>
+                                </td>
+                            </tr>
+                        {{/isDocCheckingType}}
 
                         {{^isUserAssertedType}}
                             <tr class="govuk-table__row">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Update CRI pages to have field for mitigated CI's and for base URL of the CIMIT stub management API

### What changed
- Updated CRI stub page to have new field for list of mitigated CI and only enable for only DCMAW cri.
- Updated CRI stub page to add input field to provide the base URL of the CIMIT stub management API. (PYIC-3383)
- Updated CRI stub page to add input field to provide the API key for the above base URL of the CIMIT stub management API. (PYIC-3383)

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3382](https://govukverify.atlassian.net/browse/PYI-3382)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
