### PR TITLE
PYIC-3318: generate and display uuid on start page

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
@@ -5,11 +5,18 @@ import spark.Response;
 import spark.Route;
 import uk.gov.di.ipv.stub.orc.utils.ViewHelper;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 public class HomeHandler {
     public static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     public static final String NON_APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:";
     public static Route serveHomePage =
             (Request request, Response response) -> {
-                return ViewHelper.render(null, "home.mustache");
+                Map<String, Object> moustacheDataModel = new HashMap<>();
+                String uuid = NON_APP_JOURNEY_USER_ID_PREFIX + UUID.randomUUID();
+                moustacheDataModel.put("uuid", uuid);
+                return ViewHelper.render(moustacheDataModel, "home.mustache");
             };
 }

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -57,7 +57,7 @@
             <input type="hidden" name="journeyType" value="full" />
             <div class="govuk-form-group">
                 <label class="govuk-label" for="userIdText">Enter userId manually</label>
-                <input class="govuk-input" data-module="govuk-input" name="userIdText" id="userIdText" type="text" value="">
+                <input class="govuk-input" data-module="govuk-input" name="userIdText" id="userIdText" type="text" value={{uuid}}>
             </div>
 
             <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Generate unique userid and display on start page.

### What changed

- Login page now will be with autogenerated uuid. 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- Update login page to display the uuid so it can be easily copied/saved for testing.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3318](https://govukverify.atlassian.net/browse/PYI-3318)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


<img width="1041" alt="Screenshot 2023-09-26 at 14 03 02" src="https://github.com/alphagov/di-ipv-stubs/assets/3963744/d5d6fc27-806b-43a5-8454-8923d05ad6d3">


