### PR TITLE
BAU: Make CRI stub health check less noisy

### DIFF
--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -375,7 +375,7 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       Matcher:
-        HttpCode: 404
+        HttpCode: 200
       Port: 8080
       Protocol: HTTP
       TargetType: ip

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.stub.cred.handlers.AuthorizeHandler;
 import uk.gov.di.ipv.stub.cred.handlers.CredentialHandler;
 import uk.gov.di.ipv.stub.cred.handlers.DocAppCredentialHandler;
 import uk.gov.di.ipv.stub.cred.handlers.F2FHandler;
+import uk.gov.di.ipv.stub.cred.handlers.HealthCheckHandler;
 import uk.gov.di.ipv.stub.cred.handlers.JwksHandler;
 import uk.gov.di.ipv.stub.cred.handlers.TokenHandler;
 import uk.gov.di.ipv.stub.cred.service.AuthCodeService;
@@ -30,6 +31,7 @@ public class CredentialIssuer {
     private final DocAppCredentialHandler docAppCredentialHandler;
     private final JwksHandler jwksHandler;
     private final F2FHandler f2fHandler;
+    private final HealthCheckHandler healthCheckHandler;
 
     public CredentialIssuer() {
         Spark.staticFileLocation("/public");
@@ -68,12 +70,14 @@ public class CredentialIssuer {
                         requestedErrorResponseService);
         jwksHandler = new JwksHandler();
         f2fHandler = new F2FHandler(credentialService, tokenService);
+        healthCheckHandler = new HealthCheckHandler();
 
         initRoutes();
         initErrorMapping();
     }
 
     private void initRoutes() {
+        Spark.get("/", healthCheckHandler.healthy);
         Spark.get("/authorize", authorizeHandler.doAuthorize);
         Spark.post("/authorize", authorizeHandler.generateResponse);
         Spark.post("/token", tokenHandler.issueAccessToken);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/HealthCheckHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/HealthCheckHandler.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.stub.cred.handlers;
+
+import org.eclipse.jetty.http.HttpStatus;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+public class HealthCheckHandler {
+
+    public Route healthy =
+            (Request request, Response response) -> {
+                response.status(HttpStatus.OK_200);
+                return "{\"OK?\":\"yep\"}";
+            };
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Make CRI stub health check less noisy

### Why did it change

The ALB healthcheck for the CRI is configured to send a GET request to `/` and check for a 404 http status response.

This route isn't mapped in Spark which generates the required 404, but it does fill the logs with junk moaning about the route not being mapped.

This adds a handler for that route that returns a 200 response, and updates the healthcheck to expect a 200 instead of a 404.
