### PR TITLE
PYIC-5082: Handle null credential subject and residence permits

### DIFF
--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/CredentialSubject.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/CredentialSubject.java
@@ -5,4 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record CredentialSubject(List<DrivingPermit> drivingPermit, List<Passport> passport) {}
+public record CredentialSubject(
+        List<DrivingPermit> drivingPermit,
+        List<Passport> passport,
+        List<ResidencePermit> residencePermit) {}

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/ResidencePermit.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/ResidencePermit.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.core.putcontraindicators.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ResidencePermit(
+        String documentType, String documentNumber, String icaoIssuerCode, String expiryDate)
+        implements Document {
+
+    private static final String RESIDENCE_PERMIT_IDENTIFIER_TEMPLATE = "residencePermit/%s/%s";
+
+    @Override
+    public String toIdentifier() {
+        return String.format(RESIDENCE_PERMIT_IDENTIFIER_TEMPLATE, icaoIssuerCode, documentNumber);
+    }
+}

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.putcontraindicators.service;
 
+import com.amazonaws.util.CollectionUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.LogManager;
@@ -9,7 +10,6 @@ import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
 import uk.gov.di.ipv.core.library.service.CimitStubItemService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.putcontraindicators.domain.PutContraIndicatorsRequest;
-import uk.gov.di.ipv.core.putcontraindicators.dto.CredentialSubject;
 import uk.gov.di.ipv.core.putcontraindicators.dto.Evidence;
 import uk.gov.di.ipv.core.putcontraindicators.dto.VcClaim;
 import uk.gov.di.ipv.core.putcontraindicators.exceptions.CiPutException;
@@ -145,13 +145,17 @@ public class ContraIndicatorsService {
     }
 
     private String getDocumentIdentifier(VcClaim vcClaim) {
-        CredentialSubject credentialSubject = vcClaim.credentialSubject();
-        if (credentialSubject.drivingPermit() != null
-                && !credentialSubject.drivingPermit().isEmpty()) {
-            return credentialSubject.drivingPermit().get(0).toIdentifier();
-        }
-        if (credentialSubject.passport() != null && !credentialSubject.passport().isEmpty()) {
-            return credentialSubject.passport().get(0).toIdentifier();
+        var credentialSubject = vcClaim.credentialSubject();
+        if (credentialSubject != null) {
+            if (!CollectionUtils.isNullOrEmpty(credentialSubject.drivingPermit())) {
+                return credentialSubject.drivingPermit().get(0).toIdentifier();
+            }
+            if (!CollectionUtils.isNullOrEmpty(credentialSubject.passport())) {
+                return credentialSubject.passport().get(0).toIdentifier();
+            }
+            if (!CollectionUtils.isNullOrEmpty(credentialSubject.residencePermit())) {
+                return credentialSubject.residencePermit().get(0).toIdentifier();
+            }
         }
         return null;
     }


### PR DESCRIPTION
- Our tests were breaking when processing a TICF VC with CIs, because they don't contain a `credentialSubject`
- We are not handling residence permits (e.g. BRP) for document types