### PR TITLE
BAU: Update DCMAW stubs evidence data

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -94,7 +94,7 @@
           },
           {
             "checkMethod": "bvr",
-            "biometricVerificationProcessLevel": 2
+            "biometricVerificationProcessLevel": 3
           }
         ]
       }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update DCMAW stubs evidence data

### Why did it change

The DCMAW CRI will always return a 3 for
biometricVerificationProcessLevel.

Our canned evidence payload for a successful check was only setting it to 2.
