### PR TITLE
[QA-465]: Scale up orch stub for stress test

### DIFF
--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -195,7 +195,7 @@ Mappings:
       lb500ErrorLimit: 10
       fargateCPUsize: "1024"
       fargateRAMsize: "2048"
-      desiredTaskCount: 2
+      desiredTaskCount: 4
       environment: production
       platform: stubs
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret


### PR DESCRIPTION
QA-465 - Scale up orchestrator stub capacity to 4 tasks for the next stress test. This will be scaled down after the completion of the test.