### PR TITLE
Pyic 3321 orch stub basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The Orchestrator Stub allows the user to select desired attributes then initiate
 
 On completion of the user journey the Orchestrator Stub receives an authorisation code which it will exchange for an access token and in turn use to access the protected resource in the IPV system. Finally the Orchestrator Stub will display the contents of the protected resource.
 
+By default the orchestrator stub is protected by HTTP basic authentication. The username and password must be configured manually in SSM under `/stubs/<environment>/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS` in the form `{ "username": "example-name", "password": "example-password" }`
+To turn off HTTP basic authentication override the `EnableBasicAuth` deployment template parameter with the value `false` (note that the SSM username and password value must still exist even when HTTP basic authentication is disabled or deployments will fail.)
+
 ## Credential Issuer Stub
 `di-ipv-credential-issuer-stub` [/di-ipv-credential-issuer-stub](/di-ipv-credential-issuer-stub)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Orchestrator Stub allows the user to select desired attributes then initiate
 On completion of the user journey the Orchestrator Stub receives an authorisation code which it will exchange for an access token and in turn use to access the protected resource in the IPV system. Finally the Orchestrator Stub will display the contents of the protected resource.
 
 By default the orchestrator stub is protected by HTTP basic authentication. The username and password must be configured manually in SSM under `/stubs/<environment>/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS` in the form `{ "username": "example-name", "password": "example-password" }`
-To turn off HTTP basic authentication override the `EnableBasicAuth` deployment template parameter with the value `false` (note that the SSM username and password value must still exist even when HTTP basic authentication is disabled or deployments will fail.)
+To turn off HTTP basic authentication override the `OrchestratorEnableBasicAuth` deployment template parameter with the value `false` (note that the SSM username and password value must still exist even when HTTP basic authentication is disabled or deployments will fail.)
 
 ## Credential Issuer Stub
 `di-ipv-credential-issuer-stub` [/di-ipv-credential-issuer-stub](/di-ipv-credential-issuer-stub)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The Orchestrator Stub allows the user to select desired attributes then initiate
 
 On completion of the user journey the Orchestrator Stub receives an authorisation code which it will exchange for an access token and in turn use to access the protected resource in the IPV system. Finally the Orchestrator Stub will display the contents of the protected resource.
 
-By default the orchestrator stub is protected by HTTP basic authentication. The username and password must be configured manually in SSM under `/stubs/<environment>/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS` in the form `{ "username": "example-name", "password": "example-password" }`
-To turn off HTTP basic authentication override the `OrchestratorEnableBasicAuth` deployment template parameter with the value `false` (note that the SSM username and password value must still exist even when HTTP basic authentication is disabled or deployments will fail.)
+By default the orchestrator stub is protected by HTTP basic authentication. The username and password are configured in SSM under `/stubs/<environment>/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME` and`/stubs/<environment>/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSOWRD`.
+To turn off HTTP basic authentication override the `OrchestratorBasicAuthEnable` deployment template parameter with the value `false` (note that the SSM username and password value must still exist even when HTTP basic authentication is disabled or deployments will fail.)
 
 ## Credential Issuer Stub
 `di-ipv-credential-issuer-stub` [/di-ipv-credential-issuer-stub](/di-ipv-credential-issuer-stub)

--- a/di-ipv-orchestrator-stub/deploy-build/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-build/template.yaml
@@ -392,7 +392,8 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       Matcher:
-        HttpCode: 200
+        # If basic auth is on then the site will return a 401
+        HttpCode: "200,401"
       Port: 8080
       Protocol: HTTP
       TargetType: ip

--- a/di-ipv-orchestrator-stub/deploy-build/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-build/template.yaml
@@ -52,6 +52,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/build/orch/env/ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+  OrchestratorBasicAuthEnable:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
+  OrchestratorBasicAuthUsername:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
+  OrchestratorBasicAuthPassword:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
   IpvBackchannelEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -84,14 +96,6 @@ Parameters:
     #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     #    Type: AWS::SSM::Parameter::Value<String>
     #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
-  OrchestratorEnableBasicAuth:
-    Description: "Environment Variables for ECS"
-    Type: String
-    Default: "true" #pragma: allowlist secret
-  OrchestratorBasicAuthCredentials:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -537,10 +541,12 @@ Resources:
             Value: !Ref IpvEndpoint
           - Name: IPV_CORE_AUDIENCE
             Value: !Ref IpvCoreAudience
-          - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
-            Value: !Ref OrchestratorEnableBasicAuth
-          - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
-            Value: !Ref OrchestratorBasicAuthCredentials
+          - Name: ORCHESTRATOR_BASIC_AUTH_ENABLE
+            Value: !Ref OrchestratorBasicAuthEnable
+          - Name: ORCHESTRATOR_BASIC_AUTH_USERNAME
+            Value: !Ref OrchestratorBasicAuthUsername
+          - Name: ORCHESTRATOR_BASIC_AUTH_PASSWORD
+            Value: !Ref OrchestratorBasicAuthPassword
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-build/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-build/template.yaml
@@ -84,6 +84,14 @@ Parameters:
     #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     #    Type: AWS::SSM::Parameter::Value<String>
     #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
+  OrchestratorEnableBasicAuth:
+    Description: "Environment Variables for ECS"
+    Type: String
+    Default: "true" #pragma: allowlist secret
+  OrchestratorBasicAuthCredentials:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -528,6 +536,10 @@ Resources:
             Value: !Ref IpvEndpoint
           - Name: IPV_CORE_AUDIENCE
             Value: !Ref IpvCoreAudience
+          - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
+            Value: !Ref OrchestratorEnableBasicAuth
+          - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
+            Value: !Ref OrchestratorBasicAuthCredentials
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
@@ -48,6 +48,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/build/orch/env/ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+  OrchestratorBasicAuthEnable:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
+  OrchestratorBasicAuthUsername:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
+  OrchestratorBasicAuthPassword:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
   IpvBackchannelEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -76,14 +88,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/build/orch/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
-  OrchestratorEnableBasicAuth:
-    Description: "Environment Variables for ECS"
-    Type: String
-    Default: "true" #pragma: allowlist secret
-  OrchestratorBasicAuthCredentials:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: String
-    Default: "{ \"username\": \"dev\", \"password\": \"dev\" }" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -531,10 +535,12 @@ Resources:
               Value: !Ref IpvEndpoint
             - Name: IPV_CORE_AUDIENCE
               Value: !Ref IpvCoreAudience
-            - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
-              Value: !Ref OrchestratorEnableBasicAuth
-            - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
-              Value: !Ref OrchestratorBasicAuthCredentials
+            - Name: ORCHESTRATOR_BASIC_AUTH_ENABLE
+              Value: !Ref OrchestratorBasicAuthEnable
+            - Name: ORCHESTRATOR_BASIC_AUTH_USERNAME
+              Value: !Ref OrchestratorBasicAuthUsername
+            - Name: ORCHESTRATOR_BASIC_AUTH_PASSWORD
+              Value: !Ref OrchestratorBasicAuthPassword
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
@@ -76,6 +76,14 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/build/orch/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+  OrchestratorEnableBasicAuth:
+    Description: "Environment Variables for ECS"
+    Type: String
+    Default: "true" #pragma: allowlist secret
+  OrchestratorBasicAuthCredentials:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -522,6 +530,10 @@ Resources:
               Value: !Ref IpvEndpoint
             - Name: IPV_CORE_AUDIENCE
               Value: !Ref IpvCoreAudience
+            - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
+              Value: !Ref OrchestratorEnableBasicAuth
+            - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
+              Value: !Ref OrchestratorBasicAuthCredentials
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
@@ -82,8 +82,8 @@ Parameters:
     Default: "true" #pragma: allowlist secret
   OrchestratorBasicAuthCredentials:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
+    Type: String
+    Default: "{ \"username\": \"dev\", \"password\": \"dev\" }" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not

--- a/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-core-dev/template.yaml
@@ -390,7 +390,8 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       Matcher:
-        HttpCode: 200
+        # If basic auth is on then the site will return a 401
+        HttpCode: "200,401"
       Port: 8080
       Protocol: HTTP
       TargetType: ip

--- a/di-ipv-orchestrator-stub/deploy-integration/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-integration/template.yaml
@@ -392,7 +392,8 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       Matcher:
-        HttpCode: 200
+        # If basic auth is on then the site will return a 401
+        HttpCode: "200,401"
       Port: 8080
       Protocol: HTTP
       TargetType: ip

--- a/di-ipv-orchestrator-stub/deploy-integration/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-integration/template.yaml
@@ -52,6 +52,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store" #pragma: allowlist secret
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/integration/orch/env/ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+  OrchestratorBasicAuthEnable:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/integration/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
+  OrchestratorBasicAuthUsername:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/integration/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
+  OrchestratorBasicAuthPassword:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/integration/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
   IpvBackchannelEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -84,14 +96,6 @@ Parameters:
     #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     #    Type: AWS::SSM::Parameter::Value<String>
     #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
-  OrchestratorEnableBasicAuth:
-    Description: "Environment Variables for ECS"
-    Type: String
-    Default: "true" #pragma: allowlist secret
-  OrchestratorBasicAuthCredentials:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/integration/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -537,10 +541,12 @@ Resources:
             Value: !Ref IpvEndpoint
           - Name: IPV_CORE_AUDIENCE
             Value: !Ref IpvCoreAudience
-          - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
-            Value: !Ref OrchestratorEnableBasicAuth
-          - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
-            Value: !Ref OrchestratorBasicAuthCredentials
+          - Name: ORCHESTRATOR_BASIC_AUTH_ENABLE
+            Value: !Ref OrchestratorBasicAuthEnable
+          - Name: ORCHESTRATOR_BASIC_AUTH_USERNAME
+            Value: !Ref OrchestratorBasicAuthUsername
+          - Name: ORCHESTRATOR_BASIC_AUTH_PASSWORD
+            Value: !Ref OrchestratorBasicAuthPassword
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-integration/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-integration/template.yaml
@@ -84,6 +84,14 @@ Parameters:
     #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     #    Type: AWS::SSM::Parameter::Value<String>
     #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
+  OrchestratorEnableBasicAuth:
+    Description: "Environment Variables for ECS"
+    Type: String
+    Default: "true" #pragma: allowlist secret
+  OrchestratorBasicAuthCredentials:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/integration/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -528,6 +536,10 @@ Resources:
             Value: !Ref IpvEndpoint
           - Name: IPV_CORE_AUDIENCE
             Value: !Ref IpvCoreAudience
+          - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
+            Value: !Ref OrchestratorEnableBasicAuth
+          - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
+            Value: !Ref OrchestratorBasicAuthCredentials
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-staging/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-staging/template.yaml
@@ -392,7 +392,8 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       Matcher:
-        HttpCode: 200
+        # If basic auth is on then the site will return a 401
+        HttpCode: "200,401"
       Port: 8080
       Protocol: HTTP
       TargetType: ip

--- a/di-ipv-orchestrator-stub/deploy-staging/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-staging/template.yaml
@@ -84,6 +84,14 @@ Parameters:
     #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     #    Type: AWS::SSM::Parameter::Value<String>
     #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
+  OrchestratorEnableBasicAuth:
+    Description: "Environment Variables for ECS"
+    Type: String
+    Default: "true" #pragma: allowlist secret
+  OrchestratorBasicAuthCredentials:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/staging/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -528,6 +536,10 @@ Resources:
             Value: !Ref IpvEndpoint
           - Name: IPV_CORE_AUDIENCE
             Value: !Ref IpvCoreAudience
+          - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
+            Value: !Ref OrchestratorEnableBasicAuth
+          - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
+            Value: !Ref OrchestratorBasicAuthCredentials
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy-staging/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy-staging/template.yaml
@@ -52,6 +52,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store" #pragma: allowlist secret
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/staging/orch/env/ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+  OrchestratorBasicAuthEnable:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/staging/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
+  OrchestratorBasicAuthUsername:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/staging/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
+  OrchestratorBasicAuthPassword:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/staging/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
   IpvBackchannelEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -84,14 +96,6 @@ Parameters:
     #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     #    Type: AWS::SSM::Parameter::Value<String>
     #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
-  OrchestratorEnableBasicAuth:
-    Description: "Environment Variables for ECS"
-    Type: String
-    Default: "true" #pragma: allowlist secret
-  OrchestratorBasicAuthCredentials:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/staging/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -527,6 +531,12 @@ Resources:
             Value: !Ref OrchestratorClientSigningKey
           - Name: ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY
             Value: !Ref OrchestratorJarEncryptionPublicKey
+          - Name: ORCHESTRATOR_BASIC_AUTH_ENABLE
+            Value: !Ref OrchestratorBasicAuthEnable
+          - Name: ORCHESTRATOR_BASIC_AUTH_USERNAME
+            Value: !Ref OrchestratorBasicAuthUsername
+          - Name: ORCHESTRATOR_BASIC_AUTH_PASSWORD
+            Value: !Ref OrchestratorBasicAuthPassword
           - Name: IPV_BACKCHANNEL_ENDPOINT
             Value: !Ref IpvBackchannelEndpoint
           - Name: IPV_BACKCHANNEL_TOKEN_PATH
@@ -537,10 +547,12 @@ Resources:
             Value: !Ref IpvEndpoint
           - Name: IPV_CORE_AUDIENCE
             Value: !Ref IpvCoreAudience
-          - Name: ORCHESTRATOR_ENABLE_BASIC_AUTH
-            Value: !Ref OrchestratorEnableBasicAuth
-          - Name: ORCHESTRATOR_BASIC_AUTH_CREDENTIALS
-            Value: !Ref OrchestratorBasicAuthCredentials
+          - Name: ORCHESTRATOR_BASIC_AUTH_ENABLE
+            Value: !Ref OrchestratorBasicAuthEnable
+          - Name: ORCHESTRATOR_BASIC_AUTH_USERNAME
+            Value: !Ref OrchestratorBasicAuthUsername
+          - Name: ORCHESTRATOR_BASIC_AUTH_PASSWORD
+            Value: !Ref OrchestratorBasicAuthPassword
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/Orchestrator.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/Orchestrator.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.stub.orc;
 
 import spark.Spark;
 import uk.gov.di.ipv.stub.orc.config.OrchestratorConfig;
+import uk.gov.di.ipv.stub.orc.handlers.BasicAuthHandler;
 import uk.gov.di.ipv.stub.orc.handlers.HomeHandler;
 import uk.gov.di.ipv.stub.orc.handlers.IpvHandler;
 
@@ -19,6 +20,10 @@ public class Orchestrator {
     }
 
     public void initRoutes() {
+        if (OrchestratorConfig.ENABLE_BASIC_AUTH) {
+            BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
+            Spark.before(basicAuthHandler.authFilter);
+        }
         Spark.get("/", HomeHandler.serveHomePage);
         Spark.get("/authorize", ipvHandler.doAuthorize);
         Spark.get("/callback", ipvHandler.doCallback);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/Orchestrator.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/Orchestrator.java
@@ -20,7 +20,7 @@ public class Orchestrator {
     }
 
     public void initRoutes() {
-        if (OrchestratorConfig.ENABLE_BASIC_AUTH) {
+        if (OrchestratorConfig.BASIC_AUTH_ENABLE) {
             BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
             Spark.before(basicAuthHandler.authFilter);
         }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/BasicAuthCredentials.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/BasicAuthCredentials.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.stub.orc.config;
+
+public class BasicAuthCredentials {
+    private String username;
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -32,7 +32,6 @@ public class OrchestratorConfig {
     public static final boolean ENABLE_BASIC_AUTH =
             Boolean.parseBoolean(getConfigValue("ORCHESTRATOR_ENABLE_BASIC_AUTH", "false"));
 
-
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);
         if (envValue == null) {

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -28,9 +28,12 @@ public class OrchestratorConfig {
             getConfigValue(
                     "IPV_CORE_AUDIENCE",
                     "https://build-di-ipv-cri-uk-passport-front.london.cloudapps.digital");
-    public static BasicAuthCredentials BASIC_AUTH_CREDENTIALS = parseUserAuth();
-    public static final boolean ENABLE_BASIC_AUTH =
-            Boolean.parseBoolean(getConfigValue("ORCHESTRATOR_ENABLE_BASIC_AUTH", "false"));
+    public static final boolean BASIC_AUTH_ENABLE =
+            Boolean.parseBoolean(getConfigValue("ORCHESTRATOR_BASIC_AUTH_ENABLE", "false"));
+    public static final String BASIC_AUTH_USERNAME =
+            getConfigValue("ORCHESTRATOR_BASIC_AUTH_USERNAME", null);
+    public static final String BASIC_AUTH_PASSWORD =
+            getConfigValue("ORCHESTRATOR_BASIC_AUTH_PASSWORD", null);
 
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);
@@ -39,13 +42,5 @@ public class OrchestratorConfig {
         }
 
         return envValue;
-    }
-
-    private static BasicAuthCredentials parseUserAuth() {
-        String user_auth = getConfigValue("ORCHESTRATOR_BASIC_AUTH_CREDENTIALS", null);
-        if (user_auth == null) {
-            return null;
-        }
-        return new Gson().fromJson(user_auth, BasicAuthCredentials.class);
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.stub.orc.config;
 
-import com.google.gson.Gson;
-
 public class OrchestratorConfig {
     public static final String PORT = getConfigValue("ORCHESTRATOR_PORT", "8083");
     public static final String IPV_ENDPOINT =

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.stub.orc.config;
 
+import com.google.gson.Gson;
+
 public class OrchestratorConfig {
     public static final String PORT = getConfigValue("ORCHESTRATOR_PORT", "8083");
     public static final String IPV_ENDPOINT =
@@ -26,6 +28,10 @@ public class OrchestratorConfig {
             getConfigValue(
                     "IPV_CORE_AUDIENCE",
                     "https://build-di-ipv-cri-uk-passport-front.london.cloudapps.digital");
+    public static BasicAuthCredentials BASIC_AUTH_CREDENTIALS = parseUserAuth();
+    public static final boolean ENABLE_BASIC_AUTH =
+            Boolean.parseBoolean(getConfigValue("ORCHESTRATOR_ENABLE_BASIC_AUTH", "false"));
+
 
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);
@@ -34,5 +40,13 @@ public class OrchestratorConfig {
         }
 
         return envValue;
+    }
+
+    private static BasicAuthCredentials parseUserAuth() {
+        String user_auth = getConfigValue("ORCHESTRATOR_BASIC_AUTH_CREDENTIALS", null);
+        if (user_auth == null) {
+            return null;
+        }
+        return new Gson().fromJson(user_auth, BasicAuthCredentials.class);
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/BasicAuthHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/BasicAuthHandler.java
@@ -1,0 +1,50 @@
+package uk.gov.di.ipv.stub.orc.handlers;
+
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+import uk.gov.di.ipv.stub.orc.config.OrchestratorConfig;
+
+import java.util.Base64;
+
+public class BasicAuthHandler {
+    private static final int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_TYPE = "Basic";
+
+    public Filter authFilter =
+            (Request request, Response response) -> {
+                if (!request.headers().contains(AUTHORIZATION_HEADER) || !authenticated(request)) {
+                    response.header("WWW-Authenticate", AUTHORIZATION_TYPE);
+                    Spark.halt(401, "Not Authenticated");
+                }
+            };
+
+    private Boolean authenticated(Request request) {
+        String authHeader = request.headers(AUTHORIZATION_HEADER);
+        int authTypeIndex = authHeader == null ? -1 : authHeader.indexOf(AUTHORIZATION_TYPE);
+
+        if (authTypeIndex < 0) {
+            return false;
+        }
+
+        String encodedHeader =
+                authHeader.substring(authTypeIndex + AUTHORIZATION_TYPE.length() + 1).trim();
+        String[] submittedCredentials = extractCredentials(encodedHeader);
+
+        if (submittedCredentials.length == NUMBER_OF_AUTHENTICATION_FIELDS) {
+            String submittedUsername = submittedCredentials[0];
+            String submittedPassword = submittedCredentials[1];
+            String username = OrchestratorConfig.BASIC_AUTH_CREDENTIALS.getUsername();
+            String password = OrchestratorConfig.BASIC_AUTH_CREDENTIALS.getPassword();
+            return submittedUsername.equals(username) && submittedPassword.equals(password);
+        }
+        return false;
+    }
+
+    private String[] extractCredentials(String encodedHeader) {
+        String decodedHeader = new String(Base64.getDecoder().decode(encodedHeader));
+        return decodedHeader.split(":");
+    }
+}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/BasicAuthHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/BasicAuthHandler.java
@@ -36,8 +36,8 @@ public class BasicAuthHandler {
         if (submittedCredentials.length == NUMBER_OF_AUTHENTICATION_FIELDS) {
             String submittedUsername = submittedCredentials[0];
             String submittedPassword = submittedCredentials[1];
-            String username = OrchestratorConfig.BASIC_AUTH_CREDENTIALS.getUsername();
-            String password = OrchestratorConfig.BASIC_AUTH_CREDENTIALS.getPassword();
+            String username = OrchestratorConfig.BASIC_AUTH_USERNAME;
+            String password = OrchestratorConfig.BASIC_AUTH_PASSWORD;
             return submittedUsername.equals(username) && submittedPassword.equals(password);
         }
         return false;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

By default any newly deployed orchestrator stub will require an SSM parameter specifying a username and password for basic auth, and any requests to the stub will need to provide the correct username and password to view the stub pages.

With this PR all dev orch stubs will default to credentials of dev/dev which can be overridden in core-common-infra. This could be changed to force developers to set up SSM credentials manually instead depending on how strictly we want to enforce this.

### Why did it change

Having all stubs orch publicly accessible isn't a good thing.

### Issue tracking

- [PYI-3321](https://govukverify.atlassian.net/browse/PYI-3321)

## Checklists

### Environment variables or secrets

For this code to work every non-dev orch stub will need an SSM parameter configured. The exact parameter path will depend on the environment but takes the form of:

`/stubs/<environment>/orch/env/ORCHESTRATOR_BASIC_AUTH_CREDENTIALS`

an example value is:

`{ "username": "dev", "password": "dev" }`

These values are secret and so need to be added manually to SSM before this PR is merged.

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
