### PR TITLE
PYIC-5805: Added CIMIT Function alias resource permissions build/dev

### DIFF
--- a/di-ipv-cimit-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-cimit-stub/core-dev-deploy/template.yaml
@@ -110,6 +110,13 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
 
+  PostMitigationsLiveAliasFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
   PostMitigationsFunctionCoreDev02InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -117,10 +124,25 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
 
+  PostMitigationsLiveAliasFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunction } ]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
   PostMitigationsFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref PostMitigationsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+
+  PostMitigationsLiveAliasFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunction } ]
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
@@ -172,6 +194,13 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
 
+  PutContraIndicatorsLiveAliasFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
   PutContraIndicatorsFunctionCoreDev02InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -179,10 +208,24 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
 
+  PutContraIndicatorsLiveAliasFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
   PutContraIndicatorsFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref PutContraIndicatorsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+  PutContraIndicatorsLiveAliasFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
@@ -233,6 +276,13 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
 
+  GetContraIndicatorCredentialLiveAliasFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
   GetContraIndicatorCredentialFunctionCoreDev02InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -240,10 +290,24 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
 
+  GetContraIndicatorCredentialLiveAliasFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
   GetContraIndicatorCredentialFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref GetContraIndicatorCredentialFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+  GetContraIndicatorCredentialLiveAliasFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -148,6 +148,13 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
 
+  PostMitigationsLiveAliasFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
   PostMitigationsFunctionCoreDev02InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -155,10 +162,24 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
 
+  PostMitigationsLiveAliasFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
   PostMitigationsFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref PostMitigationsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+  PostMitigationsLiveAliasFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
@@ -210,6 +231,13 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
 
+  PutContraIndicatorsLiveAliasFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PutContraIndicatorsFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
   PutContraIndicatorsFunctionCoreDev02InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -217,10 +245,24 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
 
+  PutContraIndicatorsLiveAliasFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PutContraIndicatorsFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
   PutContraIndicatorsFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref PutContraIndicatorsFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+  PutContraIndicatorsLiveAliasFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref PutContraIndicatorsFunction }]
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
@@ -271,6 +313,13 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
 
+  GetContraIndicatorCredentialLiveAliasFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref GetContraIndicatorCredentialFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
   GetContraIndicatorCredentialFunctionCoreDev02InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -278,10 +327,24 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
 
+  GetContraIndicatorCredentialLiveAliasFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref GetContraIndicatorCredentialFunction }]
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
   GetContraIndicatorCredentialFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref GetContraIndicatorCredentialFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+  GetContraIndicatorCredentialLiveAliasFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ["${function}:live", { function: !Ref GetContraIndicatorCredentialFunction }]
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added CIMIT Function alias resource permissions build/dev

### Why did it change

We need to add a resource-based permission policy for the CIMIT stubs so that core-back lambdas can invoke them by alias.

Currently we only have a resource-based policy for the CIMIT stubs themselves, but we need a separate one for the Aliases, so we can use them to invoke the CIMIT lambdas.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-5805](https://govukverify.atlassian.net/browse/PYI-5805)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

