### PR TITLE
PYIC-5099: Enable CRI stub to sign with RSA

### DIFF
--- a/di-ipv-credential-issuer-stub/core-dev-deploy/dwp-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/dwp-kbv/template.yaml
@@ -52,6 +52,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/dwp-kbv/env/VC_TTL_SECONDS" #pragma: allowlist secret
+  VcSigningAlgorithm:
+    Description: Environment Variables for ECS - Retrieved from SSM Parameter Store
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /stubs/credential-issuer/dwp-kbv/env/VC_SIGNING_ALGORITHM #pragma: allowlist secret
 
 Conditions:
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670"]
@@ -457,6 +461,8 @@ Resources:
             Value: !Ref VcIssuer
           - Name: VC_TTL_SECONDS
             Value: !Ref VcTtlSeconds
+          - Name: VC_SIGNING_ALGORITHM
+            Value: !Ref 'VcSigningAlgorithm'
           Secrets:
             - Name: "VC_SIGNING_KEY"
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/dwp-kbv/env/VC_SIGNING_KEY"

--- a/di-ipv-credential-issuer-stub/deploy/dwp-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/dwp-kbv/template.yaml
@@ -52,6 +52,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/credential-issuer/dwp-kbv/env/VC_TTL_SECONDS" #pragma: allowlist secret
+  VcSigningAlgorithm:
+    Description: Environment Variables for ECS - Retrieved from SSM Parameter Store
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /stubs/credential-issuer/dwp-kbv/env/VC_SIGNING_ALGORITHM #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -502,6 +506,8 @@ Resources:
             Value: !Ref VcIssuer
           - Name: VC_TTL_SECONDS
             Value: !Ref VcTtlSeconds
+          - Name: VC_SIGNING_ALGORITHM
+            Value: !Ref 'VcSigningAlgorithm'
           Secrets:
             - Name: "VC_SIGNING_KEY"
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/dwp-kbv/env/VC_SIGNING_KEY"

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CredentialIssuerConfig.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.stub.cred.config;
 
+import uk.gov.di.ipv.stub.cred.vc.EncryptionAlgorithm;
+
 public class CredentialIssuerConfig {
     public static final String PORT = getConfigValue("CREDENTIAL_ISSUER_PORT", "8084");
     public static final String NAME =
@@ -32,6 +34,15 @@ public class CredentialIssuerConfig {
 
     public static String getVerifiableCredentialSigningKey() {
         return getConfigValue("VC_SIGNING_KEY", null);
+    }
+
+    public static EncryptionAlgorithm getVerifiableCredentialSigningAlgorithm() {
+        var signingAlgorithm = getConfigValue("VC_SIGNING_ALGORITHM", null);
+        if (signingAlgorithm == null) {
+            return EncryptionAlgorithm.EC;
+        }
+
+        return EncryptionAlgorithm.valueOf(signingAlgorithm);
     }
 
     public static Long getVerifiableCredentialTtlSeconds() {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/EncryptionAlgorithm.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/EncryptionAlgorithm.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.stub.cred.vc;
+
+public enum EncryptionAlgorithm {
+    EC,
+    RSA
+}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.stub.cred.service.ConfigService;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPrivateKey;
-import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.*;
@@ -114,10 +113,8 @@ public class VerifiableCredentialGenerator {
 
     private static SignedJWT signTestVc(JWTClaimsSet claimsSet)
             throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
-        var signingAlgorithm = CredentialIssuerConfig
-                .getVerifiableCredentialSigningAlgorithm();
-        var signingKey = CredentialIssuerConfig
-                .getVerifiableCredentialSigningKey();
+        var signingAlgorithm = CredentialIssuerConfig.getVerifiableCredentialSigningAlgorithm();
+        var signingKey = CredentialIssuerConfig.getVerifiableCredentialSigningKey();
 
         return switch (signingAlgorithm) {
             case EC -> signTestVcWithEc(claimsSet, signingKey);
@@ -125,15 +122,13 @@ public class VerifiableCredentialGenerator {
         };
     }
 
-    private static SignedJWT signTestVcWithEc(JWTClaimsSet claimsSet, String signingKey) throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
+    private static SignedJWT signTestVcWithEc(JWTClaimsSet claimsSet, String signingKey)
+            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
         var kf = KeyFactory.getInstance(EncryptionAlgorithm.EC.name());
-        var privateKeySpec =
-                new PKCS8EncodedKeySpec(Base64.getDecoder().decode(signingKey));
-        var ecdsaSigner =
-                new ECDSASigner((ECPrivateKey) kf.generatePrivate(privateKeySpec));
+        var privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(signingKey));
+        var ecdsaSigner = new ECDSASigner((ECPrivateKey) kf.generatePrivate(privateKeySpec));
 
-        var jwsHeader =
-                new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
 
         var signedJWT = new SignedJWT(jwsHeader, claimsSet);
         signedJWT.sign(ecdsaSigner);
@@ -141,10 +136,10 @@ public class VerifiableCredentialGenerator {
         return signedJWT;
     }
 
-    private static SignedJWT signTestVcWithRSA(JWTClaimsSet claimsSet, String signingKey)  throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
+    private static SignedJWT signTestVcWithRSA(JWTClaimsSet claimsSet, String signingKey)
+            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
         var kf = KeyFactory.getInstance(EncryptionAlgorithm.RSA.name());
-        var privateKeySpec =
-                new PKCS8EncodedKeySpec(Base64.getDecoder().decode(signingKey));
+        var privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(signingKey));
         var signer = new RSASSASigner(kf.generatePrivate(privateKeySpec));
 
         var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).type(JOSEObjectType.JWT).build();

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -50,7 +50,6 @@ import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_CREDEN
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VC_TYPE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
-import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator.EC_ALGO;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator.JTI_SCHEME_AND_PATH_PREFIX;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -62,6 +61,7 @@ public class VerifiableCredentialGeneratorTest {
 
     private static final Pattern JTI_PATTERN =
             Pattern.compile(String.format("%s:(?<uuid>[^:]+)", JTI_SCHEME_AND_PATH_PREFIX));
+    private static final String EC_ALGO = "EC";
 
     @SystemStub
     private final EnvironmentVariables environmentVariables =


### PR DESCRIPTION
## Proposed changes

### What changed

- Added reference to VC_SIGNING_ALGORITHM
- Used said algorithm to decide which algorithm to sign VCs with

### Why did it change

- So we update the DWP KBV CRI stub to act like the RSA-signing real thing

###  infra change PR
https://github.com/govuk-one-login/ipv-stubs-common-infra/pull/204

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-5099](https://govukverify.atlassian.net/browse/PYI-5099)
