### PR TITLE
PYIC-3717: Add stub data evidence for the BAV CRI stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -1645,6 +1645,140 @@
           }
         ]
       }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "Kenneth Decerqueira BAV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Kenneth",
+                "type": "GivenName"
+              },
+              {
+                "value": "Decerqueira",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "bankAccount": [
+          {
+            "sortCode": "103233",
+            "accountNumber": "12345678"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "James Moriarty BAV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "James",
+                "type": "GivenName"
+              },
+              {
+                "value": "Moriarty",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "bankAccount": [
+          {
+            "sortCode": "103233",
+            "accountNumber": "12345678"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "Mary Watson BAV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Mary",
+                "type": "GivenName"
+              },
+              {
+                "value": "Watson",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "bankAccount": [
+          {
+            "sortCode": "103233",
+            "accountNumber": "12345678"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "Alice Parker BAV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Aliçe",
+                "type": "GivenName"
+              },
+              {
+                "value": "Jane",
+                "type": "GivenName"
+              },
+              {
+                "value": "Parkér",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "bankAccount": [
+          {
+            "sortCode": "103233",
+            "accountNumber": "12345678"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "Bob Parker BAV",
+      "payload": {
+        "name": [
+          {
+            "nameParts": [
+              {
+                "value": "Böb",
+                "type": "GivenName"
+              },
+              {
+                "value": "Pârker",
+                "type": "FamilyName"
+              }
+            ]
+          }
+        ],
+        "bankAccount": [
+          {
+            "sortCode": "103233",
+            "accountNumber": "12345678"
+          }
+        ]
+      }
     }
   ]
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -397,7 +397,7 @@
       "payload": {
         "type": "IdentityCheck",
         "txn": "Vlj6bIQYFtTGODUyX5HrstSgfoE",
-        "strengthScore": 0,
+        "strengthScore": 3,
         "validityScore": 0,
         "failedCheckDetails": [
           {

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -374,6 +374,38 @@
           }
         ]
       }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "Passed Bank account verification (Stub)",
+      "payload": {
+        "type": "IdentityCheck",
+        "txn": "Vlj6bIQYFtTGODUyX5HrstSgfoE",
+        "strengthScore": 3,
+        "validityScore": 2,
+        "checkDetails": [
+          {
+            "checkMethod": "data",
+            "identityCheckPolicy": "none"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "Bank account verification (Stub)",
+      "label": "Failed Bank account verification (Stub)",
+      "payload": {
+        "type": "IdentityCheck",
+        "txn": "Vlj6bIQYFtTGODUyX5HrstSgfoE",
+        "strengthScore": 0,
+        "validityScore": 0,
+        "failedCheckDetails": [
+          {
+            "checkMethod": "data",
+            "identityCheckPolicy": "none"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add stub data evidence for the BAV CRI stub
Following this RFC:  https://github.com/govuk-one-login/architecture/blob/b15fedc4e4ae1f924092ce0272eeb95a38eb2856/rfc/0059-bank-account-verification.md#success

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3717](https://govukverify.atlassian.net/browse/PYIC-3717)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3717]: https://govukverify.atlassian.net/browse/PYIC-3717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ