### PR TITLE
Pyic 3684 nino stub scope

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -76,6 +76,7 @@ import static uk.gov.di.ipv.stub.cred.config.CriType.USER_ASSERTED_CRI_TYPE;
 
 public class AuthorizeHandler {
 
+    public static final String REQUEST_SCOPE = "scope";
     public static final String SHARED_CLAIMS = "shared_claims";
     public static final String EVIDENCE_REQUESTED = "evidence_requested";
 
@@ -189,11 +190,16 @@ public class AuthorizeHandler {
 
                 String sharedAttributesJson;
                 String evidenceRequestedJson;
+                String requestScope;
                 try {
                     JWTClaimsSet claimsSet = getJwtClaimsSet(queryParamsMap);
+                    requestScope = claimsSet.getStringClaim(REQUEST_SCOPE);
+                    requestScope =
+                            requestScope == null ? "No scope provided in request" : requestScope;
                     sharedAttributesJson = getSharedAttributes(claimsSet);
                     evidenceRequestedJson = getEvidenceRequested(claimsSet);
                 } catch (Exception e) {
+                    requestScope = e.getMessage();
                     sharedAttributesJson = e.getMessage();
                     evidenceRequestedJson = e.getMessage();
                 }
@@ -224,6 +230,7 @@ public class AuthorizeHandler {
                         CredentialIssuerConfig.isEnabled(
                                 CredentialIssuerConfig.CRI_MITIGATION_ENABLED, "false"));
                 frontendParams.put(IS_USER_ASSERTED_TYPE, criType.equals(USER_ASSERTED_CRI_TYPE));
+                frontendParams.put(REQUEST_SCOPE, requestScope);
                 if (!criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
                     frontendParams.put(SHARED_CLAIMS, sharedAttributesJson);
                 }
@@ -883,8 +890,8 @@ public class AuthorizeHandler {
         try {
             Map<String, Object> sharedAttributes = claimsSet.getJSONObjectClaim(SHARED_CLAIMS);
             if (sharedAttributes == null) {
-                LOGGER.error("evidence_requested not found in JWT");
-                return "evidence_requested not found in JWT";
+                LOGGER.error("shared_claims not found in JWT");
+                return "shared_claims not found in JWT";
             }
             sharedAttributesJson = gson.toJson(sharedAttributes);
             return sharedAttributesJson;

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -79,6 +79,11 @@
                 <div class="govuk-tabs__panel" id="authCode">
                     <table class="govuk-table">
                         <tbody class="govuk-table__body">
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">
+                                <p><strong>Request scope:</strong> {{scope}}</p>
+                            </td>
+                        </tr>
                         {{#shared_claims}}
                             <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

CRI stubs now display the scope parameter of the auth request

### Why did it change

For the no-photo-id journey we will be passing a scope to the NINO CRI. This will allow us to see that the scope is being passed correctly to the stub.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3684](https://govukverify.atlassian.net/browse/PYI-3684)
