### PR TITLE
[QA-438]: Scale down orch stub

### DIFF
--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -171,7 +171,7 @@ Mappings:
     "388905755587": #Stubs Prod
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
-      desiredTaskCount: 12
+      desiredTaskCount: 2
       environment: production
       platform: stubs
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret


### PR DESCRIPTION
Scale down Orchestrator stub to 2 tasks. The latest performance test failed and needs to be re-run. Scaling down orch stubs until the next run to avoid unnecessary costs.