### PR TITLE
Pyic 4026 reprove identity claim

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -81,12 +81,22 @@ public class IpvHandler {
                         request.queryMap().hasKey("vtrText")
                                 ? request.queryMap("vtrText").values()
                                 : new String[] {"Cl.Cm.P2"};
+                String reproveIdentityString = request.queryMap().get("reproveIdentity").value();
+                JwtBuilder.ReproveIdentityClaimValue reproveIdentityClaimValue =
+                        StringUtils.isNotBlank(reproveIdentityString)
+                                ? JwtBuilder.ReproveIdentityClaimValue.valueOf(
+                                        reproveIdentityString)
+                                : JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT;
 
                 String userId = getUserIdValue(userIdTextValue);
 
                 JWTClaimsSet claims =
                         JwtBuilder.buildAuthorizationRequestClaims(
-                                userId, signInJourneyIdText, vtr, errorType);
+                                userId,
+                                signInJourneyIdText,
+                                vtr,
+                                errorType,
+                                reproveIdentityClaimValue);
 
                 SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
                 EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt);

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -69,7 +69,7 @@
             </div>
             <div class="govuk-form-group">
                 <label class="govuk-label" for="reproveIdentity">Choose a value for reprove_identity:</label>
-                <select class="govuk-select" name="reproveIdentity" id="error">
+                <select class="govuk-select" name="reproveIdentity" id="reproveIdentity">
                     <option value="NOT_PRESENT">Not set</option>
                     <option value="TRUE">true</option>
                     <option value="FALSE">false</option>

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -67,6 +67,14 @@
                 <label class="govuk-label" for="vtrText">Enter vtr manually</label>
                 <input class="govuk-input" data-module="govuk-input" name="vtrText" id="vtrText" type="text" value="Cl.Cm.P2">
             </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="reproveIdentity">Choose an value for reprove_identity:</label>
+                <select class="govuk-select" name="reproveIdentity" id="error">
+                    <option value="NOT_PRESENT">Not set</option>
+                    <option value="TRUE">true</option>
+                    <option value="FALSE">false</option>
+                </select>
+            </div>
 
             <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
         </form>

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -68,7 +68,7 @@
                 <input class="govuk-input" data-module="govuk-input" name="vtrText" id="vtrText" type="text" value="Cl.Cm.P2">
             </div>
             <div class="govuk-form-group">
-                <label class="govuk-label" for="reproveIdentity">Choose an value for reprove_identity:</label>
+                <label class="govuk-label" for="reproveIdentity">Choose a value for reprove_identity:</label>
                 <select class="govuk-select" name="reproveIdentity" id="error">
                     <option value="NOT_PRESENT">Not set</option>
                     <option value="TRUE">true</option>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Allow devs/testers to set a value for `reprove_identity` in the request from the orchestrator stub

### What changed

Add a dropdown to the orch stub page to all the user to set a value for the `reprove_identity` claim

### Why did it change

To facilitate testing of the reprove identity feature

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-4026](https://govukverify.atlassian.net/browse/PYI-4026)

