### PR TITLE
PYIC-3402: Fix silent failure in BuildUserIdentityDetails when no invoke permissions on getContraIndicatorCredential lambda

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -188,6 +188,15 @@ public class IpvHandler {
 
         HTTPResponse userInfoHttpResponse = sendHttpRequest(userInfoRequest.toHTTPRequest());
 
+        int statusCode = userInfoHttpResponse.getStatusCode();
+        if (statusCode != HTTPResponse.SC_OK) {
+            logger.error(
+                    "User info request failed with status code {}: {} ",
+                    statusCode,
+                    userInfoHttpResponse.getContent());
+            throw new RuntimeException("User info request failed with status code " + statusCode);
+        }
+
         try {
             return userInfoHttpResponse.getContentAsJSONObject();
         } catch (ParseException e) {
@@ -196,17 +205,11 @@ public class IpvHandler {
     }
 
     private List<Map<String, Object>> buildMustacheData(JSONObject credentials)
-            throws ParseException, JsonSyntaxException, java.text.ParseException,
-                    OrchestratorStubException {
+            throws ParseException, JsonSyntaxException, java.text.ParseException {
         List<Map<String, Object>> moustacheDataModel = new ArrayList<>();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         List<String> vcJwts = (List<String>) credentials.get(CREDENTIALS_URL_PROPERTY);
-
-        if (vcJwts == null) {
-            logger.error("The list of VC JWTs is null.");
-            throw new OrchestratorStubException("The list of VC JWTs is null.");
-        }
 
         for (String vc : vcJwts) {
             SignedJWT signedJWT = SignedJWT.parse(vc);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -190,11 +190,13 @@ public class IpvHandler {
 
         int statusCode = userInfoHttpResponse.getStatusCode();
         if (statusCode != HTTPResponse.SC_OK) {
-            logger.error(
-                    "User info request failed with status code {}: {} ",
-                    statusCode,
-                    userInfoHttpResponse.getContent());
-            throw new RuntimeException("User info request failed with status code " + statusCode);
+            var errorMessage =
+                    "User info request failed with status code "
+                            + statusCode
+                            + ": "
+                            + userInfoHttpResponse.getContent();
+            logger.error(errorMessage);
+            throw new RuntimeException(errorMessage);
         }
 
         try {

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -196,11 +196,17 @@ public class IpvHandler {
     }
 
     private List<Map<String, Object>> buildMustacheData(JSONObject credentials)
-            throws ParseException, JsonSyntaxException, java.text.ParseException {
+            throws ParseException, JsonSyntaxException, java.text.ParseException,
+                    OrchestratorStubException {
         List<Map<String, Object>> moustacheDataModel = new ArrayList<>();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         List<String> vcJwts = (List<String>) credentials.get(CREDENTIALS_URL_PROPERTY);
+
+        if (vcJwts == null) {
+            logger.error("The list of VC JWTs is null.");
+            throw new OrchestratorStubException("The list of VC JWTs is null.");
+        }
 
         for (String vc : vcJwts) {
             SignedJWT signedJWT = SignedJWT.parse(vc);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix silent failure in BuildUserIdentityDetails when no invoke permissions on getContraIndicatorCredential lambda

### Why did it change

Handing this exception

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3402](https://govukverify.atlassian.net/browse/PYIC-3402)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3402]: https://govukverify.atlassian.net/browse/PYIC-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ