### PR TITLE
Pyic 3800 display request context

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -199,7 +199,9 @@ public class AuthorizeHandler {
                             requestScope == null ? "No scope provided in request" : requestScope;
                     requestContext = claimsSet.getStringClaim(REQUEST_CONTEXT);
                     requestContext =
-                            requestContext == null ? "No context provided in request" : requestContext;
+                            requestContext == null
+                                    ? "No context provided in request"
+                                    : requestContext;
                     sharedAttributesJson = getSharedAttributes(claimsSet);
                     evidenceRequestedJson = getEvidenceRequested(claimsSet);
                 } catch (Exception e) {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -76,6 +76,7 @@ import static uk.gov.di.ipv.stub.cred.config.CriType.USER_ASSERTED_CRI_TYPE;
 public class AuthorizeHandler {
 
     public static final String REQUEST_SCOPE = "scope";
+    public static final String REQUEST_CONTEXT = "context";
     public static final String SHARED_CLAIMS = "shared_claims";
     public static final String EVIDENCE_REQUESTED = "evidence_requested";
 
@@ -190,15 +191,20 @@ public class AuthorizeHandler {
                 String sharedAttributesJson;
                 String evidenceRequestedJson;
                 String requestScope;
+                String requestContext;
                 try {
                     JWTClaimsSet claimsSet = getJwtClaimsSet(queryParamsMap);
                     requestScope = claimsSet.getStringClaim(REQUEST_SCOPE);
                     requestScope =
                             requestScope == null ? "No scope provided in request" : requestScope;
+                    requestContext = claimsSet.getStringClaim(REQUEST_CONTEXT);
+                    requestContext =
+                            requestContext == null ? "No context provided in request" : requestContext;
                     sharedAttributesJson = getSharedAttributes(claimsSet);
                     evidenceRequestedJson = getEvidenceRequested(claimsSet);
                 } catch (Exception e) {
                     requestScope = e.getMessage();
+                    requestContext = e.getMessage();
                     sharedAttributesJson = e.getMessage();
                     evidenceRequestedJson = e.getMessage();
                 }
@@ -230,6 +236,7 @@ public class AuthorizeHandler {
                                 CredentialIssuerConfig.CRI_MITIGATION_ENABLED, "false"));
                 frontendParams.put(IS_USER_ASSERTED_TYPE, criType.equals(USER_ASSERTED_CRI_TYPE));
                 frontendParams.put(REQUEST_SCOPE, requestScope);
+                frontendParams.put(REQUEST_CONTEXT, requestContext);
                 if (!criType.equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
                     frontendParams.put(SHARED_CLAIMS, sharedAttributesJson);
                 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
@@ -81,7 +81,7 @@ public class TokenHandler {
                     try {
                         clientJwtVerifier.authenticateClient(requestParams);
                     } catch (ClientAuthenticationException e) {
-                        LOGGER.error("Failed client JWT authentication: %s", e);
+                        LOGGER.error("Failed client JWT authentication: {}", e.getMessage());
                         TokenErrorResponse errorResponse =
                                 new TokenErrorResponse(OAuth2Error.INVALID_CLIENT);
                         response.status(OAuth2Error.INVALID_CLIENT.getHTTPStatusCode());

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -84,6 +84,11 @@
                                 <p><strong>Request scope:</strong> {{scope}}</p>
                             </td>
                         </tr>
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">
+                                <p><strong>Request context:</strong> {{context}}</p>
+                            </td>
+                        </tr>
                         {{#shared_claims}}
                             <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -542,7 +542,6 @@ class AuthorizeHandlerTest {
         assertEquals("test scope", viewParamsCaptor.getValue().get("scope").toString());
     }
 
-
     @Test
     void doAuthorizeShouldUseDefaultContextValueWhenNoContextInRequest() throws Exception {
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -542,6 +542,47 @@ class AuthorizeHandlerTest {
         assertEquals("test scope", viewParamsCaptor.getValue().get("scope").toString());
     }
 
+
+    @Test
+    void doAuthorizeShouldUseDefaultContextValueWhenNoContextInRequest() throws Exception {
+
+        // Arrange
+        QueryParamsMap queryParamsMap = toQueryParamsMap(validEncryptedDoAuthorizeQueryParams());
+        when(mockRequest.queryMap()).thenReturn(queryParamsMap);
+
+        String renderOutput = "rendered output";
+        when(mockViewHelper.render(anyMap(), eq("authorize.mustache"))).thenReturn(renderOutput);
+
+        // Act
+        String result = (String) authorizeHandler.doAuthorize.handle(mockRequest, mockResponse);
+
+        // Assert
+        verify(mockViewHelper).render(viewParamsCaptor.capture(), eq("authorize.mustache"));
+        assertEquals(
+                "No context provided in request",
+                viewParamsCaptor.getValue().get("context").toString());
+    }
+
+    @Test
+    void doAuthorizeShouldUseRequestContextValueWhenContextInRequest() throws Exception {
+
+        // Arrange
+        var claimsSet = DefaultClaimSetBuilder().claim("context", "test context").build();
+        QueryParamsMap queryParamsMap =
+                toQueryParamsMap(validEncryptedDoAuthorizeQueryParams(claimsSet));
+        when(mockRequest.queryMap()).thenReturn(queryParamsMap);
+
+        String renderOutput = "rendered output";
+        when(mockViewHelper.render(anyMap(), eq("authorize.mustache"))).thenReturn(renderOutput);
+
+        // Act
+        String result = (String) authorizeHandler.doAuthorize.handle(mockRequest, mockResponse);
+
+        // Assert
+        verify(mockViewHelper).render(viewParamsCaptor.capture(), eq("authorize.mustache"));
+        assertEquals("test context", viewParamsCaptor.getValue().get("context").toString());
+    }
+
     private String createExpectedErrorQueryStringParams(ErrorObject error) {
         return createExpectedErrorQueryStringParams(error.getCode(), error.getDescription());
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Request "context" claim is now displayed on stub page

### Why did it change

So devs & testers can easily see when a "context" is set on a request to a CRI (e.g. the CIC CRI in the new M2B journey)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-3800](https://govukverify.atlassian.net/browse/PYI-3800)
