### PR TITLE
BAU: Add logging and exception handling to `sendAuthorizationRequest`

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -259,7 +259,7 @@ public class CoreStubHandler {
             };
 
     private <T> void sendAuthorizationRequest(
-            Request request, Response response, CredentialIssuer credentialIssuer, T sharedClaims) throws JOSEException, ParseException {
+            Request request, Response response, CredentialIssuer credentialIssuer, T sharedClaims) throws ParseException, JOSEException {
         State state = createNewState(credentialIssuer);
         request.session().attribute("state", state);
 
@@ -273,6 +273,9 @@ public class CoreStubHandler {
         } catch (ParseException parseException) {
             LOGGER.error("ParseException occurred," + parseException.getMessage());
             throw parseException;
+        } catch (Exception e) {
+            LOGGER.error("Unknown exception occurred," + e.getMessage());
+            throw e;
         }
 
         LOGGER.info("🚀 sending AuthorizationRequest for state {}", state);
@@ -283,10 +286,14 @@ public class CoreStubHandler {
                 LOGGER.info("Redirecting to {}", uri);
                 response.redirect(authRequest.toURI().toString());
             } else {
-                LOGGER.error("AuthorizationRequest URI object is null");
+                String error = "AuthorizationRequest URI object is null";
+                LOGGER.error(error);
+                throw new RuntimeException(error);
             }
         } else {
-            LOGGER.error("AuthorizationRequest object is null");
+            String error = "AuthorizationRequest object is null";
+            LOGGER.error(error);
+            throw new RuntimeException(error);
         }
     }
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -259,14 +259,16 @@ public class CoreStubHandler {
             };
 
     private <T> void sendAuthorizationRequest(
-            Request request, Response response, CredentialIssuer credentialIssuer, T sharedClaims) throws ParseException, JOSEException {
+            Request request, Response response, CredentialIssuer credentialIssuer, T sharedClaims)
+            throws ParseException, JOSEException {
         State state = createNewState(credentialIssuer);
         request.session().attribute("state", state);
 
         AuthorizationRequest authRequest;
 
         try {
-            authRequest = handlerHelper.createAuthorizationJAR(state, credentialIssuer, sharedClaims);
+            authRequest =
+                    handlerHelper.createAuthorizationJAR(state, credentialIssuer, sharedClaims);
         } catch (JOSEException joseException) {
             LOGGER.error("JOSEException occurred," + joseException.getMessage());
             throw joseException;
@@ -280,9 +282,9 @@ public class CoreStubHandler {
 
         LOGGER.info("🚀 sending AuthorizationRequest for state {}", state);
 
-        if(authRequest != null) {
+        if (authRequest != null) {
             URI uri = authRequest.toURI();
-            if(uri != null) {
+            if (uri != null) {
                 LOGGER.info("Redirecting to {}", uri);
                 response.redirect(authRequest.toURI().toString());
             } else {


### PR DESCRIPTION
## Proposed changes

### What changed
`sendAuthorizationRequest` method details

### Why did it change
When there's a problem in sendAuthorizationRequest, the CloudWatch logs will show `sending AuthorizationRequest for state` however there will be nothing else in the logs and a HTTP 500 status is returned. When debugging, there's no useful information present here so we wouldn't know what went wrong. 

The changes are to check for nulls and catch-log-rethrow exceptions to get better detailed logging. 
