### PR TITLE
PYIC-3470: Add 'Kenneth Decerqueira' Persona to DCMAW stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -1021,6 +1021,37 @@
           }
         ]
       }
+    },
+    {
+      "criType": "DOC Checking App (Stub)",
+      "label": "Kenneth Decerqueira (Valid Experian) Passport",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Kenneth",
+                "type": "GivenName"
+              },
+              {
+                "value": "Decerqueira",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "birthDate": [
+          {
+            "value": "1965-07-08"
+          }
+        ],
+        "passport": [
+          {
+            "documentNumber": "321654987",
+            "expiryDate": "2030-01-01"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add 'Kenneth Decerqueira' Persona to DCMAW stub

### Why did it change

DCMAW is missing web journey personas required for mitigation feature tests.
QA have identified that the following personas need to be added to DCMAW stub:

Kenneth Decerqueira (valid Experian passport)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3470](https://govukverify.atlassian.net/browse/PYIC-3470)


[PYIC-3470]: https://govukverify.atlassian.net/browse/PYIC-3470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ