### PR TITLE
BAU: Provide stubs-prod CiMit stub URL as default

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -392,14 +392,14 @@
                                             </label>
                                         </h1>
                                         <div id="ci-miti-more-detail-hint" class="govuk-hint">
-                                            Please provide a comma-separated mitigated CI list e.g. A01,D02
+                                            Please provide a comma-separated list of CIs to mitigate e.g. X01,X02
                                         </div>
                                         <textarea class="govuk-textarea" id="ciMitigated" name="ciMitigated" rows="1" aria-describedby="ci-miti-more-detail-hint"></textarea>
                                         <div id="ci-miti-base-url-hint" class="govuk-hint">
                                             Please provide base URL of the CIMIT stub management API e.g for dev-> https://cimit-dev-{user}.core.dev.stubs.account.gov.uk,
-                                            for build-> https://cimit.build.stubs.account.gov.uk
+                                            for build-> https://cimit.stubs.account.gov.uk
                                         </div>
-                                        <textarea class="govuk-textarea" id="ciMitiBaseUrl" name="ciMitiBaseUrl" rows="1" aria-describedby="ci-miti-base-url-hint"></textarea>
+                                        <textarea class="govuk-textarea" id="ciMitiBaseUrl" name="ciMitiBaseUrl" rows="1" aria-describedby="ci-miti-base-url-hint">https://cimit.stubs.account.gov.uk</textarea>
                                         <div id="ci-miti-api-key-hint" class="govuk-hint">
                                             Please provide corresponding API key
                                         </div>


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Provide stubs-prod CiMit stub URL as default

### Why did it change

The dev and build envs are going to be configured to use the stubs-prod deploy of out CiMit stub. It would be helpful to have the correct URL for the mitigations admin endpoint already configured. Think of the cost saving for all those less worn keyboard keys...
