### PR TITLE
BAU: Fix orch-stub vtr parsing

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -48,6 +48,7 @@ import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,10 +85,11 @@ public class IpvHandler {
                 String errorType = request.queryMap().get("error").value();
                 String userIdTextValue = request.queryMap().get("userIdText").value();
                 String signInJourneyIdText = request.queryMap().get("signInJourneyIdText").value();
-                String[] vtr =
-                        request.queryMap().hasKey("vtrText")
-                                ? request.queryMap("vtrText").values()
-                                : new String[] {"P2"};
+                List<String> vtr =
+                        Arrays.stream(request.queryMap("vtrText").value().split(","))
+                                .map(String::trim)
+                                .filter(value -> !value.isEmpty())
+                                .toList();
                 String vot = request.queryMap().get("votText").value();
                 String userEmailAddress = request.queryMap().get("emailAddress").value();
                 String reproveIdentityString = request.queryMap().get("reproveIdentity").value();

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -63,7 +63,7 @@ public class JwtBuilder {
             String userId,
             String signInJourneyId,
             String state,
-            String[] vtr,
+            List<String> vtr,
             String errorType,
             String userEmailAddress,
             ReproveIdentityClaimValue reproveIdentityValue,
@@ -106,7 +106,7 @@ public class JwtBuilder {
                         .claim("govuk_signin_journey_id", signInJourneyId)
                         .claim("persistent_session_id", UUID.randomUUID().toString())
                         .claim("email_address", userEmailAddress)
-                        .claim("vtr", List.of(vtr));
+                        .claim("vtr", vtr);
         if (reproveIdentityValue != ReproveIdentityClaimValue.NOT_PRESENT) {
             claimSetBuilder.claim(
                     "reprove_identity", reproveIdentityValue == ReproveIdentityClaimValue.TRUE);

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -70,7 +70,7 @@
                 <input class="govuk-input" data-module="govuk-input" name="signInJourneyIdText" id="signInJourneyIdText" type="text" value={{signInJourneyId}} readonly="readonly">
             </div>
             <div class="govuk-form-group">
-                <label class="govuk-label" for="vtrText">Enter vtr manually</label>
+                <label class="govuk-label" for="vtrText">Enter vtr manually - comma separated list for multiple values</label>
                 <input class="govuk-input" data-module="govuk-input" name="vtrText" id="vtrText" type="text" value="P2">
             </div>
             <div class="govuk-form-group">


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix orch-stub vtr parsing

### Why did it change

The value entered in the input on the front page of orch stub was being read as a single array with one string in. This chops the value up on a space delimiter to allow multiple values.

We were also wrapping the array inside a list when setting it on the claimsSet. This just sets the array as the value, which is what we acutally want.
