### PR TITLE
OJ-2611: Add button for KBV confidence selection (Evidence Requested)

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -14,6 +14,11 @@ public record CredentialIssuer(
         String publicEncryptionJwkBase64,
         String publicVCSigningVerificationJwkBase64,
         String apiKeyEnvVar) {
+
+    public boolean isKbvCri() {
+        return this.id.contains("kbv") && !this.id.contains("hmrc");
+    }
+
     public boolean isAddressCri() {
         return this.id.contains("address");
     }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/EvidenceRequestClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/EvidenceRequestClaims.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record EvidenceRequestClaims(
         @JsonProperty("scoringPolicy") String scoringPolicy,
-        @JsonProperty("strengthScore") int strengthScore) {
+        @JsonProperty("strengthScore") int strengthScore,
+        @JsonProperty("verificationScore") int verificationScore) {
 
     @JsonCreator
     public EvidenceRequestClaims {}
@@ -16,5 +17,9 @@ public record EvidenceRequestClaims(
 
     public int getStrengthScore() {
         return strengthScore;
+    }
+
+    public int getVerificationScore() {
+        return verificationScore;
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -186,10 +186,12 @@ public class CoreStubHandler {
                 var postcode = request.queryParams("postcode");
                 var strengthScore = request.queryParams("score");
                 var scoringPolicy = request.queryParams("evidence_request");
+                var verificationScore = request.queryParams("verification_score");
 
                 if (credentialIssuer.sendIdentityClaims()
                         && Objects.isNull(request.queryParams("postcode"))) {
-                    saveEvidenceRequestToSessionIfPresent(request, strengthScore, scoringPolicy);
+                    saveEvidenceRequestToSessionIfPresent(
+                            request, strengthScore, scoringPolicy, verificationScore);
                     return ViewHelper.render(
                             Map.of(
                                     "cri",
@@ -522,10 +524,15 @@ public class CoreStubHandler {
     }
 
     private static void saveEvidenceRequestToSessionIfPresent(
-            Request request, String strengthScore, String scoringPolicy) {
-        if (Objects.nonNull(strengthScore) && Objects.nonNull(scoringPolicy)) {
+            Request request, String strengthScore, String scoringPolicy, String verificationScore) {
+        if (Objects.nonNull(strengthScore)
+                && Objects.nonNull(scoringPolicy)
+                && Objects.nonNull(verificationScore)) {
             EvidenceRequestClaims evidenceRequest =
-                    new EvidenceRequestClaims(scoringPolicy, Integer.valueOf(strengthScore));
+                    new EvidenceRequestClaims(
+                            scoringPolicy,
+                            Integer.parseInt(strengthScore),
+                            Integer.parseInt(verificationScore));
             LOGGER.info("✅  Saving evidence request to session to {}", evidenceRequest);
             request.session().attribute("evidence_request", evidenceRequest);
         }

--- a/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
@@ -64,6 +64,12 @@
                            value="{{name}}{{#isCheckHmrcCri}} - Evidence Requested{{/isCheckHmrcCri}}">
                 </a>
             {{/isCheckHmrcCri}}
+            {{#isKbvCri}}
+                <a href="{{#isKbvCri}}/evidence-request{{/isKbvCri}}?cri={{id}}" >
+                <input class="govuk-button" data-module="govuk-button" type="button"
+                       value="{{name}}{{#isKbvCri}} - Evidence Requested{{/isKbvCri}}">
+                </a>
+            {{/isKbvCri}}
 			{{#isAddressCri}}
                 <a href="{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}" >
                 <input class="govuk-button" data-module="govuk-button" type="button"

--- a/di-ipv-core-stub/src/main/resources/templates/evidence-request.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/evidence-request.mustache
@@ -53,7 +53,7 @@
 		<a href="/" class="govuk-back-link">Back</a>
 		<div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
 			<h2 class="govuk-heading-xl">
-                Check - Evidence Requested
+                Evidence Requested
             </h2>
 		</div>
 		<legend class="govuk-fieldset__legend govuk-label"></legend>
@@ -86,6 +86,15 @@
                                 <option value="2" selected>2</option>
                                 <option value="3">3</option>
                                 <option value="4">4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-margin-bottom-5" for="verification_score">
+                                Verification Score:
+                            </label>
+                            <select class="govuk-select" id="verification_score" name="verification_score">
+                                <option value="1">1</option>
+                                <option value="2">2</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
## Proposed changes

### What changed
This PR adds the ability to select confidence level as part of the evidence requested block.
The JAR request will now contain `verification_score` .

### Why did it change
We are working towards having a low confidence journey and the entry in core stub allows us to test this. 

### Screenshots

**Button**
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/29cdecba-f545-4c97-8763-e079c50b2409)

**Verification Score Field**
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/ab20f72a-c57e-4f84-88ec-b842bddd2b49)

**Console verification**
![image](https://github.com/govuk-one-login/ipv-stubs/assets/76599223/0aa3421c-7544-4279-8d4a-818ece0e58c7)

### Issue tracking
- [OJ-2611](https://govukverify.atlassian.net/browse/OJ-2611)


[OJ-2611]: https://govukverify.atlassian.net/browse/OJ-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ