### PR TITLE
BAU: Fix iss value for legacy endpoint to be componentId.

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -48,9 +48,9 @@ import static uk.gov.di.ipv.core.library.vc.VerifiableCredentialConstants.VC_EVI
 @ExtendWith({SystemStubsExtension.class, MockitoExtension.class})
 class GetContraIndicatorCredentialHandlerTest {
 
-    public static final String USER_ID = "user_id";
-    public static final String CI_V_03 = "V03";
-    public static final String MITIGATION_M_01 = "M01";
+    private static final String USER_ID = "user_id";
+    private static final String CI_V_03 = "V03";
+    private static final String MITIGATION_M_01 = "M01";
     private static final String CIMIT_PRIVATE_KEY =
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM+QJXk0PI339EyYkt6tjgfS+RcOMQNO";
     private static final String CIMIT_PUBLIC_JWK =

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicators/src/main/java/uk/gov/di/ipv/core/getcontraindicators/GetContraIndicatorsHandler.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicators/src/main/java/uk/gov/di/ipv/core/getcontraindicators/GetContraIndicatorsHandler.java
@@ -67,6 +67,7 @@ public class GetContraIndicatorsHandler implements RequestStreamHandler {
                                 ContraIndicatorItem.builder()
                                         .ci(item.getContraIndicatorCode())
                                         .ttl(Long.toString(item.getTtl()))
+                                        .iss(configService.getCimitComponentId())
                                         .userId(userId)
                                         .build())
                 .collect(Collectors.toList());

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicators/src/test/java/uk/gov/di/ipv/core/getcontraindicators/GetContraIndicatorsHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicators/src/test/java/uk/gov/di/ipv/core/getcontraindicators/GetContraIndicatorsHandlerTest.java
@@ -31,8 +31,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class GetContraIndicatorsHandlerTest {
 
-    public static final String USER_ID = "user_id";
-    public static final String CI_V_03 = "V03";
+    private static final String USER_ID = "user_id";
+    private static final String CI_V_03 = "V03";
+    private static final String CIMIT_COMPONENT_ID = "https://cimit.stubs.account.gov.uk";
     private static final ObjectMapper mapper = new ObjectMapper();
     @Mock private Context mockContext;
     @Mock private ConfigService mockConfigService;
@@ -75,6 +76,7 @@ class GetContraIndicatorsHandlerTest {
                         .ttl(505L)
                         .build());
         when(mockCimitStubItemService.getCIsForUserId(USER_ID)).thenReturn(cimitStubItems);
+        when(mockConfigService.getCimitComponentId()).thenReturn(CIMIT_COMPONENT_ID);
 
         var response =
                 makeRequest(
@@ -85,6 +87,7 @@ class GetContraIndicatorsHandlerTest {
 
         assertFalse(response.getContraIndicators().isEmpty());
         assertEquals(CI_V_03, response.getContraIndicators().get(0).getCi());
+        assertEquals(CIMIT_COMPONENT_ID, response.getContraIndicators().get(0).getIss());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Fix issue with legacy endpoint for getContraindicator.

### What changed
Fixed iss value for legacy endpoint to be componentId.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-XXXX](https://govukverify.atlassian.net/browse/PYI-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
