### PR TITLE
PYIC-3589: Allow redirection from stubs to localhost for debugging

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 public class Validator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Validator.class);
-    private static final String PAAS_DOMAIN = ".london.cloudapps.digital";
+    private static final String LOCALHOST_DOMAIN = "localhost";
     private static final String INVALID_GPG45_SCORE_ERROR_CODE = "1001";
     private static final String INVALID_EVIDENCE_VALUES_ERROR_CODE = "1002";
     private static final String INVALID_ACTIVITY_VALUES_ERROR_CODE = "1003";
@@ -116,7 +116,7 @@ public class Validator {
 
         LOGGER.info("Validating client redirect uri: {}", redirectUri);
 
-        if (isRedirectUriPaasDomain(redirectUri)
+        if (isRedirectUriLocalhost(redirectUri)
                 || isRedirectUriAmazonApiGatewayCallback(redirectUri)
                 || isRedirectUriDevDomain(redirectUri)) {
             return false;
@@ -128,19 +128,8 @@ public class Validator {
         return !validRedirectUrls.contains(redirectUri);
     }
 
-    /**
-     * To simplify the configuration of the CRI stubs they will accept any redirectUri that includes
-     * the London PaaS Domain. This removes the need to configure the stub with the redirect uri of
-     * each of the developer environments which share the common stubs.
-     *
-     * <p>Keeping some redirect uri validation will still permit developers to check the behaviour
-     * when required.
-     *
-     * @param redirectUri
-     * @return true if the redirect uri includes the London PaaS Domain
-     */
-    private static boolean isRedirectUriPaasDomain(String redirectUri) {
-        return redirectUri != null && redirectUri.contains(PAAS_DOMAIN);
+    private static boolean isRedirectUriLocalhost(String redirectUri) {
+        return redirectUri != null && redirectUri.contains(LOCALHOST_DOMAIN);
     }
 
     private static boolean isRedirectUriDevDomain(String redirectUri) {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow redirection from stubs to localhost
Also remove the PAAS domain as that is obsolete

### Why did it change

To run core-front locally for debugging or testing we would like to allow the stubs to redirect back to the local core-front.

This PR replaces the obsolete check fro GOV PaaS with the check for local host.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3589](https://govukverify.atlassian.net/browse/PYI-3589)

## Checklists

