### PR TITLE
BAU: Ensure CRI stub jti conforms to RFC 3986

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -40,6 +40,7 @@ import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VERIFIABL
 public class VerifiableCredentialGenerator {
 
     public static final String EC_ALGO = "EC";
+    static final String JTI_SCHEME_AND_PATH_PREFIX = "urn:uuid";
 
     public SignedJWT generate(Credential credential)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
@@ -103,7 +104,11 @@ public class VerifiableCredentialGenerator {
                                 CredentialIssuerConfig.getClientConfig(credential.getClientId())
                                         .getAudienceForVcJwt())
                         .claim(NOT_BEFORE, now.getEpochSecond())
-                        .claim(JWT_ID, UUID.randomUUID().toString())
+                        .claim(
+                                JWT_ID,
+                                String.format(
+                                        "%s:%s",
+                                        JTI_SCHEME_AND_PATH_PREFIX, UUID.randomUUID().toString()))
                         .claim(VC_CLAIM, vc);
         if (!Objects.isNull(credential.getExp())) {
             claim = claim.claim(EXPIRATION_TIME, credential.getExp());


### PR DESCRIPTION
## Proposed changes

### What changed
Amend CRI Stub VCs `jti` to be an RFC 3986 URI. 

### Why did it change
SPoT expects `jti` to conform to RFC 3986.

### Issue tracking
n/a

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations
