### PR TITLE
OJ-2216: update url to 3rdparty

### DIFF
--- a/di-ipv-core-stub/deploy/cri-3rdparty/template.yaml
+++ b/di-ipv-core-stub/deploy/cri-3rdparty/template.yaml
@@ -272,13 +272,13 @@ Resources:
     Properties:
       DomainName: !If
         - IsCoreDev
-        - !Sub "cri-${Environment}.core.dev.stubs.account.gov.uk"
-        - !If [IsNonProd, !Sub "cri.core.${Environment}.stubs.account.gov.uk", cri.core.stubs.account.gov.uk]
+        - !Sub "cri-3rdparty${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "cri-3rdparty.core.${Environment}.stubs.account.gov.uk", cri-3rdparty.core.stubs.account.gov.uk]
       DomainValidationOptions:
         - DomainName: !If
             - IsCoreDev
-            - !Sub "cri-${Environment}.core.dev.stubs.account.gov.uk"
-            - !If [IsNonProd, !Sub "cri.core.${Environment}.stubs.account.gov.uk", cri.core.stubs.account.gov.uk]
+            - !Sub "cri-3rdparty${Environment}.core.dev.stubs.account.gov.uk"
+            - !If [IsNonProd, !Sub "cri-3rdparty.core.${Environment}.stubs.account.gov.uk", cri-3rdparty.core.stubs.account.gov.uk]
           HostedZoneId: !If
             - IsCoreDev
             - !ImportValue DevPublicHostedZoneId
@@ -292,8 +292,8 @@ Resources:
       Type: A
       Name: !If
         - IsCoreDev
-        - !Sub "cri-${Environment}.core.dev.stubs.account.gov.uk"
-        - !If [IsNonProd, !Sub "cri.core.${Environment}.stubs.account.gov.uk", cri.core.stubs.account.gov.uk]
+        - !Sub "cri-3rdparty${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "cri-3rdparty.core.${Environment}.stubs.account.gov.uk", cri-3rdparty.core.stubs.account.gov.uk]
       HostedZoneId: !If
         - IsCoreDev
         - !ImportValue DevPublicHostedZoneId
@@ -393,8 +393,8 @@ Resources:
     Properties:
       DomainName: !If
         - IsCoreDev
-        - !Sub "cri-${Environment}.core.dev.stubs.account.gov.uk"
-        - !If [IsNonProd, !Sub "cri.core.${Environment}.stubs.account.gov.uk", cri.core.stubs.account.gov.uk]
+        - !Sub "cri-3rdparty${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "cri-3rdparty.core.${Environment}.stubs.account.gov.uk", cri-3rdparty.core.stubs.account.gov.uk]
       DomainNameConfigurations:
         - CertificateArn: !Ref CoreStubSSLCert
           EndpointType: REGIONAL
@@ -405,8 +405,8 @@ Resources:
     Properties:
       DomainName: !If
         - IsCoreDev
-        - !Sub "cri-${Environment}.core.dev.stubs.account.gov.uk"
-        - !If [IsNonProd, !Sub "cri.core.${Environment}.stubs.account.gov.uk", cri.core.stubs.account.gov.uk]
+        - !Sub "cri-3rdparty${Environment}.core.dev.stubs.account.gov.uk"
+        - !If [IsNonProd, !Sub "cri-3rdparty.core.${Environment}.stubs.account.gov.uk", cri-3rdparty.core.stubs.account.gov.uk]
       ApiId: !Ref ApiGwHttpEndpoint
       Stage: "$default"
     DependsOn:


### PR DESCRIPTION
## Proposed changes

Updated the stubs for the 3rdparty to have it's own url

### What changed

The introduction of a seperate client id for 3rdparty requires a new url

### Why did it change

Need for separate clientId just for 3rdparty



- [OJ-2216](https://govukverify.atlassian.net/browse/OJ-2216)



[OJ-2216]: https://govukverify.atlassian.net/browse/OJ-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ