### PR TITLE
PYIC-6658: udpate Orchestrator stub JAR to match real orch JAR

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
@@ -15,6 +15,8 @@ public record JarClaims(JarUserInfo userinfo) {
                                 : new ListOfStringValues(List.of(inheritedIdentityJwt)),
                         evcsAccessToken == null
                                 ? null
-                                : new ListOfStringValues(List.of(evcsAccessToken))));
+                                : new ListOfStringValues(List.of(evcsAccessToken)),
+                        null,
+                        null));
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
@@ -10,13 +10,14 @@ public record JarClaims(JarUserInfo userinfo) {
                         new Essential(true),
                         new Essential(true),
                         null,
+                        new Essential(true),
+                        new Essential(true),
                         inheritedIdentityJwt == null
                                 ? null
                                 : new ListOfStringValues(List.of(inheritedIdentityJwt)),
                         evcsAccessToken == null
                                 ? null
-                                : new ListOfStringValues(List.of(evcsAccessToken)),
-                        new Essential(true),
-                        new Essential(true)));
+                                : new ListOfStringValues(List.of(evcsAccessToken))
+                        ));
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
@@ -17,7 +17,6 @@ public record JarClaims(JarUserInfo userinfo) {
                                 : new ListOfStringValues(List.of(inheritedIdentityJwt)),
                         evcsAccessToken == null
                                 ? null
-                                : new ListOfStringValues(List.of(evcsAccessToken))
-                        ));
+                                : new ListOfStringValues(List.of(evcsAccessToken))));
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarClaims.java
@@ -16,7 +16,7 @@ public record JarClaims(JarUserInfo userinfo) {
                         evcsAccessToken == null
                                 ? null
                                 : new ListOfStringValues(List.of(evcsAccessToken)),
-                        null,
-                        null));
+                        new Essential(true),
+                        new Essential(true)));
     }
 }

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
@@ -8,10 +8,16 @@ public record JarUserInfo(
                 Essential coreIdentityJwtClaim,
         @JsonProperty(value = "https://vocab.account.gov.uk/v1/address") Essential addressClaim,
         @JsonProperty(value = "https://vocab.account.gov.uk/v1/passport") Essential passportClaim,
-        @JsonProperty(value = "https://vocab.account.gov.uk/v1/socialSecurityNumber")
+        @JsonProperty(value = "https://vocab.account.gov.uk/v1/socialSecurityRecord")
                 Essential ninoClaim,
         @JsonInclude(JsonInclude.Include.NON_NULL)
                 @JsonProperty(value = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
                 ListOfStringValues inheritedIdentityClaim,
         @JsonProperty(value = "https://vocab.account.gov.uk/v1/storageAccessToken")
-                ListOfStringValues evcsAccessToken) {}
+                ListOfStringValues evcsAccessToken,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+                @JsonProperty(value = "https://vocab.account.gov.uk/v1/drivingPermit")
+                Essential drivingPermitClaim,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+                @JsonProperty(value = "https://vocab.account.gov.uk/v1/returnCode")
+                Essential returnCodeClaim) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
@@ -13,11 +13,9 @@ public record JarUserInfo(
         @JsonInclude(JsonInclude.Include.NON_NULL)
                 @JsonProperty(value = "https://vocab.account.gov.uk/v1/drivingPermit")
                 Essential drivingPermitClaim,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-                @JsonProperty(value = "https://vocab.account.gov.uk/v1/returnCode")
+        @JsonProperty(value = "https://vocab.account.gov.uk/v1/returnCode")
                 Essential returnCodeClaim,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-                @JsonProperty(value = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
+        @JsonProperty(value = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
                 ListOfStringValues inheritedIdentityClaim,
         @JsonProperty(value = "https://vocab.account.gov.uk/v1/storageAccessToken")
                 ListOfStringValues evcsAccessToken) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/models/JarUserInfo.java
@@ -11,13 +11,13 @@ public record JarUserInfo(
         @JsonProperty(value = "https://vocab.account.gov.uk/v1/socialSecurityRecord")
                 Essential ninoClaim,
         @JsonInclude(JsonInclude.Include.NON_NULL)
-                @JsonProperty(value = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
-                ListOfStringValues inheritedIdentityClaim,
-        @JsonProperty(value = "https://vocab.account.gov.uk/v1/storageAccessToken")
-                ListOfStringValues evcsAccessToken,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
                 @JsonProperty(value = "https://vocab.account.gov.uk/v1/drivingPermit")
                 Essential drivingPermitClaim,
         @JsonInclude(JsonInclude.Include.NON_NULL)
                 @JsonProperty(value = "https://vocab.account.gov.uk/v1/returnCode")
-                Essential returnCodeClaim) {}
+                Essential returnCodeClaim,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+                @JsonProperty(value = "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
+                ListOfStringValues inheritedIdentityClaim,
+        @JsonProperty(value = "https://vocab.account.gov.uk/v1/storageAccessToken")
+                ListOfStringValues evcsAccessToken) {}

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -114,13 +114,13 @@ public class JwtBuilder {
                         .issuer(clientId)
                         .notBeforeTime(Date.from(now))
                         .expirationTime(generateExpirationTime(now))
+                        .jwtID(UUID.randomUUID().toString())
                         .claim("claims", jarClaimsMap)
                         .claim("client_id", clientId)
                         .claim("response_type", ResponseType.Value.CODE.toString())
                         .claim("redirect_uri", redirectUri)
                         .claim("state", state)
                         .claim("govuk_signin_journey_id", signInJourneyId)
-                        .claim("persistent_session_id", UUID.randomUUID().toString())
                         .claim("email_address", userEmailAddress)
                         .claim("vtr", vtr)
                         .claim("scope", scope.toString());
@@ -138,7 +138,6 @@ public class JwtBuilder {
                 .audience(getIpvCoreAudience(targetEnvironment))
                 .issuer(ORCHESTRATOR_CLIENT_ID)
                 .expirationTime(generateExpirationTime(now))
-                .jwtID(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -138,6 +138,7 @@ public class JwtBuilder {
                 .audience(getIpvCoreAudience(targetEnvironment))
                 .issuer(ORCHESTRATOR_CLIENT_ID)
                 .expirationTime(generateExpirationTime(now))
+                .jwtID(UUID.randomUUID().toString())
                 .build();
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- removes `persistent_session_id` from stub as real orch JAR does not have this
- adds `jti` to orch stub JAR
- adds `drivingPermit` and `returnCode` claims and re-names `socialSecurityNumber` -> `socialSecurityRecord` 

### Why did it change
We had a P1 incident recently caused by our the JAR provided by the orchestrator stub differing from the JAR received in production. This PR ensures that there are no discrepancies between a JAR from the orch stub and one from the real orch.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-6658](https://govukverify.atlassian.net/browse/PYI-6658)