### PR TITLE
PYIC 4188: call to stub management handler lambda for add issuer to t…

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
@@ -49,6 +49,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
     public static final String MITIGATION = "mitigation";
     public static final String MITIGATION_CREDENTIAL = "mitigatingCredential";
     public static final String ISSUANCE_DATE = "issuanceDate";
+    public static final String ISSUERS = "issuers";
 
     private static final ObjectMapper mapper = new ObjectMapper();
     private final ConfigService configService;
@@ -164,6 +165,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
         for (CimitStubItem cimitStubItem : cimitStubItems) {
             Map<String, Object> contraIndicator = new LinkedHashMap<>();
             contraIndicator.put(CODE, cimitStubItem.getContraIndicatorCode());
+            contraIndicator.put(ISSUERS, cimitStubItem.getIssuers());
             contraIndicator.put(ISSUANCE_DATE, cimitStubItem.getIssuanceDate().toString());
             contraIndicator.put(MITIGATION, getMitigations(cimitStubItem.getMitigations()));
             contraIndicators.add(contraIndicator);

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.CODE;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.CONTRA_INDICATORS;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.ISSUANCE_DATE;
+import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.ISSUERS;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.MITIGATION;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.MITIGATION_CREDENTIAL;
 import static uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler.SECURITY_CHECK_CREDENTIAL_VC_TYPE;
@@ -56,9 +57,9 @@ class GetContraIndicatorCredentialHandlerTest {
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM+QJXk0PI339EyYkt6tjgfS+RcOMQNO";
     private static final String CIMIT_PUBLIC_JWK =
             "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
+    public static final String ISSUERS_TEST = "https://review-d.account.gov.uk";
 
     private static final String CIMIT_COMPONENT_ID = "https://cimit.stubs.account.gov.uk";
-
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock private Context mockContext;
@@ -81,6 +82,7 @@ class GetContraIndicatorCredentialHandlerTest {
                 CimitStubItem.builder()
                         .userId(USER_ID)
                         .contraIndicatorCode(CI_V_03)
+                        .issuers(List.of(ISSUERS_TEST))
                         .issuanceDate(issuanceDate)
                         .mitigations(List.of(MITIGATION_M_01))
                         .build());
@@ -164,6 +166,9 @@ class GetContraIndicatorCredentialHandlerTest {
         assertEquals(1, contraIndicators.size());
         JsonNode firstCINode = contraIndicators.get(0);
         assertEquals(CI_V_03, firstCINode.get(CODE).asText());
+        JsonNode issuers = firstCINode.get(ISSUERS);
+        assertEquals(1, issuers.size());
+        assertEquals(ISSUERS_TEST, issuers.get(0).asText());
         assertEquals(issuanceDate.toString(), firstCINode.get(ISSUANCE_DATE).asText());
         JsonNode mitigations = firstCINode.get(MITIGATION);
         assertEquals(1, mitigations.size());

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
@@ -161,6 +161,7 @@ public class ContraIndicatorsService {
                         cimitStubItemService.persistCimitStub(
                                 userId,
                                 cimitStubItem.getContraIndicatorCode().toUpperCase(),
+                                cimitStubItem.getIssuers(),
                                 cimitStubItem.getIssuanceDate(),
                                 Collections.emptyList());
                     } else {

--- a/di-ipv-cimit-stub/lambdas/stub-management/src/main/java/uk/gov/di/ipv/core/stubmanagement/model/UserCisRequest.java
+++ b/di-ipv-cimit-stub/lambdas/stub-management/src/main/java/uk/gov/di/ipv/core/stubmanagement/model/UserCisRequest.java
@@ -22,4 +22,7 @@ public class UserCisRequest {
 
     @JsonProperty("mitigations")
     private List<String> mitigations;
+
+    @JsonProperty("issuer")
+    private String issuer;
 }

--- a/di-ipv-cimit-stub/lambdas/stub-management/src/test/java/uk/gov/di/ipv/core/stubmanagement/service/UserServiceTest.java
+++ b/di-ipv-cimit-stub/lambdas/stub-management/src/test/java/uk/gov/di/ipv/core/stubmanagement/service/UserServiceTest.java
@@ -37,11 +37,13 @@ public class UserServiceTest {
                 List.of(
                         UserCisRequest.builder()
                                 .code("code1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(List.of("V01", "V03"))
                                 .build(),
                         UserCisRequest.builder()
                                 .code("code2")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(Collections.emptyList())
                                 .build());
@@ -51,7 +53,7 @@ public class UserServiceTest {
         assertDoesNotThrow(() -> userService.addUserCis(userId, userCisRequests));
 
         verify(cimitStubItemService, times(userCisRequests.size()))
-                .persistCimitStub(any(), any(), any(), any());
+                .persistCimitStub(any(), any(), any(), any(), any());
         verify(cimitStubItemService, never()).updateCimitStubItem(any());
     }
 
@@ -68,7 +70,7 @@ public class UserServiceTest {
         assertThrows(
                 BadRequestException.class, () -> userService.addUserCis(userId, userCisRequests));
 
-        verify(cimitStubItemService, never()).persistCimitStub(any(), any(), any(), any());
+        verify(cimitStubItemService, never()).persistCimitStub(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -77,13 +79,22 @@ public class UserServiceTest {
         List<UserCisRequest> userCisRequests =
                 List.of(
                         UserCisRequest.builder()
-                                .code("code1")
+                                .code("CODE1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(List.of("V01", "V03"))
                                 .build());
         List<CimitStubItem> existingItems = new ArrayList<>();
         existingItems.add(
-                new CimitStubItem(userId, "code1", Instant.now(), 30000, new ArrayList<>()));
+                new CimitStubItem(
+                        userId,
+                        "CODE1",
+                        List.of(
+                                "https://review-d.account.gov.uk",
+                                "https://review-f.account.gov.uk"),
+                        Instant.now(),
+                        30000,
+                        new ArrayList<>()));
 
         when(cimitStubItemService.getCIsForUserId(userId)).thenReturn(existingItems);
 
@@ -99,20 +110,27 @@ public class UserServiceTest {
                 List.of(
                         UserCisRequest.builder()
                                 .code("code1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(List.of("V01"))
                                 .build());
 
         List<CimitStubItem> existingItems = new ArrayList<>();
         existingItems.add(
-                new CimitStubItem(userId, "code1", Instant.now(), 30000, new ArrayList<>()));
+                CimitStubItem.builder()
+                        .userId(userId)
+                        .contraIndicatorCode("code1")
+                        .issuanceDate(Instant.now())
+                        .ttl(30000)
+                        .mitigations(new ArrayList<>())
+                        .build());
 
         when(cimitStubItemService.getCIsForUserId(userId)).thenReturn(existingItems);
 
         assertDoesNotThrow(() -> userService.updateUserCis(userId, userCisRequests));
 
         verify(cimitStubItemService, times(userCisRequests.size()))
-                .persistCimitStub(any(), any(), any(), any());
+                .persistCimitStub(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -139,23 +157,41 @@ public class UserServiceTest {
                 List.of(
                         UserCisRequest.builder()
                                 .code("code1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(List.of("V01"))
                                 .build());
 
         List<CimitStubItem> existingItems =
                 List.of(
-                        new CimitStubItem(userId, "code1", Instant.now(), 30000, new ArrayList<>()),
-                        new CimitStubItem(userId, "code2", Instant.now(), 30000, new ArrayList<>()),
-                        new CimitStubItem(
-                                userId, "code3", Instant.now(), 30000, new ArrayList<>()));
+                        CimitStubItem.builder()
+                                .userId(userId)
+                                .contraIndicatorCode("code1")
+                                .issuanceDate(Instant.now())
+                                .ttl(30000)
+                                .mitigations(new ArrayList<>())
+                                .build(),
+                        CimitStubItem.builder()
+                                .userId(userId)
+                                .contraIndicatorCode("code2")
+                                .issuanceDate(Instant.now())
+                                .ttl(30000)
+                                .mitigations(new ArrayList<>())
+                                .build(),
+                        CimitStubItem.builder()
+                                .userId(userId)
+                                .contraIndicatorCode("code3")
+                                .issuanceDate(Instant.now())
+                                .ttl(30000)
+                                .mitigations(new ArrayList<>())
+                                .build());
 
         when(cimitStubItemService.getCIsForUserId(userId)).thenReturn(existingItems);
 
         assertDoesNotThrow(() -> userService.updateUserCis(userId, userCisRequests));
 
         verify(cimitStubItemService, times(userCisRequests.size()))
-                .persistCimitStub(any(), any(), any(), any());
+                .persistCimitStub(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -164,12 +200,20 @@ public class UserServiceTest {
         List<UserCisRequest> userCisRequests =
                 List.of(
                         UserCisRequest.builder()
-                                .code("code1")
+                                .code("CODE1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(List.of("V01", "V03"))
                                 .build());
         List<CimitStubItem> existingItems =
-                List.of(new CimitStubItem(userId, "code1", Instant.now(), 30000, null));
+                List.of(
+                        CimitStubItem.builder()
+                                .userId(userId)
+                                .contraIndicatorCode("CODE1")
+                                .issuanceDate(Instant.now())
+                                .ttl(30000)
+                                .mitigations(null)
+                                .build());
 
         when(cimitStubItemService.getCIsForUserId(userId)).thenReturn(existingItems);
 
@@ -184,14 +228,24 @@ public class UserServiceTest {
         List<UserCisRequest> userCisRequests =
                 List.of(
                         UserCisRequest.builder()
-                                .code("code1")
+                                .code("CODE1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(null)
                                 .build());
         List<CimitStubItem> existingItems =
                 List.of(
-                        new CimitStubItem(
-                                userId, "code1", Instant.now(), 30000, List.of("V01", "V03")));
+                        CimitStubItem.builder()
+                                .userId(userId)
+                                .contraIndicatorCode("CODE1")
+                                .issuers(
+                                        List.of(
+                                                "https://review-d.account.gov.uk",
+                                                "https://review-f.account.gov.uk"))
+                                .issuanceDate(Instant.now())
+                                .ttl(30000)
+                                .mitigations(List.of("V01", "V03"))
+                                .build());
 
         when(cimitStubItemService.getCIsForUserId(userId)).thenReturn(existingItems);
 
@@ -206,12 +260,20 @@ public class UserServiceTest {
         List<UserCisRequest> userCisRequests =
                 List.of(
                         UserCisRequest.builder()
-                                .code("code1")
+                                .code("CODE1")
+                                .issuer("https://review-d.account.gov.uk")
                                 .issuanceDate("2023-07-25T10:00:00Z")
                                 .mitigations(null)
                                 .build());
         List<CimitStubItem> existingItems =
-                List.of(new CimitStubItem(userId, "code1", Instant.now(), 30000, null));
+                List.of(
+                        CimitStubItem.builder()
+                                .userId(userId)
+                                .contraIndicatorCode("CODE1")
+                                .issuanceDate(Instant.now())
+                                .ttl(30000)
+                                .mitigations(null)
+                                .build());
 
         when(cimitStubItemService.getCIsForUserId(userId)).thenReturn(existingItems);
 

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/items/CimitStubItem.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/items/CimitStubItem.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 public class CimitStubItem implements DynamodbItem {
     private String userId;
     private String contraIndicatorCode;
+    private List<String> issuers;
     private Instant issuanceDate;
     private long ttl;
     private List<String> mitigations;

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/CimitStubItemService.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/CimitStubItemService.java
@@ -43,6 +43,7 @@ public class CimitStubItemService {
     public CimitStubItem persistCimitStub(
             String userId,
             String contraIndicatorCode,
+            List<String> issuers,
             Instant issuanceDate,
             List<String> mitigations) {
 
@@ -50,6 +51,7 @@ public class CimitStubItemService {
                 CimitStubItem.builder()
                         .userId(userId)
                         .contraIndicatorCode(contraIndicatorCode)
+                        .issuers(issuers)
                         .issuanceDate(issuanceDate)
                         .mitigations(mitigations)
                         .build();

--- a/di-ipv-cimit-stub/lib/src/test/java/uk/gov/di/ipv/core/library/service/CimitStubItemServiceTest.java
+++ b/di-ipv-cimit-stub/lib/src/test/java/uk/gov/di/ipv/core/library/service/CimitStubItemServiceTest.java
@@ -60,9 +60,10 @@ class CimitStubItemServiceTest {
         String ciCode = "V03";
         List<String> mitigations = List.of("V01", "V03");
         Instant issuanceDate = Instant.now();
+        List<String> issuer = List.of("https://address-cri.stubs.account.gov.uk");
 
         CimitStubItem cimitStubItem =
-                classToTest.persistCimitStub(USER_ID, ciCode, issuanceDate, mitigations);
+                classToTest.persistCimitStub(USER_ID, ciCode, issuer, issuanceDate, mitigations);
 
         ArgumentCaptor<CimitStubItem> cimitStubItemArgumentCaptor =
                 ArgumentCaptor.forClass(CimitStubItem.class);

--- a/di-ipv-cimit-stub/openAPI/cimit-external.yaml
+++ b/di-ipv-cimit-stub/openAPI/cimit-external.yaml
@@ -59,7 +59,7 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "input": “{ \"userId\": \"$input.params('userId')\", \"code\": \"$input.body('code')\", \"issuanceDate\": \"$input.body('issuanceDate')\", \"mitigations\": \"$input.body('mitigations')\ "}"
+                "input": “{ \"userId\": \"$input.params('userId')\", \"code\": \"$input.body('code')\", \"issuanceDate\": \"$input.body('issuanceDate')\", \"mitigations\": \"$input.body('mitigations')\, \"issuer\": \"$input.body('issuer')\ "}"
               }
         responses:
           default:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

If Any ContraIndicator(CI) is set within any CRI stub, invoke to the POST CIS operation in Cimit Stub's Stub Management. This way, we store the 'issuers' within the CimitStubItem   

### Why did it change

So, can add issuers within the response from  GetContraIndicatorCredential CimitStub's lambda, similar to how it is done in the SPOT CIMIT's response 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4188](https://govukverify.atlassian.net/browse/PYIC-4188)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4188]: https://govukverify.atlassian.net/browse/PYIC-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ