### PR TITLE
BAU: Downgrade jackson for compatibility with powertools

### DIFF
--- a/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
@@ -16,7 +16,7 @@ java {
 
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.fasterxml.jackson.core:jackson-annotations:2.16.1",
+			"com.fasterxml.jackson.core:jackson-annotations:2.15.3",
 			"com.nimbusds:oauth2-oidc-sdk:9.27",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.0",
@@ -26,7 +26,7 @@ dependencies {
 	annotationProcessor "org.projectlombok:lombok:1.18.28"
 
 	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.16.1"
+			"software.amazon.lambda:powertools-tracing:1.18.0"
 	aspect('org.aspectj:aspectjrt') {
 		version {
 			strictly '1.9.8'

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-events:3.11.1",
 			"com.amazonaws:aws-java-sdk-dynamodb:1.12.669",
 			"software.amazon.awssdk:dynamodb-enhanced:2.25.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.16.1",
+			"com.fasterxml.jackson.core:jackson-annotations:2.15.3",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.0",
 			"com.nimbusds:oauth2-oidc-sdk:9.27",
@@ -29,7 +29,7 @@ dependencies {
 	annotationProcessor "org.projectlombok:lombok:1.18.28"
 
 	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.16.1"
+			"software.amazon.lambda:powertools-tracing:1.18.0"
 	aspect('org.aspectj:aspectjrt') {
 		version {
 			strictly '1.9.8'

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-events:3.11.1",
 			"com.amazonaws:aws-java-sdk-dynamodb:1.12.669",
 			"software.amazon.awssdk:dynamodb-enhanced:2.25.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.16.1",
+			"com.fasterxml.jackson.core:jackson-annotations:2.15.3",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.0",
 			project(":di-ipv-cimit-stub:lib")
@@ -28,7 +28,7 @@ dependencies {
 	annotationProcessor "org.projectlombok:lombok:1.18.28"
 
 	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.16.1"
+			"software.amazon.lambda:powertools-tracing:1.18.0"
 	aspect('org.aspectj:aspectjrt') {
 		version {
 			strictly '1.9.8'


### PR DESCRIPTION
Jackson 2.16 conflicts with the transitive Jackson dependency for lambda powertools, which is currently using a deprecated feature removed in 2.16.

Causes errors like: `java.lang.NoSuchFieldError: CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES`