### PR TITLE
OJ-2611: Add button for KBV confidence selection (Using new Verification Score button)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -240,7 +240,7 @@
         "filename": "di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 96
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java": [
@@ -503,5 +503,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-05T14:02:24Z"
+  "generated_at": "2024-06-14T10:44:33Z"
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -44,6 +44,7 @@ public class CoreStub {
         Spark.post("/edit-user", coreStubHandler.updateUser);
         Spark.get("/callback", coreStubHandler.doCallback);
         Spark.get("/answers", coreStubHandler.answers);
+        Spark.get("/select-verification-score", coreStubHandler.verificationScoreRequest);
         setupBackendRoutes(coreStubHandler);
         Spark.exception(Exception.class, exceptionHandler());
     }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -14,6 +14,11 @@ public record CredentialIssuer(
         String publicEncryptionJwkBase64,
         String publicVCSigningVerificationJwkBase64,
         String apiKeyEnvVar) {
+
+    public boolean isKbvCri() {
+        return this.id.contains("kbv") && !this.id.contains("hmrc");
+    }
+
     public boolean isAddressCri() {
         return this.id.contains("address");
     }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/VerificationScore.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/VerificationScore.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record VerificationScore(@JsonProperty("verification_score") int verificationScore) {}

--- a/di-ipv-core-stub/src/main/resources/templates/verification-score.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/verification-score.mustache
@@ -47,40 +47,41 @@
         </div>
     </div>
 </header>
-
 <div class="govuk-width-container ">
     <main class="govuk-main-wrapper>" id="main-content" role="main">
+
         <a href="/" class="govuk-back-link">Back</a>
         <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
             <h2 class="govuk-heading-xl">
-                Visit Credential Issuers
+                KBV - Verification Score
             </h2>
         </div>
+        <legend class="govuk-fieldset__legend govuk-label"></legend>
+        <form action="/credential-issuer?cri={{cri}}">
+        <input type="hidden" name="cri" value="{{cri}}">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <h1 class="govuk-fieldset__heading">
+                        Select Confidence Level
+                    </h1>
+                </legend>
+                <div id="waste-hint" class="govuk-hint"></div>
+                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                    <div class="govuk-form-group">
+                        <select class="govuk-select" id="verification_score" name="verification_score">
+                            <option value="1">Low Confidence (1)</option>
+                            <option value="2">Medium Confidence (2)</option>
+                        </select>
+                    </div>
+                </div>
 
-        {{#cris}}
-            {{#isCheckHmrcCri}}
-                <a href="{{#isCheckHmrcCri}}/evidence-request{{/isCheckHmrcCri}}?cri={{id}}" >
-                    <input class="govuk-button" data-module="govuk-button" type="button"
-                           value="{{name}}{{#isCheckHmrcCri}} - Evidence Requested{{/isCheckHmrcCri}}">
-                </a>
-            {{/isCheckHmrcCri}}
-            {{#isKbvCri}}
-                <a href="{{#isKbvCri}}/select-verification-score{{/isKbvCri}}?cri={{id}}" >
-                <input class="govuk-button" data-module="govuk-button" type="button"
-                       value="{{name}}{{#isKbvCri}} - Verification Score{{/isKbvCri}}">
-                </a>
-            {{/isKbvCri}}
-			{{#isAddressCri}}
-                <a href="{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}" >
-                <input class="govuk-button" data-module="govuk-button" type="button"
-                       value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}">
-                </a>
-			{{/isAddressCri}}
-            <div class="govuk-button-group">
-                <a href="/credential-issuer?cri={{id}}">
-                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
-            </div>
-        {{/cris}}
+                <div class="govuk-button-group govuk-!-margin-top-9">
+                    <button class="govuk-button" data-module="govuk-button">Continue</button>
+                </div>
+            </fieldset>
+        </div>
+        </form>
     </main>
 </div>
 


### PR DESCRIPTION
## Proposed changes

### What changed
This PR adds the ability to select confidence level in Experian KBV.
The JAR request will now contain `verification_score` when using the "Verification Score button

### Why did it change
We are working towards having a low confidence journey and the entry in core stub allows us to test this. 

### Screenshots

**Button**
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/7acfb72d-7461-4c2f-8de3-9b2d464ba90c)

**Page**
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/e2eb2a86-9d93-4307-bdbb-b007727a6aea)

**Console verification**
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/cea51e6f-3943-4e35-8c65-72ea8273770a)
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/3161c49c-8c09-4239-810a-adb92f767bae)


### Issue tracking
- [OJ-2611](https://govukverify.atlassian.net/browse/OJ-2611)


[OJ-2611]: https://govukverify.atlassian.net/browse/OJ-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ