### PR TITLE
PYIC-6069: Update orch stub for MFA reset result

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -233,7 +233,7 @@ public class IpvHandler {
                     var accessToken = exchangeCodeForToken(authorizationCode, targetBackend);
 
                     var userInfo = getUserInfo(accessToken, targetBackend);
-                    var state = userInfo.getAsString("state");
+                    var state = request.queryMap().get("state").value();
 
                     if (ORCHESTRATOR_STUB_STATE.toString().equals(state)) {
                         var userInfoJson = gson.toJson(userInfo);
@@ -253,7 +253,7 @@ public class IpvHandler {
                     var errorObject =
                             List.of(
                                     Map.of(
-                                            "error",
+                                            "error_code",
                                             e.getErrorObject().getCode(),
                                             "error_description",
                                             e.getErrorObject().getDescription()));

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -121,14 +121,16 @@ public class IpvHandler {
 
         JWTClaimsSet claims;
         String scope, clientId;
+        State state;
         if (isMfaReset) {
             scope = "reverification";
             clientId = AUTH_CLIENT_ID;
+            state = AUTH_STUB_STATE;
             claims =
                     JwtBuilder.buildAuthorizationRequestClaims(
                             userId,
                             signInJourneyIdText,
-                            AUTH_STUB_STATE.getValue(),
+                            state.getValue(),
                             null,
                             errorType,
                             userEmailAddress,
@@ -143,6 +145,7 @@ public class IpvHandler {
         } else {
             scope = "openid";
             clientId = ORCHESTRATOR_CLIENT_ID;
+            state = ORCHESTRATOR_STUB_STATE;
             var vtr =
                     Arrays.stream(queryMap.get(VTR_PARAM).value().split(","))
                             .map(String::trim)
@@ -166,7 +169,7 @@ public class IpvHandler {
                     JwtBuilder.buildAuthorizationRequestClaims(
                             userId,
                             signInJourneyIdText,
-                            ORCHESTRATOR_STUB_STATE.getValue(),
+                            state.getValue(),
                             vtr,
                             errorType,
                             userEmailAddress,
@@ -185,7 +188,7 @@ public class IpvHandler {
         var authRequest =
                 new AuthorizationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE), new ClientID(clientId))
-                        .state(ORCHESTRATOR_STUB_STATE)
+                        .state(state)
                         .scope(new Scope(scope))
                         .redirectionURI(new URI(ORCHESTRATOR_REDIRECT_URL))
                         .endpointURI(getIpvEndpoint(environment).resolve("/oauth2/authorize"))

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -92,6 +92,7 @@ public class IpvHandler {
     private static final State ORCHESTRATOR_STUB_STATE = new State("orchestrator-stub-state");
     private static final State AUTH_STUB_STATE = new State("auth-stub-state");
 
+    private final ObjectMapper objectMapper = new ObjectMapper().enable(INDENT_OUTPUT);
     private final Logger logger = LoggerFactory.getLogger(IpvHandler.class);
 
     public Route doAuthorize =
@@ -226,7 +227,6 @@ public class IpvHandler {
 
     public Route doCallback =
             (Request request, Response response) -> {
-                var objectMapper = new ObjectMapper().enable(INDENT_OUTPUT);
                 String targetBackend = request.cookie(ENVIRONMENT_COOKIE);
 
                 try {

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/error.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/error.mustache
@@ -54,7 +54,7 @@
         {{#error}}
             <h3 class="govuk-heading-l">Something went wrong: </h3>
             <div class="govuk-details__text">
-                <pre><code>error: {{error}}</code></pre>
+                <pre><code>error_code: {{error_code}}</code></pre>
                 <pre><code>error_description: {{error_description}}</code></pre>
             </div>
         {{/error}}

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/error.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/error.mustache
@@ -51,57 +51,13 @@
 
 <div class="govuk-width-container ">
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-        <div class="govuk-!-margin-bottom-9">
-            <h1 class="govuk-heading-l">
-                User information
-            </h1>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                {{#rawUserInfo}}
-                    <details class="govuk-details" data-module="govuk-details">
-                        <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">Raw User Info Object</span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <pre><code>{{rawUserInfo}}</code></pre>
-                        </div>
-                    </details>
-                {{/rawUserInfo}}
+        {{#error}}
+            <h3 class="govuk-heading-l">Something went wrong: </h3>
+            <div class="govuk-details__text">
+                <pre><code>error: {{error}}</code></pre>
+                <pre><code>error_description: {{error_description}}</code></pre>
             </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <dl class="govuk-summary-list">
-                    {{#data}}
-                        <div class="govuk-summary-list__row">
-                            <dt class="govuk-summary-list__key">
-                                <span class="govuk-heading-s">Cri Type: {{criType}}</span>
-                            </dt>
-                            <dd class="govuk-summary-list__value">
-                                <details class="govuk-details" data-module="govuk-details">
-                                    <summary class="govuk-details__summary">
-                                        <span class="govuk-details__summary-text">Verifiable Credential</span>
-                                    </summary>
-                                    <div class="govuk-details__text">
-                                        <pre><code>{{VC}}</code></pre>
-                                    </div>
-                                </details>
-                            </dd>
-                        </div>
-                    {{/data}}
-                    {{^data}}
-                        <h3 class="govuk-heading-s">Something went wrong: </h3>
-                        {{#error}}
-                            <div class="govuk-details__text">
-                                <pre><code>error: {{error}}</code></pre>
-                                <pre><code>error_description: {{error_description}}</code></pre>
-                            </div>
-                        {{/error}}
-                    {{/data}}
-                </dl>
-            </div>
-        </div>
+        {{/error}}
     </main>
 </div>
 

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/mfa-reset-result.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/mfa-reset-result.mustache
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+<head>
+    <title>Orchestrator Stub - GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
+    <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+
+    <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/govuk-frontend-4.8.0.min.css">
+    <!--<![endif]-->
+    <!--[if IE 8]>
+    <link rel="stylesheet" href="/govuk-frontend-ie8-4.8.0.min.css">
+    <![endif]-->
+</head>
+<body class="govuk-template__body ">
+<script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+</script>
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+<header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <!--[if gt IE 8]><!-->
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30" height="30" width="32">
+                <path fill="currentColor" fill-rule="evenodd" d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8"></path>
+              </svg>
+              <!--<![endif]-->
+              <!--[if IE 8]>
+              <img src="/assets/images/govuk-logotype-tudor-crown.png" class="govuk-header__logotype-crown-fallback-image" width="32" height="30" alt="">
+              <![endif]-->
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+    </div>
+</header>
+
+<div class="govuk-width-container ">
+    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+        <div class="govuk-!-margin-bottom-9">
+            <h1 class="govuk-heading-l">
+                MFA Reset Result
+            </h1>
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                {{#data}}
+                    {{#success}}
+                        <span class="govuk-heading-s">Success</span>
+                    {{/success}}
+                    {{^success}}
+                        <span class="govuk-heading-s">Failure</span>
+                    {{/success}}
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">Raw MFA Reset Result Object</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <pre><code>{{data}}</code></pre>
+                        </div>
+                    </details>
+                {{/data}}
+            </div>
+        </div>
+    </main>
+</div>
+
+<footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+                <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                    <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                </svg>
+                <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+                <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="/govuk-frontend-4.8.0.min.js"></script>
+<script>
+    window.GOVUKFrontend.initAll()
+</script>
+</body>
+</html>

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/mfa-reset-result.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/mfa-reset-result.mustache
@@ -58,22 +58,20 @@
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                {{#data}}
-                    {{#success}}
-                        <span class="govuk-heading-s">Success</span>
-                    {{/success}}
-                    {{^success}}
-                        <span class="govuk-heading-s">Failure</span>
-                    {{/success}}
-                    <details class="govuk-details" data-module="govuk-details">
-                        <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">Raw MFA Reset Result Object</span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <pre><code>{{data}}</code></pre>
-                        </div>
-                    </details>
-                {{/data}}
+                {{#success}}
+                    <span class="govuk-heading-s">Success</span>
+                {{/success}}
+                {{^success}}
+                    <span class="govuk-heading-s">Failure</span>
+                {{/success}}
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">Raw MFA Reset Result Object</span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        <pre><code>{{rawUserInfo}}</code></pre>
+                    </div>
+                </details>
             </div>
         </div>
     </main>

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/user-info.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/user-info.mustache
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+<head>
+    <title>Orchestrator Stub - GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
+    <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+
+    <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/govuk-frontend-4.8.0.min.css">
+    <!--<![endif]-->
+    <!--[if IE 8]>
+    <link rel="stylesheet" href="/govuk-frontend-ie8-4.8.0.min.css">
+    <![endif]-->
+</head>
+<body class="govuk-template__body ">
+<script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+</script>
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+<header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <!--[if gt IE 8]><!-->
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30" height="30" width="32">
+                <path fill="currentColor" fill-rule="evenodd" d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8"></path>
+              </svg>
+              <!--<![endif]-->
+              <!--[if IE 8]>
+              <img src="/assets/images/govuk-logotype-tudor-crown.png" class="govuk-header__logotype-crown-fallback-image" width="32" height="30" alt="">
+              <![endif]-->
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+    </div>
+</header>
+
+<div class="govuk-width-container ">
+    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+        <div class="govuk-!-margin-bottom-9">
+            <h1 class="govuk-heading-l">
+                User information
+            </h1>
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                {{#rawUserInfo}}
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">Raw User Info Object</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <pre><code>{{rawUserInfo}}</code></pre>
+                        </div>
+                    </details>
+                {{/rawUserInfo}}
+            </div>
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <dl class="govuk-summary-list">
+                    {{#data}}
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                <span class="govuk-heading-s">Cri Type: {{criType}}</span>
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <details class="govuk-details" data-module="govuk-details">
+                                    <summary class="govuk-details__summary">
+                                        <span class="govuk-details__summary-text">Verifiable Credential</span>
+                                    </summary>
+                                    <div class="govuk-details__text">
+                                        <pre><code>{{VC}}</code></pre>
+                                    </div>
+                                </details>
+                            </dd>
+                        </div>
+                    {{/data}}
+                </dl>
+            </div>
+        </div>
+    </main>
+</div>
+
+<footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+                <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                    <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                </svg>
+                <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+                <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="/govuk-frontend-4.8.0.min.js"></script>
+<script>
+    window.GOVUKFrontend.initAll()
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes

### What changed

- Add mfa-reset-result.mustache
- Extract errors into error.mustache
- Conditionally render on IpvHandler callback result

### Why did it change

- Need to conditionally render mfa reset result based on state value passed in and retrieved by orch stub
- Errors were extracted since no longer tied to a single client.

### Issue tracking

- [PYIC-6069](https://govukverify.atlassian.net/browse/PYIC-6069)

### Screenshots

1. <img width="789" alt="Screenshot 2024-05-24 at 10 42 49" src="https://github.com/govuk-one-login/ipv-stubs/assets/144116535/c579b3a1-96d7-4396-bf53-6d4844ec47d8">


2. <img width="507" alt="Screenshot 2024-05-24 at 10 02 31" src="https://github.com/govuk-one-login/ipv-stubs/assets/144116535/a2f90801-8c3d-4969-8cb7-3e85037a5fc7">


3. The user details page looks unchanged

[PYIC-6069]: https://govukverify.atlassian.net/browse/PYIC-6069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ