### PR TITLE
PYIC 4188: added a new property 'issuers' in the contraIndicator and GetContraIndicatorCredential Lambda's response in the cimit-stub

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
@@ -30,6 +30,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,6 +50,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
     public static final String MITIGATION = "mitigation";
     public static final String MITIGATION_CREDENTIAL = "mitigatingCredential";
     public static final String ISSUANCE_DATE = "issuanceDate";
+    public static final String ISSUERS = "issuers";
 
     private static final ObjectMapper mapper = new ObjectMapper();
     private final ConfigService configService;
@@ -164,6 +166,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
         for (CimitStubItem cimitStubItem : cimitStubItems) {
             Map<String, Object> contraIndicator = new LinkedHashMap<>();
             contraIndicator.put(CODE, cimitStubItem.getContraIndicatorCode());
+            contraIndicator.put(ISSUERS, Arrays.asList(configService.getIssuers().split("\\,")));
             contraIndicator.put(ISSUANCE_DATE, cimitStubItem.getIssuanceDate().toString());
             contraIndicator.put(MITIGATION, getMitigations(cimitStubItem.getMitigations()));
             contraIndicators.add(contraIndicator);

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.CODE;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.CONTRA_INDICATORS;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.ISSUANCE_DATE;
+import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.ISSUERS;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.MITIGATION;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.MITIGATION_CREDENTIAL;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.SECURITY_CHECK_CREDENTIAL_VC_TYPE;
@@ -56,6 +57,7 @@ class GetContraIndicatorCredentialHandlerTest {
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM+QJXk0PI339EyYkt6tjgfS+RcOMQNO";
     private static final String CIMIT_PUBLIC_JWK =
             "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
+    public static final String ISSUERS_TEST = "https://review-d.account.gov.uk,https://review-f.account.gov.uk";
 
     private static final String CIMIT_COMPONENT_ID = "https://cimit.stubs.account.gov.uk";
 
@@ -75,6 +77,7 @@ class GetContraIndicatorCredentialHandlerTest {
             throws IOException, ParseException, JOSEException {
         when(mockConfigService.getCimitSigningKey()).thenReturn(CIMIT_PRIVATE_KEY);
         when(mockConfigService.getCimitComponentId()).thenReturn(CIMIT_COMPONENT_ID);
+        when(mockConfigService.getIssuers()).thenReturn(ISSUERS_TEST);
         List<CimitStubItem> cimitStubItems = new ArrayList<>();
         Instant issuanceDate = Instant.now();
         cimitStubItems.add(
@@ -164,6 +167,10 @@ class GetContraIndicatorCredentialHandlerTest {
         assertEquals(1, contraIndicators.size());
         JsonNode firstCINode = contraIndicators.get(0);
         assertEquals(CI_V_03, firstCINode.get(CODE).asText());
+        JsonNode issuers = firstCINode.get(ISSUERS);
+        assertEquals(2, issuers.size());
+        assertEquals("https://review-d.account.gov.uk", issuers.get(0).asText());
+        assertEquals("https://review-f.account.gov.uk", issuers.get(1).asText());
         assertEquals(issuanceDate.toString(), firstCINode.get(ISSUANCE_DATE).asText());
         JsonNode mitigations = firstCINode.get(MITIGATION);
         assertEquals(1, mitigations.size());

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -57,7 +57,8 @@ class GetContraIndicatorCredentialHandlerTest {
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM+QJXk0PI339EyYkt6tjgfS+RcOMQNO";
     private static final String CIMIT_PUBLIC_JWK =
             "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
-    public static final String ISSUERS_TEST = "https://review-d.account.gov.uk,https://review-f.account.gov.uk";
+    public static final String ISSUERS_TEST =
+            "https://review-d.account.gov.uk,https://review-f.account.gov.uk";
 
     private static final String CIMIT_COMPONENT_ID = "https://cimit.stubs.account.gov.uk";
 

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -13,6 +13,7 @@ public class ConfigService {
 
     public static final String CIMIT_SIGNING_KEY_PARAM = "signingKey";
     public static final String CIMIT_COMPONENT_ID_PARAM = "componentId";
+    public static final String CIMIT_CONTRAINDICATOR_ISSUERS = "issuers";
     private final SSMProvider ssmProvider;
 
     public ConfigService(SSMProvider ssmProvider) {
@@ -35,6 +36,11 @@ public class ConfigService {
     public String getCimitSigningKey() {
         String cimitParamBasePath = getEnvironmentVariable(CIMIT_PARAM_BASE_PATH);
         return getSsmParameter(cimitParamBasePath + CIMIT_SIGNING_KEY_PARAM);
+    }
+
+    public String getIssuers() {
+        String cimitParamBasePath = getEnvironmentVariable(CIMIT_PARAM_BASE_PATH);
+        return getSsmParameter(cimitParamBasePath + CIMIT_CONTRAINDICATOR_ISSUERS);
     }
 
     private String getSsmParameter(String ssmParamKey, String... pathProperties) {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

added a new property 'issuers' in the contraIndicator and GetContraIndicatorCredential Lambda's response in the cimit-stub

### Why did it change

The GetContraIndicatorCredential Stub Lambda should return issuers from response like Cimit service

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4188](https://govukverify.atlassian.net/browse/PYIC-4188)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4188]: https://govukverify.atlassian.net/browse/PYIC-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ