### PR TITLE
Fix codeowners syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-* @govuk-one-login/core-team
-* @govuk-one-login/cri-lime-team
-* @govuk-one-login/cri-orange-team
+* @govuk-one-login/core-team @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team


### PR DESCRIPTION
Previously GH was just taking the last rule, as it superseded the others. I think the correct format is to have them all on one line.