### PR TITLE
PYIC-6218: Include evcs access token in orch-stub JAR

### DIFF
--- a/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
@@ -120,6 +120,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_VTM" #pragma: allowlist secret
+  EvcsAccessTokenEndpoint:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_ENDPOINT" #pragma: allowlist secret
+  EvcsAccessTokenTtl:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_TTL" #pragma: allowlist secret
+  EvcsAccessTokenSigningKeyJwk:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -589,6 +601,12 @@ Resources:
               Value: !Ref InheritedIdentityJwtIssuer
             - Name: INHERITED_IDENTITY_JWT_VTM
               Value: !Ref InheritedIdentityJwtVtm
+            - Name: EVCS_ACCESS_TOKEN_ENDPOINT
+              Value: !Ref EvcsAccessTokenEndpoint
+            - Name: EVCS_ACCESS_TOKEN_TTL
+              Value: !Ref EvcsAccessTokenTtl
+            - Name: EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK
+              Value: !Ref EvcsAccessTokenSigningKeyJwk
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -135,10 +135,18 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_VTM" #pragma: allowlist secret
-    # PassportPrivateApiKey:
-    #    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    #    Type: AWS::SSM::Parameter::Value<String>
-    #    Default: "/stubs/core/passport/env/PASSPORT_PRIVATE_API_KEY" #pragma: allowlist secret
+  EvcsAccessTokenEndpoint:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_ENDPOINT" #pragma: allowlist secret
+  EvcsAccessTokenTtl:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_TTL" #pragma: allowlist secret
+  EvcsAccessTokenSigningKeyJwk:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -630,6 +638,12 @@ Resources:
               Value: !Ref InheritedIdentityJwtIssuer
             - Name: INHERITED_IDENTITY_JWT_VTM
               Value: !Ref InheritedIdentityJwtVtm
+            - Name: EVCS_ACCESS_TOKEN_ENDPOINT
+              Value: !Ref EvcsAccessTokenEndpoint
+            - Name: EVCS_ACCESS_TOKEN_TTL
+              Value: !Ref EvcsAccessTokenTtl
+            - Name: EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK
+              Value: !Ref EvcsAccessTokenSigningKeyJwk
           Secrets:
             - Name: DT_TENANT
               ValueFrom: !Join

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/Orchestrator.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/Orchestrator.java
@@ -5,6 +5,7 @@ import uk.gov.di.ipv.stub.orc.config.OrchestratorConfig;
 import uk.gov.di.ipv.stub.orc.handlers.BasicAuthHandler;
 import uk.gov.di.ipv.stub.orc.handlers.HomeHandler;
 import uk.gov.di.ipv.stub.orc.handlers.IpvHandler;
+import uk.gov.di.ipv.stub.orc.utils.EvcsAccessTokenGenerator;
 
 public class Orchestrator {
 
@@ -14,7 +15,7 @@ public class Orchestrator {
         Spark.staticFileLocation("/public");
         Spark.port(Integer.parseInt(OrchestratorConfig.PORT));
 
-        ipvHandler = new IpvHandler();
+        ipvHandler = new IpvHandler(new EvcsAccessTokenGenerator());
 
         initRoutes();
     }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -41,12 +41,12 @@ public class OrchestratorConfig {
     public static final boolean BASIC_AUTH_ENABLE =
             Boolean.parseBoolean(getConfigValue("ORCHESTRATOR_BASIC_AUTH_ENABLE", "false"));
     public static final String BASIC_AUTH_USERNAME =
-            getConfigValue("ORCHESTRATOR_BASIC_AUTH_USERNAME", null);
+            getConfigValue("ORCHESTRATOR_BASIC_AUTH_USERNAME");
     public static final String BASIC_AUTH_PASSWORD =
-            getConfigValue("ORCHESTRATOR_BASIC_AUTH_PASSWORD", null);
+            getConfigValue("ORCHESTRATOR_BASIC_AUTH_PASSWORD");
 
     public static final String INHERITED_IDENTITY_JWT_SIGNING_KEY =
-            getConfigValue("INHERITED_IDENTITY_JWT_SIGNING_KEY", null);
+            getConfigValue("INHERITED_IDENTITY_JWT_SIGNING_KEY");
     public static final String INHERITED_IDENTITY_JWT_ISSUER =
             getConfigValue(
                     "INHERITED_IDENTITY_JWT_ISSUER",
@@ -55,6 +55,15 @@ public class OrchestratorConfig {
             getConfigValue("INHERITED_IDENTITY_JWT_VTM", "https://hmrc.gov.uk/trustmark");
     public static final String INHERITED_IDENTITY_JWT_TTL =
             getConfigValue("INHERITED_IDENTITY_JWT_TTL", "900");
+    public static final String EVCS_ACCESS_TOKEN_ENDPOINT =
+            getConfigValue("EVCS_ACCESS_TOKEN_ENDPOINT");
+    public static final String EVCS_ACCESS_TOKEN_TTL = getConfigValue("EVCS_ACCESS_TOKEN_TTL");
+    public static final String EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK =
+            getConfigValue("EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK");
+
+    private static String getConfigValue(String key) {
+        return getConfigValue(key, null);
+    }
 
     private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/exceptions/OrchestratorStubException.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/exceptions/OrchestratorStubException.java
@@ -4,4 +4,8 @@ public class OrchestratorStubException extends Exception {
     public OrchestratorStubException(String errorMessage) {
         super(errorMessage);
     }
+
+    public OrchestratorStubException(Exception exception) {
+        super(exception);
+    }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/exceptions/SignerCreationException.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/exceptions/SignerCreationException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.stub.orc.exceptions;
+
+public class SignerCreationException extends RuntimeException {
+    public SignerCreationException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/EvcsTokenRequest.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/EvcsTokenRequest.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.stub.orc.models;
+
+public record EvcsTokenRequest(String subject, int ttl) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/EvcsTokenResponse.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/EvcsTokenResponse.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.stub.orc.models;
+
+public record EvcsTokenResponse(String token) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
@@ -3,7 +3,7 @@ package uk.gov.di.ipv.stub.orc.models;
 import java.util.List;
 
 public record JarClaims(JarUserInfo userInfo) {
-    public JarClaims(String inheritedIdentityJwt) {
+    public JarClaims(String inheritedIdentityJwt, String evcsAccessToken) {
         this(
                 new JarUserInfo(
                         new Essential(true),
@@ -12,6 +12,9 @@ public record JarClaims(JarUserInfo userInfo) {
                         null,
                         inheritedIdentityJwt == null
                                 ? null
-                                : new InheritedIdentityJwtClaim(List.of(inheritedIdentityJwt))));
+                                : new ListOfStringValues(List.of(inheritedIdentityJwt)),
+                        evcsAccessToken == null
+                                ? null
+                                : new ListOfStringValues(List.of(evcsAccessToken))));
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
@@ -12,4 +12,6 @@ public record JarUserInfo(
                 Essential ninoClaim,
         @JsonInclude(JsonInclude.Include.NON_NULL)
                 @JsonProperty(value = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
-                InheritedIdentityJwtClaim inheritedIdentityClaim) {}
+                ListOfStringValues inheritedIdentityClaim,
+        @JsonProperty(value = "https://vocab.account.gov.uk/v1/storageAccessToken")
+                ListOfStringValues evcsAccessToken) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/ListOfStringValues.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/ListOfStringValues.java
@@ -2,4 +2,4 @@ package uk.gov.di.ipv.stub.orc.models;
 
 import java.util.List;
 
-public record InheritedIdentityJwtClaim(List<String> values) {}
+public record ListOfStringValues(List<String> values) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/EvcsAccessTokenGenerator.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/EvcsAccessTokenGenerator.java
@@ -1,0 +1,114 @@
+package uk.gov.di.ipv.stub.orc.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.stub.orc.exceptions.OrchestratorStubException;
+import uk.gov.di.ipv.stub.orc.exceptions.SignerCreationException;
+import uk.gov.di.ipv.stub.orc.models.EvcsTokenRequest;
+import uk.gov.di.ipv.stub.orc.models.EvcsTokenResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.text.ParseException;
+
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.EVCS_ACCESS_TOKEN_ENDPOINT;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK;
+import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.EVCS_ACCESS_TOKEN_TTL;
+
+public class EvcsAccessTokenGenerator {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOGGER = LoggerFactory.getLogger(EvcsAccessTokenGenerator.class);
+    private static final String STAGING = "staging";
+    private static final JWSHeader JWS_HEADER =
+            new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
+    private final ECDSASigner signer;
+
+    public EvcsAccessTokenGenerator() {
+        this.signer = createJwtSigner();
+    }
+
+    public String getAccessToken(String environment, String userId)
+            throws OrchestratorStubException {
+        if (STAGING.equalsIgnoreCase(environment)) {
+            LOGGER.info("Getting evcs access token from api");
+            return getAccessTokenFromEndpoint(userId);
+        }
+
+        LOGGER.info("Generating evcs access token");
+        return generateAccessToken(userId);
+    }
+
+    private String generateAccessToken(String userId) throws OrchestratorStubException {
+        SignedJWT signedJWT =
+                new SignedJWT(JWS_HEADER, new JWTClaimsSet.Builder().subject(userId).build());
+
+        try {
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            LOGGER.error("Failed to sign evcs access token");
+            throw new OrchestratorStubException(e);
+        }
+
+        return signedJWT.serialize();
+    }
+
+    private String getAccessTokenFromEndpoint(String userId) throws OrchestratorStubException {
+        var httpRequest =
+                new HTTPRequest(HTTPRequest.Method.POST, URI.create(EVCS_ACCESS_TOKEN_ENDPOINT));
+
+        try {
+            httpRequest.setQuery(
+                    OBJECT_MAPPER.writeValueAsString(
+                            new EvcsTokenRequest(userId, Integer.parseInt(EVCS_ACCESS_TOKEN_TTL))));
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to create evcs token request");
+            throw new OrchestratorStubException(e);
+        }
+
+        var response = sendHttpRequest(httpRequest);
+
+        if (!response.indicatesSuccess()) {
+            throw new OrchestratorStubException(
+                    String.format(
+                            "Failed to get access token - status code: %d",
+                            response.getStatusCode()));
+        }
+
+        try {
+            return OBJECT_MAPPER.readValue(response.getContent(), EvcsTokenResponse.class).token();
+        } catch (IOException e) {
+            LOGGER.error("Failed to read evcs token response");
+            throw new OrchestratorStubException(e);
+        }
+    }
+
+    private HTTPResponse sendHttpRequest(HTTPRequest request) throws OrchestratorStubException {
+        try {
+            return request.send();
+        } catch (IOException e) {
+            throw new OrchestratorStubException(e);
+        }
+    }
+
+    private ECDSASigner createJwtSigner() {
+        try {
+            LOGGER.info(EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK);
+            return new ECDSASigner(ECKey.parse(EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK).toECPrivateKey());
+        } catch (ParseException | JOSEException e) {
+            LOGGER.error("Failed to create jwt signer");
+            throw new SignerCreationException(e);
+        }
+    }
+}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -20,6 +20,7 @@ import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
 import uk.gov.di.ipv.stub.orc.models.JarClaims;
 
 import java.security.KeyFactory;
@@ -74,8 +75,9 @@ public class JwtBuilder {
             String inheritedIdSubject,
             String inheritedIdEvidence,
             String inheritedIdVot,
-            String scope,
-            String clientId)
+            Scope scope,
+            String clientId,
+            String evcsAccessToken)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     JsonProcessingException {
         String audience = getIpvCoreAudience(environment);
@@ -99,7 +101,7 @@ public class JwtBuilder {
             }
         }
 
-        var jarClaims = new JarClaims(inheritedIdJwt);
+        var jarClaims = new JarClaims(inheritedIdJwt, evcsAccessToken);
         var jarClaimsMap =
                 objectMapper.convertValue(jarClaims, new TypeReference<Map<String, Object>>() {});
 
@@ -121,7 +123,7 @@ public class JwtBuilder {
                         .claim("persistent_session_id", UUID.randomUUID().toString())
                         .claim("email_address", userEmailAddress)
                         .claim("vtr", vtr)
-                        .claim("scope", scope);
+                        .claim("scope", scope.toString());
         if (reproveIdentityValue != ReproveIdentityClaimValue.NOT_PRESENT) {
             claimSetBuilder.claim(
                     "reprove_identity", reproveIdentityValue == ReproveIdentityClaimValue.TRUE);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Include evcs access token in orch-stub JAR

### Why did it change
This adds logic to generate an access token for the evcs storage system and include it as a claim in the JAR. The evcs system requires this before reading anythign from it. Core will parse it and send it in requests to evcs.

This change introduceds two ways of generating a token.

If the stub is being used against the staging environment it will call an API provided to us by the accounts bravo team. That will return to us a token signed by them that will be accepted by the staging deploy of the evcs system that we will be integrating with. We provide the user ID and a ttl to the API.

If the stub is running in any other env (dev and build) it will generate a sign a token itself. It's using the private key that matches the public key that our stub of evcs is using to validate access tokens. Our stub only validates the signature and that the `sub` attribute of the JWT matches the user ID sent in the get request to it. So we don't need to include anything else in the JWT.

### Decrypted JAR requests generated by these changes
#### dev/build
##### JAR
```
{
  "sub": "urn:uuid:ebb0b160-5768-4f33-8191-1f87ea56751a",
  "iss": "orchestrator",
  "persistent_session_id": "37ca097b-a3b9-499d-8842-787fb00a0c1c",
  "response_type": "code",
  "client_id": "orchestrator",
  "govuk_signin_journey_id": "7a2be982-07ec-4257-9532-46f020608a75",
  "aud": "https://dev-chrisw.01.dev.identity.account.gov.uk",
  "nbf": 1716472732,
  "email_address": "dev-platform-testing@digital.cabinet-office.gov.uk",
  "vtr": [
    "P2"
  ],
  "claims": {
    "userInfo": {
      "https://vocab.account.gov.uk/v1/coreIdentityJWT": {
        "essential": true
      },
      "https://vocab.account.gov.uk/v1/storageAccessToken": {
        "values": [
          "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplYmIwYjE2MC01NzY4LTRmMzMtODE5MS0xZjg3ZWE1Njc1MWEifQ.xX1yH-owk7ayF_z9a89X-EVBQ87PdQYqPR8YmjFrii1qL7D8a1mpz3F42c0_3UIEoxA4S5YYd48I9wq7Utem8g"
        ]
      }
    }
  },
  "redirect_uri": "https://orch-dev-chrisw.01.core.dev.stubs.account.gov.uk/callback",
  "state": "orchestrator-stub-state",
  "exp": 1716473632,
  "iat": 1716472732
}
```
##### access token inside JAR
```
{
  "header": {
    "typ": "JWT",
    "alg": "ES256"
  },
  "payload": {
    "sub": "urn:uuid:ebb0b160-5768-4f33-8191-1f87ea56751a"
  }
}
```


#### staging
##### JAR
```
{
  "sub": "urn:uuid:577b59a0-8247-4c25-ab8b-557d325545fa",
  "iss": "orchestrator",
  "persistent_session_id": "82835d94-e58c-490c-a322-f4e659545714",
  "response_type": "code",
  "client_id": "orchestrator",
  "govuk_signin_journey_id": "f4aea96e-2648-4496-87b6-46639a14e870",
  "aud": "https://identity.staging.account.gov.uk",
  "nbf": 1716472871,
  "email_address": "dev-platform-testing@digital.cabinet-office.gov.uk",
  "vtr": [
    "P2"
  ],
  "claims": {
    "userInfo": {
      "https://vocab.account.gov.uk/v1/coreIdentityJWT": {
        "essential": true
      },
      "https://vocab.account.gov.uk/v1/storageAccessToken": {
        "values": [
          "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImVjS2lkMTIzIn0.eyJzdWJqZWN0IjoidXJuOnV1aWQ6NTc3YjU5YTAtODI0Ny00YzI1LWFiOGItNTU3ZDMyNTU0NWZhIiwiZXhwIjoxNzE2NDc2NDcxLCJpYXQiOjE3MTY0NzI4NzEsImlzcyI6Imh0dHBzOi8vbW9jay5jcmVkZW50aWFsLXN0b3JlLmJ1aWxkLmFjY291bnQuZ292LnVrL29yY2hlc3RyYXRpb24iLCJhdWQiOiJpcHZBdWRpZW5jZSJ9.VINFF6-9g37P5aU9bpHi_BG4N37ux8fa7HZH3NUxG7FVFMUXdd31gtBq7fk2MvqD-foQxfDVPwt4FWtMJQc3fQ"
        ]
      }
    }
  },
  "redirect_uri": "https://orch-dev-chrisw.01.core.dev.stubs.account.gov.uk/callback",
  "state": "orchestrator-stub-state",
  "exp": 1716473771,
  "iat": 1716472871
}
```

##### access token inside JAR
```
{
  "header": {
    "typ": "JWT",
    "alg": "ES256",
    "kid": "ecKid123"
  },
  "payload": {
    "aud": "ipvAudience",
    "exp": 1716476471,
    "iat": 1716472871,
    "iss": "https://mock.credential-store.build.account.gov.uk/orchestration",
    "subject": "urn:uuid:577b59a0-8247-4c25-ab8b-557d325545fa"
  }
}
```

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-6218](https://govukverify.atlassian.net/browse/PYI-6218)
