### PR TITLE
PYIC-6086: initiate mfa reset in orchestrator stub

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -11,6 +11,8 @@ public class OrchestratorConfig {
             getConfigValue("IPV_BACKCHANNEL_TOKEN_PATH", "/dev/token");
     public static final String IPV_BACKCHANNEL_USER_IDENTITY_PATH =
             getConfigValue("IPV_BACKCHANNEL_USER_IDENTITY_PATH", "/dev/user-identity");
+    public static final String AUTH_CLIENT_ID =
+            getConfigValue("AUTH_CLIENT_ID", "auth");
     public static final String ORCHESTRATOR_CLIENT_ID =
             getConfigValue("ORCHESTRATOR_CLIENT_ID", "orchestrator");
     public static final String ORCHESTRATOR_REDIRECT_URL =

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -11,8 +11,7 @@ public class OrchestratorConfig {
             getConfigValue("IPV_BACKCHANNEL_TOKEN_PATH", "/dev/token");
     public static final String IPV_BACKCHANNEL_USER_IDENTITY_PATH =
             getConfigValue("IPV_BACKCHANNEL_USER_IDENTITY_PATH", "/dev/user-identity");
-    public static final String AUTH_CLIENT_ID =
-            getConfigValue("AUTH_CLIENT_ID", "auth");
+    public static final String AUTH_CLIENT_ID = getConfigValue("AUTH_CLIENT_ID", "auth");
     public static final String ORCHESTRATOR_CLIENT_ID =
             getConfigValue("ORCHESTRATOR_CLIENT_ID", "orchestrator");
     public static final String ORCHESTRATOR_REDIRECT_URL =

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -83,6 +83,7 @@ public class IpvHandler {
     private static final String INHERITED_ID_EVIDENCE_PARAM = "evidenceJsonPayload";
     private static final String MFA_RESET_PARAM = "mfaReset";
     private static final String ERROR_TYPE_PARAM = "error";
+    private static final String CHECKBOX_CHECKED_VALUE = "checked";
 
     private static final String ENVIRONMENT_COOKIE = "targetEnvironment";
 
@@ -116,7 +117,7 @@ public class IpvHandler {
         var signInJourneyIdText = queryMap.get(JOURNEY_ID_PARAM).value();
         var userEmailAddress = queryMap.get(EMAIL_ADDRESS_PARAM).value();
         var userId = getUserIdValue(userIdTextValue);
-        var isMfaReset = Objects.equals(queryMap.value(MFA_RESET_PARAM), "checked");
+        var isMfaReset = Objects.equals(queryMap.value(MFA_RESET_PARAM), CHECKBOX_CHECKED_VALUE);
 
         JWTClaimsSet claims;
         if (isMfaReset) {
@@ -149,7 +150,7 @@ public class IpvHandler {
                             : JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT;
 
             var includeInheritedId =
-                    Objects.equals(queryMap.value(INHERITED_ID_INCLUDED_PARAM), "checked");
+                    Objects.equals(queryMap.value(INHERITED_ID_INCLUDED_PARAM), CHECKBOX_CHECKED_VALUE);
             var inheritedIdVot = queryMap.get(INHERITED_ID_VOT_PARAM).value();
             var inheritedIdSubject = queryMap.value(INHERITED_ID_SUBJECT_PARAM);
             var inheritedIdEvidence = queryMap.value(INHERITED_ID_EVIDENCE_PARAM);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.stub.orc.handlers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
@@ -61,6 +62,7 @@ import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_T
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_USER_IDENTITY_PATH;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_ENDPOINT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.AUTH_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_REDIRECT_URL;
 import static uk.gov.di.ipv.stub.orc.utils.JwtBuilder.URN_UUID;
 import static uk.gov.di.ipv.stub.orc.utils.JwtBuilder.buildClientAuthenticationClaims;
@@ -76,6 +78,7 @@ public class IpvHandler {
     private static final String ENVIRONMENT_PARAM = "targetEnvironment";
     private static final String REPROVE_IDENTITY_PARAM = "reproveIdentity";
     private static final String EMAIL_ADDRESS_PARAM = "emailAddress";
+    private static final String MFA_RESET_PARAM = "mfaReset";
     private static final String INHERITED_ID_INCLUDED_PARAM = "duringMigration";
     private static final String INHERITED_ID_VOT_PARAM = "votText";
     private static final String INHERITED_ID_SUBJECT_PARAM = "jsonPayload";
@@ -105,17 +108,33 @@ public class IpvHandler {
                 return null;
             };
 
-    private String getAuthorizeRedirect(QueryParamsMap queryMap, String errorType)
-            throws Exception {
-        var environment = queryMap.get(ENVIRONMENT_PARAM).value();
+    private JWTClaimsSet getJWTClaimsSet(QueryParamsMap queryMap, String errorType, String environment, boolean isMfaReset)
+        throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         var userIdTextValue = queryMap.get(USER_ID_PARAM).value();
         var signInJourneyIdText = queryMap.get(JOURNEY_ID_PARAM).value();
-        var vtr =
-                Arrays.stream(queryMap.get(VTR_PARAM).value().split(","))
-                        .map(String::trim)
-                        .filter(value -> !value.isEmpty())
-                        .toList();
         var userEmailAddress = queryMap.get(EMAIL_ADDRESS_PARAM).value();
+        var userId = getUserIdValue(userIdTextValue);
+        if (isMfaReset) {
+            return JwtBuilder.buildAuthorizationRequestClaims(
+                        userId,
+                        signInJourneyIdText,
+                        ORCHESTRATOR_STUB_STATE.getValue(),
+                        null,
+                        errorType,
+                        userEmailAddress,
+                        JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT,
+                        environment,
+                        false,
+                        null,
+                        null,
+                        null);
+        }
+
+        var vtr =
+        Arrays.stream(queryMap.get(VTR_PARAM).value().split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .toList();
         var reproveIdentityString = queryMap.get(REPROVE_IDENTITY_PARAM).value();
         var reproveIdentityClaimValue =
                 StringUtils.isNotBlank(reproveIdentityString)
@@ -128,10 +147,7 @@ public class IpvHandler {
         var inheritedIdSubject = queryMap.value(INHERITED_ID_SUBJECT_PARAM);
         var inheritedIdEvidence = queryMap.value(INHERITED_ID_EVIDENCE_PARAM);
 
-        var userId = getUserIdValue(userIdTextValue);
-
-        JWTClaimsSet claims =
-                JwtBuilder.buildAuthorizationRequestClaims(
+        return JwtBuilder.buildAuthorizationRequestClaims(
                         userId,
                         signInJourneyIdText,
                         ORCHESTRATOR_STUB_STATE.getValue(),
@@ -144,15 +160,23 @@ public class IpvHandler {
                         inheritedIdSubject,
                         inheritedIdEvidence,
                         inheritedIdVot);
+    }
+
+    private String getAuthorizeRedirect(QueryParamsMap queryMap, String errorType)
+            throws Exception {
+        var environment = queryMap.get(ENVIRONMENT_PARAM).value();
+        var isMfaReset = Objects.equals(queryMap.value(MFA_RESET_PARAM), "checked");
+
+        JWTClaimsSet claims = getJWTClaimsSet(queryMap, errorType, environment, isMfaReset);
 
         SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
         EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt, environment);
         var authRequest =
                 new AuthorizationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE),
-                                new ClientID(ORCHESTRATOR_CLIENT_ID))
+                                new ClientID(isMfaReset ? AUTH_CLIENT_ID : ORCHESTRATOR_CLIENT_ID))
                         .state(ORCHESTRATOR_STUB_STATE)
-                        .scope(new Scope("openid"))
+                        .scope(new Scope(isMfaReset ? "reverification" : "openid" ))
                         .redirectionURI(new URI(ORCHESTRATOR_REDIRECT_URL))
                         .endpointURI(getIpvEndpoint(environment).resolve("/oauth2/authorize"))
                         .requestObject(EncryptedJWT.parse(encryptedJwt.serialize()))
@@ -160,6 +184,8 @@ public class IpvHandler {
 
         return authRequest.toURI().toString();
     }
+
+
 
     private URI getIpvEndpoint(String environment) throws URISyntaxException {
         String url =

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -108,7 +108,7 @@ public class IpvHandler {
                 return null;
             };
 
-    private JWTClaimsSet getJWTClaimsSet(QueryParamsMap queryMap, String errorType, String environment, boolean isMfaReset)
+    private JWTClaimsSet buildJWTClaimsSet(QueryParamsMap queryMap, String errorType, String environment, boolean isMfaReset)
         throws JsonProcessingException, NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         var userIdTextValue = queryMap.get(USER_ID_PARAM).value();
         var signInJourneyIdText = queryMap.get(JOURNEY_ID_PARAM).value();
@@ -127,7 +127,8 @@ public class IpvHandler {
                         false,
                         null,
                         null,
-                        null);
+                        null,
+                        AUTH_CLIENT_ID);
         }
 
         var vtr =
@@ -159,7 +160,8 @@ public class IpvHandler {
                         includeInheritedId,
                         inheritedIdSubject,
                         inheritedIdEvidence,
-                        inheritedIdVot);
+                        inheritedIdVot,
+                        ORCHESTRATOR_CLIENT_ID);
     }
 
     private String getAuthorizeRedirect(QueryParamsMap queryMap, String errorType)
@@ -167,9 +169,9 @@ public class IpvHandler {
         var environment = queryMap.get(ENVIRONMENT_PARAM).value();
         var isMfaReset = Objects.equals(queryMap.value(MFA_RESET_PARAM), "checked");
 
-        JWTClaimsSet claims = getJWTClaimsSet(queryMap, errorType, environment, isMfaReset);
+        SignedJWT signedJwt = JwtBuilder.createSignedJwt(
+            buildJWTClaimsSet(queryMap, errorType, environment, isMfaReset));
 
-        SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);
         EncryptedJWT encryptedJwt = JwtBuilder.encryptJwt(signedJwt, environment);
         var authRequest =
                 new AuthorizationRequest.Builder(

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -150,7 +150,8 @@ public class IpvHandler {
                             : JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT;
 
             var includeInheritedId =
-                    Objects.equals(queryMap.value(INHERITED_ID_INCLUDED_PARAM), CHECKBOX_CHECKED_VALUE);
+                    Objects.equals(
+                            queryMap.value(INHERITED_ID_INCLUDED_PARAM), CHECKBOX_CHECKED_VALUE);
             var inheritedIdVot = queryMap.get(INHERITED_ID_VOT_PARAM).value();
             var inheritedIdSubject = queryMap.value(INHERITED_ID_SUBJECT_PARAM);
             var inheritedIdEvidence = queryMap.value(INHERITED_ID_EVIDENCE_PARAM);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -87,6 +87,7 @@ public class IpvHandler {
     private static final String ENVIRONMENT_COOKIE = "targetEnvironment";
 
     private static final State ORCHESTRATOR_STUB_STATE = new State("orchestrator-stub-state");
+    private static final State AUTH_STUB_STATE = new State("auth-stub-state");
 
     private final Logger logger = LoggerFactory.getLogger(IpvHandler.class);
 
@@ -120,13 +121,20 @@ public class IpvHandler {
         JWTClaimsSet claims;
         if (isMfaReset) {
             claims =
-                    JwtBuilder.buildMFAResetAuthenticationClaims(
+                    JwtBuilder.buildAuthorizationRequestClaims(
                             userId,
                             signInJourneyIdText,
-                            ORCHESTRATOR_STUB_STATE.getValue(),
+                            AUTH_STUB_STATE.getValue(),
+                            null,
                             errorType,
                             userEmailAddress,
-                            environment);
+                            JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT,
+                            environment,
+                            false,
+                            null,
+                            null,
+                            null,
+                            AUTH_CLIENT_ID);
         } else {
             var vtr =
                     Arrays.stream(queryMap.get(VTR_PARAM).value().split(","))
@@ -159,7 +167,8 @@ public class IpvHandler {
                             includeInheritedId,
                             inheritedIdSubject,
                             inheritedIdEvidence,
-                            inheritedIdVot);
+                            inheritedIdVot,
+                            ORCHESTRATOR_CLIENT_ID);
         }
 
         SignedJWT signedJwt = JwtBuilder.createSignedJwt(claims);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -108,7 +108,7 @@ public class JwtBuilder {
                         .subject(userId)
                         .audience(audience)
                         .issueTime(Date.from(now))
-                        .issuer(ORCHESTRATOR_CLIENT_ID)
+                        .issuer(clientId)
                         .notBeforeTime(Date.from(now))
                         .expirationTime(generateExpirationTime(now))
                         .claim("claims", jarClaimsMap)

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.AUTH_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_CORE_AUDIENCE;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_KEY;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
@@ -74,7 +73,8 @@ public class JwtBuilder {
             boolean includeInheritedId,
             String inheritedIdSubject,
             String inheritedIdEvidence,
-            String inheritedIdVot)
+            String inheritedIdVot,
+            String clientId)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     JsonProcessingException {
         String audience = getIpvCoreAudience(environment);
@@ -112,7 +112,7 @@ public class JwtBuilder {
                         .notBeforeTime(Date.from(now))
                         .expirationTime(generateExpirationTime(now))
                         .claim("claims", jarClaimsMap)
-                        .claim("client_id", ORCHESTRATOR_CLIENT_ID)
+                        .claim("client_id", clientId)
                         .claim("response_type", ResponseType.Value.CODE.toString())
                         .claim("redirect_uri", redirectUri)
                         .claim("state", state)
@@ -124,49 +124,6 @@ public class JwtBuilder {
             claimSetBuilder.claim(
                     "reprove_identity", reproveIdentityValue == ReproveIdentityClaimValue.TRUE);
         }
-        return claimSetBuilder.build();
-    }
-
-    public static JWTClaimsSet buildMFAResetAuthenticationClaims(
-            String userId,
-            String signInJourneyId,
-            String state,
-            String errorType,
-            String userEmailAddress,
-            String environment)
-            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
-                    JsonProcessingException {
-
-        String audience = getIpvCoreAudience(environment);
-        String redirectUri = ORCHESTRATOR_REDIRECT_URL;
-
-        if (errorType != null) {
-            switch (errorType) {
-                case "recoverable" -> audience = INVALID_AUDIENCE;
-                case "non-recoverable" -> redirectUri = INVALID_REDIRECT_URI;
-            }
-        }
-
-        var jarClaimsMap = new TypeReference<Map<String, Object>>() {};
-
-        Instant now = Instant.now();
-        var claimSetBuilder =
-                new JWTClaimsSet.Builder()
-                        .subject(userId)
-                        .audience(audience)
-                        .issueTime(Date.from(now))
-                        .issuer(AUTH_CLIENT_ID)
-                        .notBeforeTime(Date.from(now))
-                        .expirationTime(generateExpirationTime(now))
-                        .claim("claims", jarClaimsMap)
-                        .claim("client_id", AUTH_CLIENT_ID)
-                        .claim("response_type", ResponseType.Value.CODE.toString())
-                        .claim("redirect_uri", redirectUri)
-                        .claim("state", state)
-                        .claim("govuk_signin_journey_id", signInJourneyId)
-                        .claim("persistent_session_id", UUID.randomUUID().toString())
-                        .claim("email_address", userEmailAddress);
-
         return claimSetBuilder.build();
     }
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -73,7 +73,8 @@ public class JwtBuilder {
             boolean includeInheritedId,
             String inheritedIdSubject,
             String inheritedIdEvidence,
-            String inheritedIdVot)
+            String inheritedIdVot,
+            String clientId)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     JsonProcessingException {
         String audience = getIpvCoreAudience(environment);
@@ -107,7 +108,7 @@ public class JwtBuilder {
                         .subject(userId)
                         .audience(audience)
                         .issueTime(Date.from(now))
-                        .issuer(ORCHESTRATOR_CLIENT_ID)
+                        .issuer(clientId)
                         .notBeforeTime(Date.from(now))
                         .expirationTime(generateExpirationTime(now))
                         .claim("claims", jarClaimsMap)

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -101,6 +101,12 @@
 
             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
               <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" type="checkbox" name="mfaReset" id="mfaReset" value="checked">
+                <label class="govuk-label govuk-checkboxes__label" for="mfaReset">
+                MFA Reset
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
                 <input class="govuk-checkboxes__input" type="checkbox" name="duringMigration" id="duringMigration" value="checked">
                 <label class="govuk-label govuk-checkboxes__label" for="duringMigration">
                 Include inherited identity claim


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Re-use orchestrator stub to act as an auth stub, so that we can initiate MFA resets

### What changed

- Adds a checkbox for MFA reset option
- Special JAR generated with 'auth'  client_id and 'reverification' scope if MFA checkbox is checked

### Why did it change

We need to be able to test MFA reset journeys

### Issue tracking

https://govukverify.atlassian.net/browse/PYIC-6086

## Checklists

### Environment variables or secrets
<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
