### PR TITLE
PYIC-5057-Simulation-of-Expired-Fraud-VC-in-STUB-CRI

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -33,6 +33,7 @@ public class CredentialIssuerConfig {
     public static final String EXPIRY_HOURS = "expHours";
     public static final String EXPIRY_MINUTES = "expMinutes";
     public static final String EXPIRY_SECONDS = "expSeconds";
+    public static final String VC_NOT_BEFORE_FLAG_CHK_BOX_VALUE = "on";
     public static final String VC_NOT_BEFORE_FLAG = "vcNotBeforeFlg";
     public static final String VC_NOT_BEFORE_DAY = "vcNotBeforeDay";
     public static final String VC_NOT_BEFORE_MONTH = "vcNotBeforeMonth";

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -33,6 +33,13 @@ public class CredentialIssuerConfig {
     public static final String EXPIRY_HOURS = "expHours";
     public static final String EXPIRY_MINUTES = "expMinutes";
     public static final String EXPIRY_SECONDS = "expSeconds";
+    public static final String VC_NOT_BEFORE_FLAG = "vcNotBeforeFlg";
+    public static final String VC_NOT_BEFORE_DAY = "vcNotBeforeDay";
+    public static final String VC_NOT_BEFORE_MONTH = "vcNotBeforeMonth";
+    public static final String VC_NOT_BEFORE_YEAR = "vcNotBeforeYear";
+    public static final String VC_NOT_BEFORE_HOURS = "vcNotBeforeHours";
+    public static final String VC_NOT_BEFORE_MINUTES = "vcNotBeforeMinutes";
+    public static final String VC_NOT_BEFORE_SECONDS = "vcNotBeforeSeconds";
 
     private static final String CREDENTIAL_ISSUER_TYPE_VAR = "CREDENTIAL_ISSUER_TYPE";
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/Credential.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/Credential.java
@@ -8,18 +8,21 @@ public class Credential {
     private final String userId;
     private final String clientId;
     private final Long exp;
+    private final Long nbf;
 
     public Credential(
             Map<String, Object> attributes,
             Map<String, Object> evidence,
             String userId,
             String clientId,
-            Long exp) {
+            Long exp,
+            Long nbf) {
         this.attributes = attributes;
         this.evidence = evidence;
         this.userId = userId;
         this.clientId = clientId;
         this.exp = exp;
+        this.nbf = nbf;
     }
 
     public Map<String, Object> getAttributes() {
@@ -40,5 +43,9 @@ public class Credential {
 
     public Long getExp() {
         return exp;
+    }
+
+    public Long getNbf() {
+        return nbf;
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -385,7 +385,7 @@ public class AuthorizeHandler {
                     Long nbf = now.getEpochSecond();
                     if (notBeforeFlag != null
                             && notBeforeFlag.equals(
-                                    CredentialIssuerConfig.EXPIRY_FLAG_CHK_BOX_VALUE)) {
+                                    CredentialIssuerConfig.VC_NOT_BEFORE_FLAG_CHK_BOX_VALUE)) {
                         nbf = getNbf(queryParamsMap);
                     }
 
@@ -485,9 +485,9 @@ public class AuthorizeHandler {
         int nbfSeconds =
                 Integer.parseInt(
                         queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS));
-        LocalDateTime ldt =
+        LocalDateTime localDateTime =
                 LocalDateTime.of(nbfYear, nbfMonth, nbfDay, nbfHours, nbfMinutes, nbfSeconds);
-        Instant nbfInstant = ldt.atZone(ZoneId.systemDefault()).toInstant();
+        Instant nbfInstant = localDateTime.atZone(ZoneId.of("Europe/London")).toInstant();
         nbf = nbfInstant.getEpochSecond();
         return nbf;
     }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -410,10 +410,16 @@ public class AuthorizeHandler {
                                 Integer.parseInt(
                                         queryParamsMap.value(
                                                 CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS));
-                        LocalDateTime ldt = LocalDateTime.of(nbfYear, nbfMonth, nbfDay, nbfHours, nbfMinutes, nbfSeconds);
+                        LocalDateTime ldt =
+                                LocalDateTime.of(
+                                        nbfYear,
+                                        nbfMonth,
+                                        nbfDay,
+                                        nbfHours,
+                                        nbfMinutes,
+                                        nbfSeconds);
                         Instant nbfInstant = ldt.atZone(ZoneId.systemDefault()).toInstant();
                         nbf = nbfInstant.getEpochSecond();
-
                     }
 
                     String signedVcJwt =

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -59,6 +59,8 @@ import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -408,15 +410,10 @@ public class AuthorizeHandler {
                                 Integer.parseInt(
                                         queryParamsMap.value(
                                                 CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS));
-                        nbf =
-                                Instant.ofEpochSecond(0)
-                                        .plusSeconds(nbfSeconds)
-                                        .plusSeconds(60L * nbfMinutes)
-                                        .plusSeconds(3600L * nbfHours)
-                                        .plusSeconds(86400L * nbfDay)
-                                        .plusSeconds(2592000L * nbfMonth)
-                                        .plusSeconds(31536000L * nbfYear)
-                                        .getEpochSecond();
+                        LocalDateTime ldt = LocalDateTime.of(nbfYear, nbfMonth, nbfDay, nbfHours, nbfMinutes, nbfSeconds);
+                        Instant nbfInstant = ldt.atZone(ZoneId.systemDefault()).toInstant();
+                        nbf = nbfInstant.getEpochSecond();
+
                     }
 
                     String signedVcJwt =

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -386,40 +386,7 @@ public class AuthorizeHandler {
                     if (notBeforeFlag != null
                             && notBeforeFlag.equals(
                                     CredentialIssuerConfig.EXPIRY_FLAG_CHK_BOX_VALUE)) {
-                        int nbfDay =
-                                Integer.parseInt(
-                                        queryParamsMap.value(
-                                                CredentialIssuerConfig.VC_NOT_BEFORE_DAY));
-                        int nbfMonth =
-                                Integer.parseInt(
-                                        queryParamsMap.value(
-                                                CredentialIssuerConfig.VC_NOT_BEFORE_MONTH));
-                        int nbfYear =
-                                Integer.parseInt(
-                                        queryParamsMap.value(
-                                                CredentialIssuerConfig.VC_NOT_BEFORE_YEAR));
-                        int nbfHours =
-                                Integer.parseInt(
-                                        queryParamsMap.value(
-                                                CredentialIssuerConfig.VC_NOT_BEFORE_HOURS));
-                        int nbfMinutes =
-                                Integer.parseInt(
-                                        queryParamsMap.value(
-                                                CredentialIssuerConfig.VC_NOT_BEFORE_MINUTES));
-                        int nbfSeconds =
-                                Integer.parseInt(
-                                        queryParamsMap.value(
-                                                CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS));
-                        LocalDateTime ldt =
-                                LocalDateTime.of(
-                                        nbfYear,
-                                        nbfMonth,
-                                        nbfDay,
-                                        nbfHours,
-                                        nbfMinutes,
-                                        nbfSeconds);
-                        Instant nbfInstant = ldt.atZone(ZoneId.systemDefault()).toInstant();
-                        nbf = nbfInstant.getEpochSecond();
+                        nbf = getNbf(queryParamsMap);
                     }
 
                     String signedVcJwt =
@@ -501,6 +468,29 @@ public class AuthorizeHandler {
                 }
                 return null;
             };
+
+    private static Long getNbf(QueryParamsMap queryParamsMap) {
+        Long nbf;
+        int nbfDay =
+                Integer.parseInt(queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_DAY));
+        int nbfMonth =
+                Integer.parseInt(queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_MONTH));
+        int nbfYear =
+                Integer.parseInt(queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_YEAR));
+        int nbfHours =
+                Integer.parseInt(queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_HOURS));
+        int nbfMinutes =
+                Integer.parseInt(
+                        queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_MINUTES));
+        int nbfSeconds =
+                Integer.parseInt(
+                        queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS));
+        LocalDateTime ldt =
+                LocalDateTime.of(nbfYear, nbfMonth, nbfDay, nbfHours, nbfMinutes, nbfSeconds);
+        Instant nbfInstant = ldt.atZone(ZoneId.systemDefault()).toInstant();
+        nbf = nbfInstant.getEpochSecond();
+        return nbf;
+    }
 
     private void processMitigatedCIs(
             String userId, QueryParamsMap queryParamsMap, String signedVcJwt)

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -376,6 +376,49 @@ public class AuthorizeHandler {
                         }
                     }
 
+                    String notBeforeFlag =
+                            queryParamsMap.value(CredentialIssuerConfig.VC_NOT_BEFORE_FLAG);
+
+                    Instant now = Instant.now();
+                    Long nbf = now.getEpochSecond();
+                    if (notBeforeFlag != null
+                            && notBeforeFlag.equals(
+                                    CredentialIssuerConfig.EXPIRY_FLAG_CHK_BOX_VALUE)) {
+                        int nbfDay =
+                                Integer.parseInt(
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VC_NOT_BEFORE_DAY));
+                        int nbfMonth =
+                                Integer.parseInt(
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VC_NOT_BEFORE_MONTH));
+                        int nbfYear =
+                                Integer.parseInt(
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VC_NOT_BEFORE_YEAR));
+                        int nbfHours =
+                                Integer.parseInt(
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VC_NOT_BEFORE_HOURS));
+                        int nbfMinutes =
+                                Integer.parseInt(
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VC_NOT_BEFORE_MINUTES));
+                        int nbfSeconds =
+                                Integer.parseInt(
+                                        queryParamsMap.value(
+                                                CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS));
+                        nbf =
+                                Instant.ofEpochSecond(0)
+                                        .plusSeconds(nbfSeconds)
+                                        .plusSeconds(60L * nbfMinutes)
+                                        .plusSeconds(3600L * nbfHours)
+                                        .plusSeconds(86400L * nbfDay)
+                                        .plusSeconds(2592000L * nbfMonth)
+                                        .plusSeconds(31536000L * nbfYear)
+                                        .getEpochSecond();
+                    }
+
                     String signedVcJwt =
                             verifiableCredentialGenerator
                                     .generate(
@@ -384,7 +427,8 @@ public class AuthorizeHandler {
                                                     gpgMap,
                                                     userId,
                                                     clientIdValue,
-                                                    exp))
+                                                    exp,
+                                                    nbf))
                                     .serialize();
 
                     if (CredentialIssuerConfig.isEnabled(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -18,7 +18,6 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.Instant;
 import java.util.*;
 
 import static com.nimbusds.jwt.JWTClaimNames.AUDIENCE;
@@ -95,7 +94,6 @@ public class VerifiableCredentialGenerator {
     private SignedJWT generateAndSignVerifiableCredentialJwt(
             Credential credential, Map<String, Object> vc)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
-        Instant now = Instant.now();
         JWTClaimsSet.Builder claim =
                 new JWTClaimsSet.Builder()
                         .claim(SUBJECT, credential.getUserId())
@@ -104,7 +102,7 @@ public class VerifiableCredentialGenerator {
                                 AUDIENCE,
                                 ConfigService.getClientConfig(credential.getClientId())
                                         .getAudienceForVcJwt())
-                        .claim(NOT_BEFORE, now.getEpochSecond())
+                        .claim(NOT_BEFORE, credential.getNbf())
                         .claim(
                                 JWT_ID,
                                 String.format(
@@ -114,6 +112,7 @@ public class VerifiableCredentialGenerator {
         if (!Objects.isNull(credential.getExp())) {
             claim = claim.claim(EXPIRATION_TIME, credential.getExp());
         }
+
         JWTClaimsSet claimsSet = claim.build();
 
         KeyFactory kf = KeyFactory.getInstance(EC_ALGO);

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -432,7 +432,7 @@
                                             <div class="govuk-checkboxes__item">
                                                 <input class="govuk-checkboxes__input" type="checkbox" name="expand_evidence" id="expand_evidence">
                                                 <label class="govuk-label govuk-checkboxes__label" for="expand_evidence">
-                                                    Include evidence block
+                                                    Override evidence block
                                                 </label>
                                             </div>
                                         </div>
@@ -457,7 +457,7 @@
                                             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                                 <div class="govuk-checkboxes__item">
                                                     <input class="govuk-checkboxes__input" type="checkbox" name="vcNotBeforeFlg" id="vcNotBeforeFlg">
-                                                    <label class="govuk-label govuk-checkboxes__label" for="vc_not_before">Include VC Not Before</label>
+                                                    <label class="govuk-label govuk-checkboxes__label" for="vcNotBeforeFlg">Override VC Not Before (nbf)</label>
                                                 </div>
                                             </div>
                                         </div>
@@ -468,7 +468,7 @@
                                             <div class="govuk-date-input" id="vcNotBefore">
                                                 <div class="govuk-date-input__item">
                                                     <div class="govuk-form-group">
-                                                        <label class="govuk-label govuk-date-input__label" for="vc-not-before-day">
+                                                        <label class="govuk-label govuk-date-input__label" for="vcNotBeforeDay">
                                                             Day
                                                         </label>
                                                         <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="vcNotBeforeDay" name="vcNotBeforeDay" type="text" inputmode="numeric">
@@ -476,7 +476,7 @@
                                                 </div>
                                                 <div class="govuk-date-input__item">
                                                     <div class="govuk-form-group">
-                                                        <label class="govuk-label govuk-date-input__label" for="vc-not-before-month">
+                                                        <label class="govuk-label govuk-date-input__label" for="vcNotBeforeMonth">
                                                             Month
                                                         </label>
                                                         <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="vcNotBeforeMonth" name="vcNotBeforeMonth" type="text" inputmode="numeric">
@@ -490,7 +490,6 @@
                                                         <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="vcNotBeforeYear" name="vcNotBeforeYear" type="text" inputmode="numeric">
                                                     </div>
                                                 </div>
-<!--                                                add fields for hours minutes and second-->
                                                 <div class="govuk-date-input__item">
                                                     <div class="govuk-form-group">
                                                         <label class="govuk-label" for="strength">

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -759,8 +759,7 @@
     }
 
 //     set the default value for not before to six months ago
-    const defaultDate = new Date();
-    defaultDate.setMonth(defaultDate.getMonth() - 6);
+    const defaultDate = new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000);
     const defaultDay = defaultDate.getDate();
     const defaultMonth = defaultDate.getMonth() + 1;
     const defaultYear = defaultDate.getFullYear();

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -471,7 +471,7 @@
                                                         <label class="govuk-label govuk-date-input__label" for="vc-not-before-day">
                                                             Day
                                                         </label>
-                                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="vc-not-before-day" name="vcNotBeforeDay" type="text" inputmode="numeric">
+                                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="vcNotBeforeDay" name="vcNotBeforeDay" type="text" inputmode="numeric">
                                                     </div>
                                                 </div>
                                                 <div class="govuk-date-input__item">

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -447,6 +447,84 @@
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">
                                 <fieldset class="govuk-fieldset">
+                                    <div class="govuk-date-input" id="vcNotBeforeOverride">
+                                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                            <h1 class="govuk-fieldset__heading">
+                                                Override VC Not Before (optional)
+                                            </h1>
+                                        </legend>
+                                        <div class="govuk-form-group">
+                                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                                <div class="govuk-checkboxes__item">
+                                                    <input class="govuk-checkboxes__input" type="checkbox" name="vcNotBeforeFlg" id="vcNotBeforeFlg">
+                                                    <label class="govuk-label govuk-checkboxes__label" for="vc_not_before">Include VC Not Before</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-form-group" id="vc_not_before_override" style="display:none">
+                                            <div id="vc_not_before-hint" class="govuk-hint">
+                                                Defaults to six months ago
+                                            </div>
+                                            <div class="govuk-date-input" id="vcNotBefore">
+                                                <div class="govuk-date-input__item">
+                                                    <div class="govuk-form-group">
+                                                        <label class="govuk-label govuk-date-input__label" for="vc-not-before-day">
+                                                            Day
+                                                        </label>
+                                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="vc-not-before-day" name="vcNotBeforeDay" type="text" inputmode="numeric">
+                                                    </div>
+                                                </div>
+                                                <div class="govuk-date-input__item">
+                                                    <div class="govuk-form-group">
+                                                        <label class="govuk-label govuk-date-input__label" for="vc-not-before-month">
+                                                            Month
+                                                        </label>
+                                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="vcNotBeforeMonth" name="vcNotBeforeMonth" type="text" inputmode="numeric">
+                                                    </div>
+                                                </div>
+                                                <div class="govuk-date-input__item">
+                                                    <div class="govuk-form-group">
+                                                        <label class="govuk-label govuk-date-input__label" for="vcNotBeforeYear">
+                                                            Year
+                                                        </label>
+                                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="vcNotBeforeYear" name="vcNotBeforeYear" type="text" inputmode="numeric">
+                                                    </div>
+                                                </div>
+<!--                                                add fields for hours minutes and second-->
+                                                <div class="govuk-date-input__item">
+                                                    <div class="govuk-form-group">
+                                                        <label class="govuk-label" for="strength">
+                                                            Hours
+                                                        </label>
+                                                        <input class="govuk-input govuk-input--width-2" id="vcNotBeforeHours" name="vcNotBeforeHours" type="number" min="0" step="1" value="00">
+                                                    </div>
+                                                </div>
+                                                <div class="govuk-date-input__item">
+                                                    <div class="govuk-form-group">
+                                                        <label class="govuk-label" for="validity">
+                                                            Minutes
+                                                        </label>
+                                                        <input class="govuk-input govuk-input--width-2" id="vcNotBeforeMinutes" name="vcNotBeforeMinutes" type="number" min="0" step="1" value="00">
+                                                    </div>
+                                                </div>
+                                                <div class="govuk-date-input__item">
+                                                    <div class="govuk-form-group">
+                                                        <label class="govuk-label" for="activityHistory">
+                                                            Seconds
+                                                        </label>
+                                                        <input class="govuk-input govuk-input--width-2" id="vcNotBeforeSeconds" name="vcNotBeforeSeconds" type="number" min="0" step="1" value="00">
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </td>
+                        </tr>
+
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">
+                                <fieldset class="govuk-fieldset">
                                     <div class="govuk-date-input" id="vcJwtExpiry">
                                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                                             <h1 class="govuk-fieldset__heading">
@@ -667,6 +745,34 @@
         }
       });
     }
+
+    const vcNotBeforeCheckbox = document.getElementById('vcNotBeforeFlg');
+    const vcNotBeforeOverride = document.getElementById('vc_not_before_override');
+
+    if (vcNotBeforeCheckbox) {
+      vcNotBeforeCheckbox.addEventListener('change', function() {
+        if(this.checked) {
+          vcNotBeforeOverride.style.display = 'block';
+        } else {
+          vcNotBeforeOverride.style.display = 'none';
+        }
+      });
+    }
+
+//     set the default value for not before to six months ago
+    const defaultDate = new Date();
+    defaultDate.setMonth(defaultDate.getMonth() - 6);
+    const defaultDay = defaultDate.getDate();
+    const defaultMonth = defaultDate.getMonth() + 1;
+    const defaultYear = defaultDate.getFullYear();
+    document.getElementById('vcNotBeforeDay').value = defaultDay;
+    document.getElementById('vcNotBeforeMonth').value = defaultMonth;
+    document.getElementById('vcNotBeforeYear').value = defaultYear;
+    document.getElementById('vcNotBeforeHours').value = defaultDate.getHours();
+    document.getElementById('vcNotBeforeMinutes').value = defaultDate.getMinutes();
+    document.getElementById('vcNotBeforeSeconds').value = defaultDate.getSeconds();
+
+
 </script>
 
 </body>

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -588,6 +588,11 @@ class AuthorizeHandlerTest {
         assertEquals("test context", viewParamsCaptor.getValue().get("context").toString());
     }
 
+    @Test
+    void doAuthorizeShouldUseNotBeforeValueWhenNotBeforeInRequest() throws Exception {
+        Map<String, String[]> queryParams = validGenerateResponseQueryParams();
+    }
+
     private String createExpectedErrorQueryStringParams(ErrorObject error) {
         return createExpectedErrorQueryStringParams(error.getCode(), error.getDescription());
     }
@@ -719,6 +724,15 @@ class AuthorizeHandlerTest {
         queryParams.put(CredentialIssuerConfig.EXPIRY_HOURS, new String[] {"5"});
         queryParams.put(CredentialIssuerConfig.EXPIRY_MINUTES, new String[] {"0"});
         queryParams.put(CredentialIssuerConfig.EXPIRY_SECONDS, new String[] {"0"});
+        queryParams.put(
+                CredentialIssuerConfig.VC_NOT_BEFORE_FLAG,
+                new String[] {CredentialIssuerConfig.VC_NOT_BEFORE_FLAG_CHK_BOX_VALUE});
+        queryParams.put(CredentialIssuerConfig.VC_NOT_BEFORE_DAY, new String[] {"1"});
+        queryParams.put(CredentialIssuerConfig.VC_NOT_BEFORE_MONTH, new String[] {"1"});
+        queryParams.put(CredentialIssuerConfig.VC_NOT_BEFORE_YEAR, new String[] {"2022"});
+        queryParams.put(CredentialIssuerConfig.VC_NOT_BEFORE_HOURS, new String[] {"0"});
+        queryParams.put(CredentialIssuerConfig.VC_NOT_BEFORE_MINUTES, new String[] {"0"});
+        queryParams.put(CredentialIssuerConfig.VC_NOT_BEFORE_SECONDS, new String[] {"0"});
         return queryParams;
     }
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -108,7 +108,8 @@ public class VerifiableCredentialGeneratorTest {
                         evidence,
                         userId,
                         "clientIdValid",
-                        Instant.now().getEpochSecond() + 300);
+                        Instant.now().getEpochSecond() + 300,
+                        Instant.now().getEpochSecond());
 
         SignedJWT verifiableCredential = vcGenerator.generate(credential);
 
@@ -209,7 +210,8 @@ public class VerifiableCredentialGeneratorTest {
                         evidence,
                         userId,
                         "clientIdValid",
-                        Instant.now().getEpochSecond());
+                        Instant.now().getEpochSecond(),
+                        null);
 
         SignedJWT verifiableCredential = vcGenerator.generate(credential);
 
@@ -241,7 +243,8 @@ public class VerifiableCredentialGeneratorTest {
                         "strength", 4,
                         "validity", 2);
         String userId = "user-id";
-        Credential credential = new Credential(attributes, evidence, userId, "clientIdValid", null);
+        Credential credential =
+                new Credential(attributes, evidence, userId, "clientIdValid", null, null);
 
         SignedJWT verifiableCredential = vcGenerator.generate(credential);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
[PYIC-5057](https://govukverify.atlassian.net/browse/PYIC-5057) Simulation of Expired Fraud VC in STUB CRI

Implement functionality within the STUB Fraud CRI to simulate a user having an expired Fraud VC by setting the nbf (Not Before) property to a date greater than 6 months ago.

- Adds UI for setting the not before flag on the CI stubs
- Implements simulation of expired fraud for VCs using the nbf flag

<img width="1512" alt="Screenshot 2024-03-06 at 14 04 11" src="https://github.com/govuk-one-login/ipv-stubs/assets/11758541/057dd34c-e6b9-4686-9d6f-f7055a962a94">

<img width="1512" alt="Screenshot 2024-03-06 at 14 04 14" src="https://github.com/govuk-one-login/ipv-stubs/assets/11758541/3049bccf-143f-4122-965f-7d43958f5393">

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

To trigger the appropriate response in subsequent identity checks, compelling the user to complete an additional fraud check. This capability is crucial for testing and ensuring the IPV Core's interaction with the Fraud CRI accurately reflects real-world scenarios where a user's fraud verification credential (VC) has expired.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

[PYIC-5057](https://govukverify.atlassian.net/browse/PYIC-5057) 



[PYIC-5057]: https://govukverify.atlassian.net/browse/PYIC-5057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-5057]: https://govukverify.atlassian.net/browse/PYIC-5057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ