### PR TITLE
BAU: Give orch stub error page IDs

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/resources/templates/error.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/error.mustache
@@ -54,8 +54,8 @@
         {{#error}}
             <h3 class="govuk-heading-l">Something went wrong: </h3>
             <div class="govuk-details__text">
-                <pre><code>error_code: {{error_code}}</code></pre>
-                <pre><code>error_description: {{error_description}}</code></pre>
+                <pre><code id="error-code">error_code: {{error_code}}</code></pre>
+                <pre><code id="error-description">error_description: {{error_description}}</code></pre>
             </div>
         {{/error}}
     </main>


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Give orch stub error page IDs

### Why did it change

So we can target them easily in tests
