### PR TITLE
LIME-889 Experian-Fraud-Stub - Allow simulating slow responses to fraud and pep check

### DIFF
--- a/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
+++ b/experian-fraud-stub/src/main/java/uk/gov/di/ipv/stub/fraud/Handler.java
@@ -25,6 +25,9 @@ public class Handler {
     public static final String PEP_CHECK_SOURCE = "pep_check_source";
     private InMemoryDataStore pepCheckInMemoryDataStore;
 
+    // To prevent accidentally requesting the stub to wait very long
+    private static long MAX_DELAYED_RESPONSE_MS = 30000;
+
     protected Handler() {
         mapper = new ObjectMapper();
         fraudCheckInMemoryDataStore = new InMemoryDataStore(mapper, FRAUD_CHECK_SOURCE);
@@ -135,6 +138,17 @@ public class Handler {
                     }
 
                      */
+
+                    // Wait x millis before replying to Fraud Check
+                    if (requestSurnameName.contains("FWAIT_")) {
+
+                        String sWait = requestSurnameName.substring(6);
+
+                        long fwait = Math.min(Long.parseLong(sWait), MAX_DELAYED_RESPONSE_MS);
+
+                        Thread.sleep(fwait);
+                        response.status(200);
+                    }
                 } else if (requestType.equals("PepSanctions01")) {
                     // PepCheck Simulation
 
@@ -200,6 +214,17 @@ public class Handler {
                                 408); // Request Timeout (closest response to an abrupt socket
                         // close)
                         return ""; // No message returned intended
+                    }
+
+                    // Wait x millis before replying to PEP Check
+                    if (requestSurnameName.contains("PWAIT_")) {
+
+                        String sWait = requestSurnameName.substring(6);
+
+                        long pwait = Math.min(Long.parseLong(sWait), MAX_DELAYED_RESPONSE_MS);
+
+                        Thread.sleep(pwait);
+                        response.status(200);
                     }
                 } else {
                     String message = String.format("Unknown Request Type %s", requestType);


### PR DESCRIPTION
## Proposed changes

### What changed

Experian-Fraud-Stub - Allow simulating slow responses to fraud and pep check

The surnames

- FWAIT_
- PWAIT_

When followed by a value, will delay the response by X milliseconds.
E.g FWAIT_10000 for 10 second delay

The delay is capped at 30seconds to prevent unreasonably long values.

### Why did it change

As part of the thirdparty API latency investigation, the HTTP client in FraudCRI's API is changed to enforce a timeout after X number of seconds.
This change allows the stub to simulate the slow response (and trigger the api timeout) on a per request (Fraud/Pep) bases.

### Issue tracking

- [LIME-889](https://govukverify.atlassian.net/browse/LIME-889)
- [LIME-612](https://govukverify.atlassian.net/browse/LIME-612)


[LIME-889]: https://govukverify.atlassian.net/browse/LIME-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-612]: https://govukverify.atlassian.net/browse/LIME-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ