### PR TITLE
PYIC-6069: Use reverification endpoint

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -9,8 +9,6 @@ public class OrchestratorConfig {
                     "IPV_BACKCHANNEL_ENDPOINT", "https://api.identity.build.account.gov.uk/");
     public static final String IPV_BACKCHANNEL_TOKEN_PATH =
             getConfigValue("IPV_BACKCHANNEL_TOKEN_PATH", "/dev/token");
-    public static final String IPV_BACKCHANNEL_USER_IDENTITY_PATH =
-            getConfigValue("IPV_BACKCHANNEL_USER_IDENTITY_PATH", "/dev/user-identity");
     public static final String AUTH_CLIENT_ID = getConfigValue("AUTH_CLIENT_ID", "stubAuth");
     public static final String ORCHESTRATOR_CLIENT_ID =
             getConfigValue("ORCHESTRATOR_CLIENT_ID", "orchestrator");

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/config/OrchestratorConfig.java
@@ -7,8 +7,6 @@ public class OrchestratorConfig {
     public static final String IPV_BACKCHANNEL_ENDPOINT =
             getConfigValue(
                     "IPV_BACKCHANNEL_ENDPOINT", "https://api.identity.build.account.gov.uk/");
-    public static final String IPV_BACKCHANNEL_TOKEN_PATH =
-            getConfigValue("IPV_BACKCHANNEL_TOKEN_PATH", "/dev/token");
     public static final String AUTH_CLIENT_ID = getConfigValue("AUTH_CLIENT_ID", "stubAuth");
     public static final String ORCHESTRATOR_CLIENT_ID =
             getConfigValue("ORCHESTRATOR_CLIENT_ID", "orchestrator");

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -313,8 +313,7 @@ public class IpvHandler {
     private AccessToken exchangeCodeForToken(
             AuthorizationCode authorizationCode, String targetEnvironment)
             throws OrchestratorStubException, URISyntaxException {
-        URI resolve =
-                getIpvBackchannelEndpoint(targetEnvironment).resolve(TOKEN_PATH);
+        URI resolve = getIpvBackchannelEndpoint(targetEnvironment).resolve(TOKEN_PATH);
         LOGGER.debug("token url is " + resolve);
 
         SignedJWT signedClientJwt;

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -61,7 +61,6 @@ import java.util.UUID;
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.AUTH_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_ENDPOINT;
-import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_BACKCHANNEL_TOKEN_PATH;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.IPV_ENDPOINT;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_CLIENT_ID;
 import static uk.gov.di.ipv.stub.orc.config.OrchestratorConfig.ORCHESTRATOR_REDIRECT_URL;
@@ -74,6 +73,7 @@ public class IpvHandler {
 
     private static final String CREDENTIALS_URL_PROPERTY =
             "https://vocab.account.gov.uk/v1/credentialJWT";
+    private static final String TOKEN_PATH = "token";
     private static final String USER_IDENTITY_PATH = "user-identity";
     private static final String REVERIFICATION_PATH = "reverification";
 
@@ -314,7 +314,7 @@ public class IpvHandler {
             AuthorizationCode authorizationCode, String targetEnvironment)
             throws OrchestratorStubException, URISyntaxException {
         URI resolve =
-                getIpvBackchannelEndpoint(targetEnvironment).resolve(IPV_BACKCHANNEL_TOKEN_PATH);
+                getIpvBackchannelEndpoint(targetEnvironment).resolve(TOKEN_PATH);
         LOGGER.debug("token url is " + resolve);
 
         SignedJWT signedClientJwt;


### PR DESCRIPTION
## Proposed changes

### What changed

- Change to use reverification endpoint instead of build user identity through user-details endpoint

### Why did it change

- We use the reverification endpoint for mfa resets

### Issue tracking

- [PYI-6069](https://govukverify.atlassian.net/browse/PYI-6069)

### Testing

I will test this:
- manually
- against the e2e regression pack
