### PR TITLE
OJ-2454 update with evidence flag for nino

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -37,6 +37,7 @@ public class CoreStub {
         Spark.get("/credential-issuers", coreStubHandler.showCredentialIssuer);
         Spark.get("/credential-issuer", coreStubHandler.handleCredentialIssuerRequest);
         Spark.get("/edit-postcode", coreStubHandler.editPostcode);
+        Spark.get("/evidence-request", coreStubHandler.evidenceRequest);
         Spark.get("/authorize", coreStubHandler.authorize);
         Spark.get("/user-search", coreStubHandler.userSearch);
         Spark.get("/edit-user", coreStubHandler.editUser);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -17,8 +17,8 @@ public record CredentialIssuer(
     public boolean isAddressCri() {
         return this.id.contains("address");
     }
+
     public boolean isCheckHmrcCri() {
         return this.id.contains("check-hmrc");
     }
-
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -17,4 +17,8 @@ public record CredentialIssuer(
     public boolean isAddressCri() {
         return this.id.contains("address");
     }
+    public boolean isCheckHmrcCri() {
+        return this.id.contains("check-hmrc");
+    }
+
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/EvidenceRequestClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/EvidenceRequestClaims.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record EvidenceRequestClaims(
+        @JsonProperty("scoringPolicy") String scoringPolicy,
+        @JsonProperty("strengthScore") int strengthScore) {
+
+    @JsonCreator
+    public EvidenceRequestClaims {}
+
+    public String getScoringPolicy() {
+        return scoringPolicy;
+    }
+
+    public int getStrengthScore() {
+        return strengthScore;
+    }
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -433,6 +433,14 @@ public class CoreStubHandler {
                         Map.of("cri", credentialIssuerId), "edit-postcode.mustache");
             };
 
+    public Route evidenceRequest =
+            (Request request, Response response) -> {
+                LOGGER.info("checkEvidence Requested Start");
+                var credentialIssuerId = Objects.requireNonNull(request.queryParams("cri"));
+                return ViewHelper.render(
+                        Map.of("cri", credentialIssuerId), "evidence-request.mustache");
+            };
+
     private String createBackendSessionRequestJSONReply(AuthorizationRequest authorizationRequest) {
         // Splits the QueryString from the Auth URI.  Turning the list of parameters
         // (key1=value1&key2=value2 etc...) into a json object.

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -22,6 +22,7 @@ import spark.Route;
 import uk.gov.di.ipv.stub.core.config.CoreStubConfig;
 import uk.gov.di.ipv.stub.core.config.credentialissuer.CredentialIssuer;
 import uk.gov.di.ipv.stub.core.config.uatuser.DisplayIdentity;
+import uk.gov.di.ipv.stub.core.config.uatuser.EvidenceRequestClaims;
 import uk.gov.di.ipv.stub.core.config.uatuser.FindDateOfBirth;
 import uk.gov.di.ipv.stub.core.config.uatuser.FullName;
 import uk.gov.di.ipv.stub.core.config.uatuser.Identity;
@@ -183,8 +184,12 @@ public class CoreStubHandler {
                         handlerHelper.findCredentialIssuer(
                                 Objects.requireNonNull(request.queryParams("cri")));
                 var postcode = request.queryParams("postcode");
+                var strengthScore = request.queryParams("score");
+                var scoringPolicy = request.queryParams("evidence_request");
+
                 if (credentialIssuer.sendIdentityClaims()
                         && Objects.isNull(request.queryParams("postcode"))) {
+                    saveEvidenceRequestToSessionIfPresent(request, strengthScore, scoringPolicy);
                     return ViewHelper.render(
                             Map.of(
                                     "cri",
@@ -263,12 +268,19 @@ public class CoreStubHandler {
             throws ParseException, JOSEException {
         State state = createNewState(credentialIssuer);
         request.session().attribute("state", state);
+        EvidenceRequestClaims evidenceRequest = request.session().attribute("evidence_request");
+
+        if (!Objects.isNull(evidenceRequest)) {
+            LOGGER.info("✅  Retrieved evidence request from session to {}", evidenceRequest);
+            request.session().removeAttribute("evidence_request");
+        }
 
         AuthorizationRequest authRequest;
 
         try {
             authRequest =
-                    handlerHelper.createAuthorizationJAR(state, credentialIssuer, sharedClaims);
+                    handlerHelper.createAuthorizationJAR(
+                            state, credentialIssuer, sharedClaims, evidenceRequest);
         } catch (JOSEException joseException) {
             LOGGER.error("JOSEException occurred," + joseException.getMessage());
             throw joseException;
@@ -355,8 +367,8 @@ public class CoreStubHandler {
                 return handlerHelper.createJWTClaimsSets(
                         state,
                         credentialIssuer,
-                        claimIdentity,
-                        new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID));
+                        new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID),
+                        claimIdentity);
             };
 
     public Route backendGenerateInitialClaimsSetPostCode =
@@ -382,8 +394,8 @@ public class CoreStubHandler {
                 return handlerHelper.createJWTClaimsSets(
                         state,
                         credentialIssuerId,
-                        claimIdentity,
-                        new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID));
+                        new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID),
+                        claimIdentity);
             };
     public Route createBackendSessionRequest =
             (Request request, Response response) -> {
@@ -501,5 +513,15 @@ public class CoreStubHandler {
         var state = new State();
         stateSession.put(state.getValue(), credentialIssuer);
         return state;
+    }
+
+    private static void saveEvidenceRequestToSessionIfPresent(
+            Request request, String strengthScore, String scoringPolicy) {
+        if (Objects.nonNull(strengthScore) && Objects.nonNull(scoringPolicy)) {
+            EvidenceRequestClaims evidenceRequest =
+                    new EvidenceRequestClaims(scoringPolicy, Integer.valueOf(strengthScore));
+            LOGGER.info("✅  Saving evidence request to session to {}", evidenceRequest);
+            request.session().attribute("evidence_request", evidenceRequest);
+        }
     }
 }

--- a/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
@@ -58,18 +58,22 @@
         </div>
 
         {{#cris}}
-            <p>
-                <a href="{{^isAddressCri}}/credential-issuer{{/isAddressCri}}{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}">
-                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}"></a>
-            </p>
-
+            {{#isCheckHmrcCri}}
+                <a href="{{#isCheckHmrcCri}}/evidence-request{{/isCheckHmrcCri}}?cri={{id}}" >
+                    <input class="govuk-button" data-module="govuk-button" type="button"
+                           value="{{name}}{{#isCheckHmrcCri}} - Evidence Requested{{/isCheckHmrcCri}}">
+                </a>
+            {{/isCheckHmrcCri}}
 			{{#isAddressCri}}
-				<p>
-					<a href="/credential-issuer?cri={{id}}">
-					<input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
-				</p>
+                <a href="{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}" >
+                <input class="govuk-button" data-module="govuk-button" type="button"
+                       value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}">
+                </a>
 			{{/isAddressCri}}
-
+            <div class="govuk-button-group">
+                <a href="/credential-issuer?cri={{id}}">
+                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
+            </div>
         {{/cris}}
     </main>
 </div>

--- a/di-ipv-core-stub/src/main/resources/templates/edit-postcode.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/edit-postcode.mustache
@@ -65,10 +65,6 @@
                 <button class="govuk-button" data-module="govuk-button">Continue</button>
             </div>
         </form>
-
-
-        </form>
-
     </main>
 </div>
 

--- a/di-ipv-core-stub/src/main/resources/templates/evidence-request.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/evidence-request.mustache
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+<head>
+    <title>IPV Core Stub - GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/gds/assets/images/favicon.ico" type="image/x-icon">
+    <link rel="mask-icon" href="/gds/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="/gds/assets/images/govuk-apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/gds/assets/images/govuk-apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/gds/assets/images/govuk-apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="/gds/assets/images/govuk-apple-touch-icon.png">
+
+    <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/gds/govuk-frontend-3.11.0.min.css">
+    <!--<![endif]-->
+    <!--[if IE 8]>
+    <link rel="stylesheet" href="/gds/govuk-frontend-ie8-3.11.0.min.css">
+    <![endif]-->
+</head>
+<body class="govuk-template__body ">
+<script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+</script>
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+<header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+            <a href="/" class="govuk-header__link govuk-header__link--homepage">
+          <span class="govuk-header__logotype">
+            <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown"
+                 xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+              <path fill="currentColor" fill-rule="evenodd"
+                    d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+              <image src="/assets/images/govuk-logotype-crown.png" xlink:href="data:," display="none"
+                     class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            </svg>
+            <span class="govuk-header__logotype-text">
+              GOV.UK
+            </span>
+          </span>
+            </a>
+        </div>
+    </div>
+</header>
+<div class="govuk-width-container ">
+    <main class="govuk-main-wrapper>" id="main-content" role="main">
+
+		<a href="/" class="govuk-back-link">Back</a>
+		<div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
+			<h2 class="govuk-heading-xl">
+                Check - Evidence Requested
+            </h2>
+		</div>
+		<legend class="govuk-fieldset__legend govuk-label"></legend>
+        <form action="/credential-issuer?cri={{cri}}">
+            <input type="hidden" name="cri" value="{{cri}}">
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">
+                            Select - Evidence Requested
+                        </h1>
+                    </legend>
+                    <div id="waste-hint" class="govuk-hint"></div>
+                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-margin-bottom-5" for="score">
+                                Scoring Policy:
+                            </label>
+                            <select class="govuk-select" id="evidence" name="evidence_request">
+                                <option value="gpg45" selected>gpg45</option>
+                                <option value="notgpg45">Not gpg45</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-margin-bottom-5" for="score">
+                                Strength Score:
+                            </label>
+                            <select class="govuk-select" id="score" name="score">
+                                <option value="1">1</option>
+                                <option value="2" selected>2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="govuk-button-group govuk-!-margin-top-9">
+                        <button class="govuk-button" data-module="govuk-button">Continue</button>
+                    </div>
+                </fieldset>
+            </div>
+        </form>
+    </main>
+</div>
+
+<footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+                <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
+                     xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                    <path fill="currentColor"
+                          d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"/>
+                </svg>
+                <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link"
+               href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+                <a class="govuk-footer__link govuk-footer__copyright-logo"
+                   href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©
+                    Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="/gds/govuk-frontend-3.11.0.min.js"></script>
+<script>
+    window.GOVUKFrontend.initAll()
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes

![image](https://github.com/govuk-one-login/ipv-stubs/assets/3749690/1151b2aa-46e8-417c-bdf9-5f843b34fca0)

To

![image](https://github.com/govuk-one-login/ipv-stubs/assets/3749690/18f1e90d-c3b1-47c4-84bc-17cf5fcf173b)


### What changed
https://govukverify.atlassian.net/browse/OJ-2454

Scope claim has been removed and an option evidence claim is available for Check HMRC when the
HMRC Check CRI - Evidence Requested 
A new form to specify evidence request setting is presented which defaults to the expected values for NINO

![image](https://github.com/govuk-one-login/ipv-stubs/assets/3749690/d08a14fc-a5d4-417d-9231-5cbc507e767f)

To simulate a malformed NINO check set Scoring Policy to `Not gpg45`

![image](https://github.com/govuk-one-login/ipv-stubs/assets/3749690/dfa40bae-afe9-4f16-b6dc-0a74028f5d8b)

### Why did it change

In order to influence the behaviour of Check HMRC CRI Credential Issuer the evidence request claim can be passed as part of the JAR, Check Hmrc CRI will use this to determine the nature of Verifiable Credential that is generated

