### PR TITLE
PLAT-4148: Locking ecs-stack version

### DIFF
--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -795,7 +795,7 @@ Resources:
     Condition: IsNotDevelopment
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecs-canary-deployment/template.yaml"
+      TemplateURL: "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=RLuCcu0SXw5m6qJPl6LeqMrzYZEUR7Xp" # v1.2.2
       Parameters:
         ECSClusterName: !Ref OrchStubCluster
         ECSServiceName: !GetAtt OrchStubService.Name


### PR DESCRIPTION
## Proposed changes

[PLAT-4148] 

As an outcome from the canary deployment meeting there are some `MAJOR` changes happening within the ecs stack.
To avoid causing any issues with the current state of the stubs we have locked the ecs-canary-deployment stack version to the current version.

### What changed

- Updated the ecs-canary-deployment version to be pinned to the current version


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PLAT-4148]: https://govukverify.atlassian.net/browse/PLAT-4148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ