### PR TITLE
PYIC-4140: Allow setting of user email in orch stub

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -81,6 +81,7 @@ public class IpvHandler {
                         request.queryMap().hasKey("vtrText")
                                 ? request.queryMap("vtrText").values()
                                 : new String[] {"Cl.Cm.P2"};
+                String userEmailAddress = request.queryMap().get("emailAddress").value();
                 String reproveIdentityString = request.queryMap().get("reproveIdentity").value();
                 JwtBuilder.ReproveIdentityClaimValue reproveIdentityClaimValue =
                         StringUtils.isNotBlank(reproveIdentityString)
@@ -96,6 +97,7 @@ public class IpvHandler {
                                 signInJourneyIdText,
                                 vtr,
                                 errorType,
+                                userEmailAddress,
                                 reproveIdentityClaimValue);
 
                 SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -56,6 +56,7 @@ public class JwtBuilder {
             String signInJourneyId,
             String[] vtr,
             String errorType,
+            String userEmailAddress,
             ReproveIdentityClaimValue reproveIdentityValue) {
         String audience = IPV_CORE_AUDIENCE;
         String redirectUri = ORCHESTRATOR_REDIRECT_URL;
@@ -83,9 +84,7 @@ public class JwtBuilder {
                         .claim("state", UUID.randomUUID().toString())
                         .claim("govuk_signin_journey_id", signInJourneyId)
                         .claim("persistent_session_id", UUID.randomUUID().toString())
-                        .claim(
-                                "email_address",
-                                "dev-platform-testing@digital.cabinet-office.gov.uk")
+                        .claim("email_address", userEmailAddress)
                         .claim("vtr", List.of(vtr));
 
         if (reproveIdentityValue != ReproveIdentityClaimValue.NOT_PRESENT) {

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -75,6 +75,10 @@
                     <option value="FALSE">false</option>
                 </select>
             </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="emailAddress">Enter user's email address manually</label>
+                <input class="govuk-input" data-module="govuk-input" name="emailAddress" id="emailAddress" type="text" value="dev-platform-testing@digital.cabinet-office.gov.uk">
+            </div>
 
             <input class="govuk-button" data-module="govuk-button" type="submit" value="Full journey route">
         </form>


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add an input to the orch stub UI to allow overriding of the user's email address

### Why did it change

We will be adding email sending to core and need to control where the email goes during testing.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-4140](https://govukverify.atlassian.net/browse/PYI-4140)

