### PR TITLE
BAU: Publish CRI stub encryption pubkey on JWKS endpoint

### DIFF
--- a/di-ipv-credential-issuer-stub/.gitignore
+++ b/di-ipv-credential-issuer-stub/.gitignore
@@ -33,5 +33,6 @@ build
 
 # Dev env stuff
 config
+!/src/test/java/uk/gov/di/ipv/stub/cred/config
 deploy/*/*-*.yaml
 core-dev-deploy/*/*-*.yaml

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/ClientConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/ClientConfig.java
@@ -1,12 +1,18 @@
 package uk.gov.di.ipv.stub.cred.config;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
 import lombok.Builder;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 
 @Builder
@@ -42,6 +48,16 @@ public class ClientConfig {
 
     public void setEncryptionPrivateKey(String encryptionPrivateKey) {
         this.base64EncryptionPrivateKey = base64EncryptionPrivateKey;
+    }
+
+    public JWK getEncryptionPublicKeyJwk()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
+        var privateKey = (RSAPrivateCrtKey) getEncryptionPrivateKey();
+        var publicKeySpec =
+                new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPublicExponent());
+        var keyFactory = KeyFactory.getInstance("RSA");
+        var publicKey = (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
+        return new RSAKey.Builder(publicKey).keyIDFromThumbprint().build();
     }
 
     public String getAudienceForVcJwt() {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/JwksHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/JwksHandler.java
@@ -17,9 +17,10 @@ public class JwksHandler {
 
     public Route getResource =
             (Request request, Response response) -> {
-                var docAppClientConfig = ConfigService.getClientConfig("authOrchestratorDocApp");
+                var docAppClientConfig = ConfigService.getClientConfig("orch-build");
                 var signingJWK = JWK.parse(docAppClientConfig.getSigningPublicJwk());
-                var jwkSet = new JWKSet(List.of(signingJWK));
+                var encryptionJWK = docAppClientConfig.getEncryptionPublicKeyJwk();
+                var jwkSet = new JWKSet(List.of(signingJWK, encryptionJWK));
 
                 response.type(RESPONSE_TYPE);
                 return jwkSet.toString(true);

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/config/ClientConfigTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/config/ClientConfigTest.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.stub.cred.config;
+
+import com.nimbusds.jose.JOSEException;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.stub.cred.fixtures.TestFixtures;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ClientConfigTest {
+    private static final ClientConfig CLIENT_CONFIG =
+            TestFixtures.CLIENT_CONFIG.get("clientIdValid");
+
+    @Test
+    void getEncryptionPublicKeyJwkReturnsTheCorrectValues()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
+        assertEquals(
+                "{\"kty\":\"RSA\",\"e\":\"AQAB\",\"kid\":\"hHgevr-0hbkWqJ5LBLyamKO3_Sag2qjj5z12Kdmmcnw\",\"n\":\"wFrdS8EQCKiD15ruRA7HWyOGhyVtNZaWrX9EFecIe6OAbBDxGKcPBKmRU03nwx5LziEhM_ce5l4kySk72lX0a-ze5dojjfLztRYpgbI9DaEp3_FLGrZJFjOd-piOIgYABk4a5MvPn9YVxJs6XviQNe8IeSzclLGWMWGW8TENpZ1bpFCqkabES7G_uEM0kdhhgaZgUxi-RYQHPqhm6MOdgRqbiy21P0NHTEVKrikYjvXewSBqmgLUPQi850Ojs1wPdYTThj5BObYwz9hJVmbHTHoPh0H4Fdja1opcS5etoHkNYOy37So8CksV6s6ur7zUqa9FTLMrMVva7joDtsWbWJ8l3jay_OHEwRR9DSoLuabZi-kVzFFSvxdCMNvW2D2cRw3GYmG0i8qs11tljQLLEtKa2YrAdDREyEPYJGSXJ2CQxjldi36-iGb-s6A1YSB74qbWdmW1ZKjpaOfkfrTAgqhqG9QDkwhOJNBnUCQ0ieZFauw1FI3NKG5XFR37JGND_YnLlBKX3W3LHeHcXSaJac618qGo81TWnW061S3LdUEg2XbtIrO--4Ge49ImtRMAkrhTR031w7d5gUrmelBq3siPfRadbbv9C5TCG8n3T35VJK4W2lGnIyYAssOpalr7T9NenO51qBf-h2N5UZ-ST5tNF03k9zzJtfND6DqCrHs\"}",
+                CLIENT_CONFIG.getEncryptionPublicKeyJwk().toString());
+    }
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
This is required by Orchestration for the DCMAW stub. Partially reverts changes made in 571b9e8a86b8cb04984f82560129e14461b6acf7

### Why did it change
Orchestration uses the DCMAW stub in the docapp journey. We call the jwks endpoint to fetch the public encryption key used to build the request. The referenced change broke the stub for us, but we pinned our version of the stub to an old commit for a while.

