### PR TITLE
PYIC-3978: Update the Orchestration Stub to include 'vtr' in authorisation request

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -77,12 +77,13 @@ public class IpvHandler {
                 String errorType = request.queryMap().get("error").value();
                 String userIdTextValue = request.queryMap().get("userIdText").value();
                 String signInJourneyIdText = request.queryMap().get("signInJourneyIdText").value();
+                String[] vtr = request.queryMap().get("vtrText").values();
 
                 String userId = getUserIdValue(userIdTextValue);
 
                 JWTClaimsSet claims =
                         JwtBuilder.buildAuthorizationRequestClaims(
-                                userId, signInJourneyIdText, errorType);
+                                userId, signInJourneyIdText, vtr, errorType);
 
                 SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
                 EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -46,7 +46,7 @@ public class JwtBuilder {
     public static final String INVALID_REDIRECT_URI = "http://example.com";
 
     public static JWTClaimsSet buildAuthorizationRequestClaims(
-            String userId, String signInJourneyId, String errorType) {
+            String userId, String signInJourneyId, String[] vtr, String errorType) {
         String audience = IPV_CORE_AUDIENCE;
         String redirectUri = ORCHESTRATOR_REDIRECT_URL;
 
@@ -73,7 +73,7 @@ public class JwtBuilder {
                 .claim("govuk_signin_journey_id", signInJourneyId)
                 .claim("persistent_session_id", UUID.randomUUID().toString())
                 .claim("email_address", "dev-platform-testing@digital.cabinet-office.gov.uk")
-                .claim("vtr", List.of("Cl.Cm.P2", "Cl.Cm.PCL200"))
+                .claim("vtr", List.of(vtr))
                 .build();
     }
 

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -63,6 +63,10 @@
                 <label class="govuk-label" for="signInJourneyIdText">Sign In Journey Id</label>
                 <input class="govuk-input" data-module="govuk-input" name="signInJourneyIdText" id="signInJourneyIdText" type="text" value={{signInJourneyId}} readonly="readonly">
             </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="vtrText">Enter vtr manually</label>
+                <input class="govuk-input" data-module="govuk-input" name="vtrText" id="vtrText" type="text" value="Cl.Cm.P2">
+            </div>
 
             <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
         </form>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the Orchestration Stub to include 'vtr' in authorisation request

### Why did it change

The "vtr" is a crucial assertion of trust expectations set by the Relying Party. Its secure storage within IPV Core is imperative for confirming that the identity proofing journey meets the RP's required trust benchmarks. This ensures that IPV Core can validate and relay trust expectations to the TICF CRI, maintaining the integrity of the identity verification process.

The asynchronous nature of the F2F journey means that the original vtr defined when initiating the F2F journey, and the associated VC’s stored should match those in the re-use journey once the user has visited the post office.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3978](https://govukverify.atlassian.net/browse/PYIC-3978)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3978]: https://govukverify.atlassian.net/browse/PYIC-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ