### PR TITLE
BAU: Remove CLIENT_CONFIG_FILE from CRI stub

### DIFF
--- a/di-ipv-credential-issuer-stub/core-dev-deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/address/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/address/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/address/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/bav/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/bav/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/bav/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/bav/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store" #pragma: allowlist secret
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/claimed-identity/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/claimed-identity/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/claimed-identity/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/claimed-identity/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/dcmaw/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/dcmaw/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/dcmaw/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/dcmaw/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -461,8 +457,6 @@ Resources:
             Value: !Ref CredentialIssuerType
           - Name: MITIGATION_ENABLED
             Value: !Ref CredentialMitigationEnabled
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/driving-license/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/driving-license/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/driving-license/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/driving-license/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-1/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/error-testing-1/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/error-testing-1/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-2/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/error-testing-2/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/error-testing-2/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/f2f/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/f2f/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -462,8 +458,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/fraud/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/fraud/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/fraud/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/hmrc-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/hmrc-kbv/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/hmrc-kbv/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/hmrc-kbv/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/kbv/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/kbv/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/kbv/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/nino/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/nino/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/nino/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/nino/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/passport/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/passport/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/passport/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store" #pragma: allowlist secret
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/toy/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/toy/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/toy/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/toy/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -455,8 +451,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/address/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/address/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/address/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/bav/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/bav/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/bav/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/bav/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -495,8 +491,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/claimed-identity/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/claimed-identity/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/claimed-identity/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/claimed-identity/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/dcmaw/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/dcmaw/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/dcmaw/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/dcmaw/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -506,8 +502,6 @@ Resources:
             Value: !Ref CredentialIssuerType
           - Name: MITIGATION_ENABLED
             Value: !Ref CredentialMitigationEnabled
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/driving-license/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/driving-license/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/driving-license/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/driving-license/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/error-testing-1/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/error-testing-1/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/error-testing-2/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/error-testing-2/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/f2f/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/f2f/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -510,8 +506,6 @@ Resources:
             Value: !Ref CredentialIssuerType
           - Name: MITIGATION_ENABLED
             Value: !Ref CredentialMitigationEnabled
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/fraud/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/fraud/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/hmrc-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/hmrc-kbv/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/hmrc-kbv/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/hmrc-kbv/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/kbv/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/kbv/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/kbv/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/nino/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/nino/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/nino/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/nino/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/passport/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/passport/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store" #pragma: allowlist secret
     Type: AWS::SSM::Parameter::Value<String>
@@ -494,8 +490,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER

--- a/di-ipv-credential-issuer-stub/deploy/toy/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/toy/template.yaml
@@ -40,10 +40,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/toy/env/CREDENTIAL_ISSUER_TYPE" #pragma: allowlist secret
-  ClientConfigFile:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/credential-issuer/toy/env/CLIENT_CONFIG_FILE" #pragma: allowlist secret
   ClientAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -500,8 +496,6 @@ Resources:
             Value: !Ref CredentialIssuerName
           - Name: CREDENTIAL_ISSUER_TYPE
             Value: !Ref CredentialIssuerType
-          - Name: CLIENT_CONFIG_FILE
-            Value: !Ref ClientConfigFile
           - Name: CLIENT_AUDIENCE
             Value: !Ref ClientAudience
           - Name: VC_ISSUER


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove CLIENT_CONFIG_FILE from CRI stub

### Why did it change

The CRI stub was recently updated to load client config from SSM, meaning it no longer requires this param. Referencing it can be removed ahead of removing the actualy SSM param.
