### PR TITLE
[QA-461]: Scale up orch stub for stress test

### DIFF
--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -171,7 +171,7 @@ Mappings:
     "388905755587": #Stubs Prod
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
-      desiredTaskCount: 2
+      desiredTaskCount: 4
       environment: production
       platform: stubs
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret


### PR DESCRIPTION
QA-461 - Scale up orchestrator stub capacity to 4 tasks for the next stress test. This will be scaled down after the completion of the test.