### PR TITLE
BAU: URL encode userId when using CiMit management API

### DIFF
--- a/di-ipv-cimit-stub/lambdas/stub-management/src/main/java/uk/gov/di/ipv/core/stubmanagement/StubManagementHandler.java
+++ b/di-ipv-cimit-stub/lambdas/stub-management/src/main/java/uk/gov/di/ipv/core/stubmanagement/StubManagementHandler.java
@@ -16,6 +16,8 @@ import uk.gov.di.ipv.core.stubmanagement.service.UserService;
 import uk.gov.di.ipv.core.stubmanagement.service.impl.UserServiceImpl;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -48,8 +50,11 @@ public class StubManagementHandler
         String path = event.getPath();
 
         Map<String, String> pathParameters = event.getPathParameters();
-        String userId = pathParameters.get(USER_ID_PATH_PARAMS);
         try {
+            String userId =
+                    URLDecoder.decode(
+                            pathParameters.get(USER_ID_PATH_PARAMS),
+                            StandardCharsets.UTF_8.toString());
             if (CIS_PATTERN.matcher(path).matches()) {
                 List<UserCisRequest> userCisRequests =
                         objectMapper.readValue(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/error/CriStubException.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/error/CriStubException.java
@@ -2,11 +2,15 @@ package uk.gov.di.ipv.stub.cred.error;
 
 public class CriStubException extends Exception {
 
-    private final String description;
+    private String description;
 
     public CriStubException(String message, String description) {
         super(message);
         this.description = description;
+    }
+
+    public CriStubException(String message, Throwable cause) {
+        super(message, cause);
     }
 
     public CriStubException(String message, String description, Throwable cause) {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -50,9 +50,11 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
@@ -452,8 +454,15 @@ public class AuthorizeHandler {
                     Stream.of(mitigatedCIsString.split(",", -1)).collect(Collectors.toList());
             String postUrlTemplate = "/user/%s/mitigations/%s";
             for (String ciCode : mitigatedCiList) {
+                String encodedUserId;
+                try {
+                    encodedUserId = URLEncoder.encode(userId, StandardCharsets.UTF_8.toString());
+                } catch (UnsupportedEncodingException e) {
+                    throw new CriStubException("Unable to URL encode userId", e);
+                }
                 String postUrl =
-                        baseStubManagedPostUrl + String.format(postUrlTemplate, userId, ciCode);
+                        baseStubManagedPostUrl
+                                + String.format(postUrlTemplate, encodedUserId, ciCode);
                 LOGGER.info("Managed cimit stub postUrl:{}", postUrl);
                 try {
                     HttpRequest request =


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

URL encode userId when using CiMit management API

### Why did it change

We've seen some failures when mitigating CIs from the CRI stub. This happens when the user ID is in the format `urn:uuid:kjddf....`. This is the correct format and is the format used by the orch stub if you don't override it.

However the user ID is used as part of the URL when hitting the CiMit stub management endpoint and having the colons breaks things.

This URL encodes them so the user ID is safe.
