### PR TITLE
PYIC-5758 Remove txn from SecurityCheck evidence

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,21 +114,21 @@
         "filename": "di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 55
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 57
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 57
       }
     ],
     "di-ipv-cimit-stub/lambdas/post-mitigations/src/test/java/uk/gov/di/ipv/core/postmitigations/PostMitigationsHandlerTest.java": [
@@ -499,5 +499,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-13T15:50:20Z"
+  "generated_at": "2024-06-20T09:47:31Z"
 }

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandler.java
@@ -124,14 +124,7 @@ public class GetContraIndicatorCredentialHandler implements RequestStreamHandler
 
     private VcClaim generateVc(String userId) {
         var contraIndicators = getContraIndicators(userId);
-        return new VcClaim(
-                List.of(
-                        new Evidence(
-                                contraIndicators,
-                                new TreeSet<>(
-                                        contraIndicators.stream()
-                                                .flatMap(ci -> ci.getTxn().stream())
-                                                .toList()))));
+        return new VcClaim(List.of(new Evidence(contraIndicators)));
     }
 
     private List<ContraIndicator> getContraIndicators(String userId) {

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/domain/cimitcredential/Evidence.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/java/uk/gov/di/ipv/core/getcontraindicatorcredential/domain/cimitcredential/Evidence.java
@@ -1,12 +1,11 @@
 package uk.gov.di.ipv.core.getcontraindicatorcredential.domain.cimitcredential;
 
 import java.util.List;
-import java.util.SortedSet;
 
-public record Evidence(List<ContraIndicator> contraIndicator, SortedSet<String> txn, String type) {
+public record Evidence(List<ContraIndicator> contraIndicator, String type) {
     private static final String SECURITY_CHECK = "SecurityCheck";
 
-    public Evidence(List<ContraIndicator> contraIndicator, SortedSet<String> txn) {
-        this(contraIndicator, txn, SECURITY_CHECK);
+    public Evidence(List<ContraIndicator> contraIndicator) {
+        this(contraIndicator, SECURITY_CHECK);
     }
 }

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/test/java/uk/gov/di/ipv/core/getcontraindicatorcredential/GetContraIndicatorCredentialHandlerTest.java
@@ -28,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 
@@ -110,9 +109,6 @@ class GetContraIndicatorCredentialHandlerTest {
 
         assertEquals(List.of("VerifiableCredential", "SecurityCheckCredential"), vcClaim.type());
 
-        var evidenceTxn = vcClaim.evidence().get(0).txn();
-        assertEquals(List.of(TXN_1), new ArrayList<>(evidenceTxn));
-
         var contraIndicators = vcClaim.evidence().get(0).contraIndicator();
         assertEquals(1, contraIndicators.size());
 
@@ -131,7 +127,7 @@ class GetContraIndicatorCredentialHandlerTest {
                                                 List.of(MitigatingCredential.EMPTY))))
                         .incompleteMitigation(List.of())
                         .document(null)
-                        .txn(evidenceTxn.stream().toList())
+                        .txn(List.of(TXN_1))
                         .build();
         assertEquals(expectedCi, firstContraIndicator);
 
@@ -592,7 +588,6 @@ class GetContraIndicatorCredentialHandlerTest {
         var claimsSet = SignedJWT.parse(response.getVc()).getJWTClaimsSet();
         var vcClaim =
                 objectMapper.convertValue(claimsSet.getJSONObjectClaim(VC_CLAIM), VcClaim.class);
-        var evidenceTxn = vcClaim.evidence().get(0).txn();
         var contraIndicators = vcClaim.evidence().get(0).contraIndicator();
 
         var expectedCi =
@@ -625,7 +620,6 @@ class GetContraIndicatorCredentialHandlerTest {
                                 .txn(List.of(TXN_2))
                                 .build());
 
-        assertEquals(evidenceTxn, new TreeSet<>(List.of(TXN_1, TXN_2, TXN_3)));
         assertEquals(expectedCi, contraIndicators);
     }
 


### PR DESCRIPTION
The `SecurityCheck` class does not include a `txn` at the top level, so we should not include one: https://vocab.account.gov.uk/v1/classes/SecurityCheckClass/

This changed in CIMIT at some point, but confirmed with @chrisclayson 

(see also https://govukverify.atlassian.net/browse/PYIC-5082)