### PR TITLE
BAU: Give CRI stubs SSM perms

### DIFF
--- a/di-ipv-credential-issuer-stub/core-dev-deploy/activity-history/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/activity-history/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/address/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/bav/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/bav/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/claimed-identity/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/claimed-identity/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/driving-license/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/driving-license/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-1/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-2/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
@@ -576,9 +576,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/fraud/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/hmrc-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/hmrc-kbv/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/kbv/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/nino/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/nino/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/passport/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/toy/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/toy/template.yaml
@@ -565,9 +565,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/deploy/activity-history/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/activity-history/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/address/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/bav/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/bav/template.yaml
@@ -605,9 +605,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/di-ipv-credential-issuer-stub/deploy/claimed-identity/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/claimed-identity/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/driving-license/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/driving-license/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -603,9 +603,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
-                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*" #pragma: allowlist secret
-                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*" #pragma: allowlist secret
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/hmrc-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/hmrc-kbv/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/kbv/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/nino/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/nino/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
@@ -583,9 +583,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17

--- a/di-ipv-credential-issuer-stub/deploy/toy/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/toy/template.yaml
@@ -589,9 +589,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:GetParameters'
+                  - 'ssm:GetParametersByPath'
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/cri/*"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer-stub-clients/*"
         - PolicyName: GetDynatraceSecret #pragma: allowlist secret
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Give CRI stubs SSM perms

### Why did it change

A change was recently made to make the CRI stub fetch client config from the param store. I forgot to give it the correct permissions...

