### PR TITLE
LIME-1121 adding nino to claimset

### DIFF
--- a/di-ipv-core-stub/.gitignore
+++ b/di-ipv-core-stub/.gitignore
@@ -30,7 +30,5 @@ build
 .gradle
 *.iml
 
-config
-
 # Ignore dev-deploy generated file
 deploy/**/core-stub-*.yaml

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -21,4 +21,8 @@ public record CredentialIssuer(
     public boolean isCheckHmrcCri() {
         return this.id.contains("check-hmrc");
     }
+
+    public boolean isHmrcKbvCri() {
+        return this.id.contains("hmrc-kbv-cri");
+    }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Identity.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Identity.java
@@ -9,4 +9,18 @@ public record Identity(
         List<UKAddress> addresses,
         FindDateOfBirth findDateOfBirth,
         FullName name,
-        Questions questions) {}
+        Questions questions,
+        String nino) {
+
+    public Identity withNino(String nino) {
+        return new Identity(
+                rowNumber,
+                accountNumber,
+                ctdbDatabase,
+                addresses,
+                findDateOfBirth,
+                name,
+                questions,
+                nino);
+    }
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -70,6 +70,7 @@ public class IdentityMapper {
         FindDateOfBirth dateOfBirth = new FindDateOfBirth(dob, dob);
 
         FullName name = new FullName(map.get("name"), map.get("surname"));
+        String nino = null;
 
         return new Identity(
                 rowNumber,
@@ -78,7 +79,8 @@ public class IdentityMapper {
                 List.of(address),
                 dateOfBirth,
                 name,
-                questions);
+                questions,
+                nino);
     }
 
     public DisplayIdentity mapToDisplayable(Identity identity) {
@@ -127,7 +129,10 @@ public class IdentityMapper {
                                         new NameParts(GIVEN_NAME, identity.name().firstName()),
                                         new NameParts(FAMILY_NAME, identity.name().surname())))),
                 List.of(new DateOfBirth(agedDOB ? dateOfBirth.getAgedDOB() : dateOfBirth.getDOB())),
-                canonicalAddresses);
+                canonicalAddresses,
+                identity.nino() == null
+                        ? null
+                        : List.of(new SocialSecurityRecord(identity.nino())));
     }
 
     public PostcodeSharedClaims mapToAddressSharedClaims(String postcode) {
@@ -222,6 +227,7 @@ public class IdentityMapper {
                 new FindDateOfBirth(
                         instant, LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
         FullName fullName = new FullName(formData.value("firstName"), formData.value("surname"));
+        String nino = formData.value("nationalInsuranceNumber");
         return new Identity(
                 identityOnRecord.rowNumber(),
                 identityOnRecord.accountNumber(),
@@ -229,7 +235,8 @@ public class IdentityMapper {
                 addresses,
                 findDateOfBirth,
                 fullName,
-                identityOnRecord.questions());
+                identityOnRecord.questions(),
+                nino);
     }
 
     private LocalDate getLocalDate(QueryParamsMap userData, String year, String month, String day) {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
@@ -8,4 +8,5 @@ public record SharedClaims(
         @JsonProperty("@context") List<String> context,
         @JsonProperty("name") List<Name> name,
         @JsonProperty("birthDate") List<DateOfBirth> birthDate,
-        @JsonProperty("address") List<CanonicalAddress> addresses) {}
+        @JsonProperty("address") List<CanonicalAddress> addresses,
+        @JsonProperty("socialSecurityRecord") List<SocialSecurityRecord> socialSecurityRecord) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
@@ -1,9 +1,13 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record SharedClaims(
         @JsonProperty("@context") List<String> context,
         @JsonProperty("name") List<Name> name,

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SocialSecurityRecord.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SocialSecurityRecord.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SocialSecurityRecord(@JsonProperty("personalNumber") String personalNumber) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -324,6 +324,7 @@ public class CoreStubHandler {
             (Request request, Response response) -> {
                 var credentialIssuerId =
                         Objects.requireNonNull(request.queryParams("cri"), "cri required");
+                boolean isHmrcKbvCri = credentialIssuerId.contains("hmrc-kbv-cri");
                 var credentialIssuer = handlerHelper.findCredentialIssuer(credentialIssuerId);
                 String rowNumber = request.queryParams("rowNumber");
                 Identity identity = fetchOrCreateIdentity(rowNumber);
@@ -343,7 +344,9 @@ public class CoreStubHandler {
                                 "addressMap",
                                 addressMap,
                                 "rowNumber",
-                                Optional.ofNullable(rowNumber).orElse("0")),
+                                Optional.ofNullable(rowNumber).orElse("0"),
+                                "isHmrcKbvCri",
+                                isHmrcKbvCri),
                         "edit-user.mustache");
             };
 
@@ -352,8 +355,10 @@ public class CoreStubHandler {
                 var credentialIssuerId = Objects.requireNonNull(request.queryParams("cri"));
                 var rowNumber =
                         Integer.valueOf(Objects.requireNonNull(request.queryParams("rowNumber")));
+                // NINO has been added here temporarily for testing implementation of HMRC KBV CRI
+                var nino = request.queryParams("nino");
                 var credentialIssuer = handlerHelper.findCredentialIssuer(credentialIssuerId);
-                var identity = handlerHelper.findIdentityByRowNumber(rowNumber);
+                var identity = handlerHelper.findIdentityByRowNumber(rowNumber).withNino(nino);
                 var claimIdentity =
                         new IdentityMapper()
                                 .mapToSharedClaim(
@@ -505,6 +510,7 @@ public class CoreStubHandler {
                         List.of(ukAddress),
                         new FindDateOfBirth(dob, dob),
                         fullName,
+                        null,
                         null);
         return identity;
     }

--- a/di-ipv-core-stub/src/main/resources/templates/edit-user.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/edit-user.mustache
@@ -269,6 +269,20 @@
 
             </div>
 
+            {{#isHmrcKbvCri}}
+
+                <div class="govuk-form-group">
+                    <label class="govuk-label" id="nationalInsuranceNumber-label" for="nationalInsuranceNumber">
+                                National Insurance Number
+                     </label>
+
+                    <input class="govuk-input govuk-input--width-20" id="nationalInsuranceNumber" name="nationalInsuranceNumber" type="text"
+                                   maxlength="9" value="{{sharedClaims.socialSecurityRecords.personalNumber}}">
+
+                </div>
+            {{/isHmrcKbvCri}}
+
+
             <details class="govuk-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The Edit User/ New user page has been updated to include a field for manually entering National Insurance Number when accessed via HMRC KBV button. It should be hidden in all other CRIs.

### Why did it change

On the full journey, a user will provide their National Insurance Number in the NINO CRI, before they reach HMRC KBV CRI. In order to simulate this, a NINO field has been added to manually edit a user for this CRI, instead of providing all users with the value from the beginning of the CRI journey. This means a NINO will always need to be added for the CRI to work correctly.

### Issue tracking

- [LIME-1121](https://govukverify.atlassian.net/browse/LIME-1121)

[LIME-1121]: https://govukverify.atlassian.net/browse/LIME-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ