### PR TITLE
OJ-2217: Config preprod checkhmrc

### DIFF
--- a/di-ipv-core-stub/deploy/cri-preprod/template.yaml
+++ b/di-ipv-core-stub/deploy/cri-preprod/template.yaml
@@ -34,6 +34,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri-preprod/env/API_KEY_CRI_ADDRESS_PRE_PROD" #pragma: allowlist secret
+  ApiKeyCriCheckHmrcPreProd:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri-preprod/env/API_KEY_CRI_CHECK_HMRC_PRE_PROD"
   ApiKeyCriKbvPreProd:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -571,6 +575,8 @@ Resources:
             Value: !Ref CoreStubBasicAuth
           - Name: API_KEY_CRI_ADDRESS_PRE_PROD
             Value: !Ref ApiKeyCriAddressPreProd
+          - Name: API_KEY_CRI_CHECK_HMRC_PRE_PROD
+            Value: !Ref ApiKeyCriCheckHmrcPreProd
           - Name: API_KEY_CRI_KBV_PRE_PROD
             Value: !Ref ApiKeyCriKbvPreProd
           - Name: API_KEY_CRI_FRAUD_PRE_PROD


### PR DESCRIPTION
## Proposed changes

Added preprod config for check hmrc

### What changed

Enable core-stub pre-prod environment

- [OJ-2217](https://govukverify.atlassian.net/browse/OJ-2217)


[OJ-2217]: https://govukverify.atlassian.net/browse/OJ-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ