### PR TITLE
PYIC-3978: Update the Orchestration Stub to include 'vtr' in authorisation request

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_CORE_AUDIENCE;
@@ -72,6 +73,7 @@ public class JwtBuilder {
                 .claim("govuk_signin_journey_id", signInJourneyId)
                 .claim("persistent_session_id", UUID.randomUUID().toString())
                 .claim("email_address", "dev-platform-testing@digital.cabinet-office.gov.uk")
+                .claim("vtr", List.of("Cl.Cm.P2", "Cl.Cm.PCL200"))
                 .build();
     }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the Orchestration Stub to include 'vtr' in authorisation request

### Why did it change

The "vtr" is a crucial assertion of trust expectations set by the Relying Party. Its secure storage within IPV Core is imperative for confirming that the identity proofing journey meets the RP's required trust benchmarks. This ensures that IPV Core can validate and relay trust expectations to the TICF CRI, maintaining the integrity of the identity verification process.

The asynchronous nature of the F2F journey means that the original vtr defined when initiating the F2F journey, and the associated VC’s stored should match those in the re-use journey once the user has visited the post office. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3978](https://govukverify.atlassian.net/browse/PYIC-3978)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3978]: https://govukverify.atlassian.net/browse/PYIC-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ