### PR TITLE
LIME-773 Add driving permit dev environment var to core-stub template

### DIFF
--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -39,6 +39,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+  ApiKeyCriDrivingPermitDev:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_DL_DEV" #pragma: allowlist secret
   ApiKeyCriPassportDev:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -626,6 +630,8 @@ Resources:
             Value: !Ref CoreStubEnableBackendRoutes
           - Name: CORE_STUB_BASIC_AUTH
             Value: !Ref CoreStubBasicAuth
+          - Name: API_KEY_CRI_DL_DEV
+            Value: !Ref ApiKeyCriDrivingPermitDev
           - Name: API_KEY_CRI_PASSPORTA_DEV
             Value: !Ref ApiKeyCriPassportDev
           - Name: API_KEY_CRI_ADDRESS_BUILD


### PR DESCRIPTION
## Proposed changes

### What changed

Add driving permit dev environment var to core-stub template

### Why did it change

DL dev environment journeys are stopping at the public api due to the missing key

### Issue tracking

- [LIME-773](https://govukverify.atlassian.net/browse/LIME-773)



[LIME-773]: https://govukverify.atlassian.net/browse/LIME-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ