### PR TITLE
BAU: Cache moustache templates

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/ViewHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/ViewHelper.java
@@ -6,7 +6,9 @@ import spark.template.mustache.MustacheTemplateEngine;
 import java.util.Map;
 
 public class ViewHelper {
-    public static String render(Map model, String templatePath) {
-        return new MustacheTemplateEngine().render(new ModelAndView(model, templatePath));
+    private static final MustacheTemplateEngine TEMPLATE_ENGINE = new MustacheTemplateEngine();
+
+    public static String render(Map<String, Object> model, String templatePath) {
+        return TEMPLATE_ENGINE.render(new ModelAndView(model, templatePath));
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/ViewHelper.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/utils/ViewHelper.java
@@ -6,7 +6,9 @@ import spark.template.mustache.MustacheTemplateEngine;
 import java.util.Map;
 
 public class ViewHelper {
-    public String render(Map model, String templatePath) {
-        return new MustacheTemplateEngine().render(new ModelAndView(model, templatePath));
+    private final MustacheTemplateEngine templateEngine = new MustacheTemplateEngine();
+
+    public String render(Map<String, Object> model, String templatePath) {
+        return templateEngine.render(new ModelAndView(model, templatePath));
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -225,7 +225,7 @@ public class IpvHandler {
             throws OrchestratorStubException, URISyntaxException {
         URI resolve =
                 getIpvBackchannelEndpoint(targetEnvironment).resolve(IPV_BACKCHANNEL_TOKEN_PATH);
-        logger.info("token url is " + resolve);
+        logger.debug("token url is " + resolve);
 
         SignedJWT signedClientJwt;
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/ViewHelper.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/ViewHelper.java
@@ -4,14 +4,11 @@ import spark.ModelAndView;
 import spark.template.mustache.MustacheTemplateEngine;
 
 import java.util.Map;
-import java.util.Set;
 
 public class ViewHelper {
-    public static String render(Map model, String templatePath) {
-        return new MustacheTemplateEngine().render(new ModelAndView(model, templatePath));
-    }
+    private static final MustacheTemplateEngine TEMPLATE_ENGINE = new MustacheTemplateEngine();
 
-    public static String renderSet(Set set, String templatePath) {
-        return new MustacheTemplateEngine().render(new ModelAndView(set, templatePath));
+    public static String render(Map<String, Object> model, String templatePath) {
+        return TEMPLATE_ENGINE.render(new ModelAndView(model, templatePath));
     }
 }


### PR DESCRIPTION
The current implementation constructs a new `MoustacheTemplateEngine` for every render, which loads the template from disk every time(!)

The default `MoustacheTemplateEngine` is thread-safe and caches templates by default, so we should use it as such.