### PR TITLE
PYIC-3319: Display signInJourneyId on ui before starting journey

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
@@ -1,13 +1,13 @@
 package uk.gov.di.ipv.stub.orc.handlers;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import spark.Request;
 import spark.Response;
 import spark.Route;
 import uk.gov.di.ipv.stub.orc.utils.ViewHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class HomeHandler {
     public static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
@@ -15,7 +15,7 @@ public class HomeHandler {
     public static Route serveHomePage =
             (Request request, Response response) -> {
                 Map<String, Object> moustacheDataModel = new HashMap<>();
-                
+
                 String journeyId = UUID.randomUUID().toString();
                 moustacheDataModel.put("signInJourneyId", journeyId);
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
@@ -1,5 +1,9 @@
 package uk.gov.di.ipv.stub.orc.handlers;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -10,6 +14,11 @@ public class HomeHandler {
     public static final String NON_APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:";
     public static Route serveHomePage =
             (Request request, Response response) -> {
-                return ViewHelper.render(null, "home.mustache");
+                Map<String, Object> moustacheDataModel = new HashMap<>();
+                
+                String journeyId = UUID.randomUUID().toString();
+                moustacheDataModel.put("signInJourneyId", journeyId);
+
+                return ViewHelper.render(moustacheDataModel, "home.mustache");
             };
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -77,11 +77,12 @@ public class IpvHandler {
                 String errorType = request.queryMap().get("error").value();
                 String userIdTextValue = request.queryMap().get("userIdText").value();
                 String signInJourneyIdText = request.queryMap().get("signInJourneyIdText").value();
-                
+
                 String userId = getUserIdValue(userIdTextValue);
                 String journeyId = getSignInJourneyId(signInJourneyIdText);
 
-                JWTClaimsSet claims = JwtBuilder.buildAuthorizationRequestClaims(userId, journeyId, errorType);
+                JWTClaimsSet claims =
+                        JwtBuilder.buildAuthorizationRequestClaims(userId, journeyId, errorType);
                 SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
                 EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt);
                 var authRequest =

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -76,9 +76,12 @@ public class IpvHandler {
 
                 String errorType = request.queryMap().get("error").value();
                 String userIdTextValue = request.queryMap().get("userIdText").value();
+                String signInJourneyIdText = request.queryMap().get("signInJourneyIdText").value();
+                
                 String userId = getUserIdValue(userIdTextValue);
+                String journeyId = getSignInJourneyId(signInJourneyIdText);
 
-                JWTClaimsSet claims = JwtBuilder.buildAuthorizationRequestClaims(userId, errorType);
+                JWTClaimsSet claims = JwtBuilder.buildAuthorizationRequestClaims(userId, journeyId, errorType);
                 SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
                 EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt);
                 var authRequest =
@@ -263,5 +266,13 @@ public class IpvHandler {
         }
 
         return URN_UUID + UUID.randomUUID();
+    }
+
+    private String getSignInJourneyId(String signInJourneyId) {
+        if (signInJourneyId.isEmpty()) {
+            return URN_UUID + UUID.randomUUID();
+        }
+
+        return signInJourneyId;
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -79,10 +79,11 @@ public class IpvHandler {
                 String signInJourneyIdText = request.queryMap().get("signInJourneyIdText").value();
 
                 String userId = getUserIdValue(userIdTextValue);
-                String journeyId = getSignInJourneyId(signInJourneyIdText);
 
                 JWTClaimsSet claims =
-                        JwtBuilder.buildAuthorizationRequestClaims(userId, journeyId, errorType);
+                        JwtBuilder.buildAuthorizationRequestClaims(
+                                userId, signInJourneyIdText, errorType);
+
                 SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
                 EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt);
                 var authRequest =
@@ -267,13 +268,5 @@ public class IpvHandler {
         }
 
         return URN_UUID + UUID.randomUUID();
-    }
-
-    private String getSignInJourneyId(String signInJourneyId) {
-        if (signInJourneyId.isEmpty()) {
-            return URN_UUID + UUID.randomUUID();
-        }
-
-        return signInJourneyId;
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -44,7 +44,8 @@ public class JwtBuilder {
     public static final String INVALID_AUDIENCE = "invalid-audience";
     public static final String INVALID_REDIRECT_URI = "http://example.com";
 
-    public static JWTClaimsSet buildAuthorizationRequestClaims(String userId, String signInJourneyId, String errorType) {
+    public static JWTClaimsSet buildAuthorizationRequestClaims(
+            String userId, String signInJourneyId, String errorType) {
         String audience = IPV_CORE_AUDIENCE;
         String redirectUri = ORCHESTRATOR_REDIRECT_URL;
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -44,9 +44,10 @@ public class JwtBuilder {
     public static final String INVALID_AUDIENCE = "invalid-audience";
     public static final String INVALID_REDIRECT_URI = "http://example.com";
 
-    public static JWTClaimsSet buildAuthorizationRequestClaims(String userId, String errorType) {
+    public static JWTClaimsSet buildAuthorizationRequestClaims(String userId, String signInJourneyId, String errorType) {
         String audience = IPV_CORE_AUDIENCE;
         String redirectUri = ORCHESTRATOR_REDIRECT_URL;
+
         if (errorType != null) {
             if (errorType.equals("recoverable")) {
                 audience = INVALID_AUDIENCE;
@@ -67,7 +68,7 @@ public class JwtBuilder {
                 .claim("response_type", ResponseType.Value.CODE.toString())
                 .claim("redirect_uri", redirectUri)
                 .claim("state", UUID.randomUUID().toString())
-                .claim("govuk_signin_journey_id", UUID.randomUUID().toString())
+                .claim("govuk_signin_journey_id", signInJourneyId)
                 .claim("persistent_session_id", UUID.randomUUID().toString())
                 .claim("email_address", "dev-platform-testing@digital.cabinet-office.gov.uk")
                 .build();

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -59,6 +59,10 @@
                 <label class="govuk-label" for="userIdText">Enter userId manually</label>
                 <input class="govuk-input" data-module="govuk-input" name="userIdText" id="userIdText" type="text" value="">
             </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="signInJourneyIdText">Sign In Journey Id</label>
+                <input class="govuk-input" data-module="govuk-input" name="signInJourneyIdText" id="signInJourneyIdText" type="text" value={{signInJourneyId}} readonly="readonly">
+            </div>
 
             <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
         </form>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`SignInJourneyId` is now being generated as a UUID on page load, and displayed in the UI before being passed to `/authorize` as a form parameter. 

This is instead of generating the UUID on submission as before. 

### Why did it change

Changed so we can display `signInJourneyId` to the user for easier tracking the journey in logs 

<img width="1728" alt="Screenshot 2023-09-28 at 16 59 59" src="https://github.com/alphagov/di-ipv-stubs/assets/143799384/5c7ae333-8592-400e-95fe-f2e307cf10cf">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3319](https://govukverify.atlassian.net/browse/PYI-3319)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
