### PR TITLE
PYIC-3740: Add NINO CRI payloads for identity checking

### DIFF
--- a/di-ipv-credential-issuer-stub/README.MD
+++ b/di-ipv-credential-issuer-stub/README.MD
@@ -16,8 +16,8 @@ The stub application to simulate the credential issuers to be used during the IP
 |-------------------------|-------------------------------------------------------|------------------------|
 | CREDENTIAL_ISSUER_PORT  | The port number the credential issuer should run on   | `8084`                 |
 | CREDENTIAL_ISSUER_NAME  | The name of the credential issuer, displayed to users | `UK Passport CRI Stub` |
-| CREDENTIAL_ISSUER_TYPE  | The name of the credential issuer                     | `CRI`                  |
 | CLIENT_CONFIG           | Configuration of accepted clients                     | See [test fixtures](https://github.com/alphagov/di-ipv-stubs/blob/main/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/fixtures/TestFixtures.java#L6) for example values                       |
+| CREDENTIAL_ISSUER_TYPE  | The type of the credential issuer                     | `EVIDENCE`             |
 | CLIENT_AUDIENCE         | Hostname that the credential issue should run on      | `http://localhost:8084` |
 | VC_ISSUER               | Hostname of the VC issuer                             | `http://localhost:8084` |
 | VC_SIGNING_KEY          | Signing key for the VC issuer | See [test fixtures](https://github.com/alphagov/di-ipv-stubs/blob/main/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/fixtures/TestFixtures.java#L6) for example values      |

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -353,7 +353,7 @@
     },
     {
       "criType": "National Insurance Number (Stub)",
-      "label": "Passed National Insurance Number (Stub)",
+      "label": "Passed National Insurance Number - no scope",
       "payload": {
         "type": "IdentityCheck",
         "checkDetails": [
@@ -365,9 +365,52 @@
     },
     {
       "criType": "National Insurance Number (Stub)",
-      "label": "Failed National Insurance Number (Stub)",
+      "label": "Failed National Insurance Number - no scope",
       "payload": {
         "type": "IdentityCheck",
+        "failedCheckDetails": [
+          {
+            "checkMethod": "data"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "National Insurance Number (Stub)",
+      "label": "Passed National Insurance Number - 'identityCheck' scope",
+      "payload": {
+        "type": "IdentityCheck",
+        "strengthScore": 2,
+        "validityScore": 2,
+        "checkDetails": [
+          {
+            "checkMethod": "data"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "National Insurance Number (Stub)",
+      "label": "Failed National Insurance Number - 'identityCheck' scope",
+      "payload": {
+        "type": "IdentityCheck",
+        "strengthScore": 2,
+        "validityScore": 0,
+        "failedCheckDetails": [
+          {
+            "checkMethod": "data"
+          }
+        ]
+      }
+    },
+    {
+      "criType": "National Insurance Number (Stub)",
+      "label": "Failed National Insurance Number with CI - 'identityCheck' scope",
+      "payload": {
+        "type": "IdentityCheck",
+        "strengthScore": 2,
+        "validityScore": 0,
+        "ci": ["QQQ"],
         "failedCheckDetails": [
           {
             "checkMethod": "data"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Extra evidence blocks for the NINO CRI along with renaming of existing ones so that it's clear when to use them.

### Why did it change

NINO CRI will be changing behaviour soon, this should allow us to stub the new behaviour

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3740](https://govukverify.atlassian.net/browse/PYI-3740)
