### PR TITLE
Revert "BAU: Added logging to `getAuthorizationResponse`"

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -105,10 +105,6 @@ public class HandlerHelper {
 
     public AuthorizationResponse getAuthorizationResponse(Request request)
             throws ParseException, JsonProcessingException {
-        LOGGER.info("uri={}", request.uri());
-        LOGGER.info("url={}", request.url());
-        LOGGER.info("pathInfo={}", request.pathInfo());
-        LOGGER.info("requestMethod={}", request.requestMethod());
         var authorizationResponse =
                 AuthorizationResponse.parse(URI.create("https:///?" + request.queryString()));
         if (!authorizationResponse.indicatesSuccess()) {


### PR DESCRIPTION
Reverts govuk-one-login/ipv-stubs#625 as this was only added for temp debugging