### PR TITLE
OJ-1966: Added API-KEYS for check HMRC staging

### DIFF
--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -99,6 +99,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/API_KEY_CRI_CHECK_HMRC_BUILD" #pragma: allowlist secret
+  ApiKeyCriCheckHmrcStaging:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_CHECK_STAGING" #pragma: allowlist secret
   ApiKeyCriPassportStaging:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -660,6 +664,8 @@ Resources:
             Value: !Ref ApiKeyCriToyStaging
           - Name: API_KEY_CRI_CHECK_HMRC_BUILD
             Value: !Ref ApiKeyCriCheckHmrcBuild
+          - Name: API_KEY_CRI_CHECK_STAGING
+            Value: !Ref ApiKeyCriCheckHmrcStaging
           - Name: API_KEY_CRI_ADDRESS_STAGING
             Value: !Ref ApiKeyCriAddressStaging
           - Name: API_KEY_CRI_KBV_STAGING


### PR DESCRIPTION
## Proposed changes

Added API-KEY for check-hmrc API need for the front end to communicate with the API

### Why did it change

- [OJ-1966](https://govukverify.atlassian.net/browse/OJ-1966)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1966]: https://govukverify.atlassian.net/browse/OJ-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ