### PR TITLE
BAU: Update the orch-stub default vtr value

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -126,7 +126,7 @@
                 <option value="non-recoverable">Non-Recoverable</option>
             </select>
             <input type="hidden" name="journeyType" value="full" />
-            <input type="hidden" name="vtrText" value="Cl.Cm.P2" />
+            <input type="hidden" name="vtrText" value="P2" />
             <input class="govuk-button" data-module="govuk-button" type="submit" value="Error journey route">
         </form>
     </main>


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the orch-stub default vtr value

### Why did it change

The vtr value is configurable on the orch-stub. The default is now wrong. The actual orch is now just sending P2. This updates our stub to match.

