### PR TITLE
PYIC-3906: Include CI in BAV VC fail response

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -399,6 +399,7 @@
         "txn": "Vlj6bIQYFtTGODUyX5HrstSgfoE",
         "strengthScore": 3,
         "validityScore": 0,
+        "ci": ["D15"],
         "failedCheckDetails": [
           {
             "checkMethod": "data",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Include CI in BAV VC fail response

### Why did it change

In the BAV fail scenario we expect a VC with a CI - we should add the CI as documented in https://github.com/govuk-one-login/architecture/blob/rfc-0059-bank-account-verification-cri/rfc/0059-bank-account-verification.md#failed-with-no-match-or-partial-name-match 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3906](https://govukverify.atlassian.net/browse/PYIC-3906)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3906]: https://govukverify.atlassian.net/browse/PYIC-3906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ