### PR TITLE
LIME-911 Add API_KEY_CRI_FRAUD_DEV to ipv-core-stub template

### DIFF
--- a/di-ipv-core-stub/deploy/cri/template.yaml
+++ b/di-ipv-core-stub/deploy/cri/template.yaml
@@ -39,6 +39,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+  ApiKeyCriFraudDev:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri/env/API_KEY_CRI_FRAUD_DEV" #pragma: allowlist secret
   ApiKeyCriDrivingPermitDev:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -655,6 +659,8 @@ Resources:
             Value: !Ref CoreStubEnableBackendRoutes
           - Name: CORE_STUB_BASIC_AUTH
             Value: !Ref CoreStubBasicAuth
+          - Name: API_KEY_CRI_FRAUD_DEV
+            Value: !Ref ApiKeyCriFraudDev
           - Name: API_KEY_CRI_DL_DEV
             Value: !Ref ApiKeyCriDrivingPermitDev
           - Name: API_KEY_CRI_PASSPORTA_DEV


### PR DESCRIPTION
## Proposed changes

### What changed

Add API_KEY_CRI_FRAUD_DEV to ipv-core-stub template

### Why did it change

A pipeline stack is deployed for fraud-cri in dev, this adds the variable used for the api key to the ipv-core-stub

### Issue tracking

- [LIME-911](https://govukverify.atlassian.net/browse/LIME-911)



[LIME-911]: https://govukverify.atlassian.net/browse/LIME-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ