### PR TITLE
PYIC-4933: Renamed kbv-stub to experian-kbv stack

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubData.json
@@ -107,7 +107,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Mary Watson (Valid) KBV",
       "payload": {
         "name": [
@@ -247,7 +247,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "James Moriarty (Invalid) KBV",
       "payload": {
         "name": [
@@ -391,7 +391,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Kenneth Decerqueira (Valid Experian) KBV",
       "payload": {
         "name": [
@@ -1037,7 +1037,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Alice Parker (Valid) KBV",
       "payload": {
         "name": [
@@ -1182,7 +1182,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Bob Parker (Valid) KBV",
       "payload": {
         "name": [

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -34,7 +34,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Passed verification (M1A) with checkDetails",
       "payload": {
         "type": "IdentityCheck",
@@ -59,7 +59,7 @@
       }
     },
     {
-      "criType": "Knowledge Based Verification (Stub)",
+      "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Failed verification with failedCheckDetails",
       "payload": {
         "type": "IdentityCheck",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Renamed kbv directories to experian-kbv to map the correct deployment template.yaml
- Renamed stub data and evidence to reflect name change from kbv to experian kbv stack
- Added new workflow file for experian-kbv stack

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-4933](https://govukverify.atlassian.net/browse/PYI-4933)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed
