### PR TITLE
BAU: scale down orch stub

### DIFF
--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -171,7 +171,7 @@ Mappings:
     "388905755587": #Stubs Prod
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
-      desiredTaskCount: 12
+      desiredTaskCount: 2
       environment: production
       platform: stubs
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret


### PR DESCRIPTION
We previously scaled up orch stub to 12 tasks for a load test, we can scale back down until we need to run another one.

(In future we may want to try and do this more automatically, but don't want to spend a lot of effort doing so)