### PR TITLE
Revert "BAU: Bump software.amazon.lambda:powertools-parameters"

### DIFF
--- a/di-ipv-cimit-stub/lib/build.gradle
+++ b/di-ipv-cimit-stub/lib/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
 	implementation "com.amazonaws:aws-java-sdk-dynamodb:1.12.692",
 			"software.amazon.awssdk:dynamodb-enhanced:2.25.11",
-			"software.amazon.lambda:powertools-parameters:1.18.0",
+			"software.amazon.lambda:powertools-parameters:1.16.1",
 			"software.amazon.awssdk:kms:2.25.22",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1"


### PR DESCRIPTION


## Proposed changes

### What changed

This reverts commit b6e272211b963184c6a6c84546031f78474c4e37.

### Why did it change

This version of powertools has a dependency issue with jackson and has broken the stub
