### PR TITLE
PYIC-6069: Fix authorization response state handling

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -294,6 +294,7 @@ public class IpvHandler {
             throws ParseException, OauthException {
         var authorizationResponse =
                 AuthorizationResponse.parse(URI.create("https:///?" + request.queryString()));
+        var state = authorizationResponse.getState();
 
         if (!authorizationResponse.indicatesSuccess()) {
             var error = authorizationResponse.toErrorResponse().getErrorObject();
@@ -301,7 +302,7 @@ public class IpvHandler {
             throw new OauthException(error);
         }
 
-        if (!ORCHESTRATOR_STUB_STATE.equals(authorizationResponse.getState())) {
+        if (!ORCHESTRATOR_STUB_STATE.equals(state) && !AUTH_STUB_STATE.equals(state)) {
             throw new OauthException(
                     OAuth2Error.INVALID_REQUEST.appendDescription(
                             " - missing or invalid state value"));


### PR DESCRIPTION
## Proposed changes

### What changed

- Enable authorisation response to have auth stub state

### Why did it change

- So it doesn't throw an error when we receive an auth stub state
- The problem was found during testing PYIC-6486

### Issue tracking

- [PYIC-6069](https://govukverify.atlassian.net/browse/PYIC-6069)

[PYIC-6069]: https://govukverify.atlassian.net/browse/PYIC-6069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ