### PR TITLE
BAU: Refactor cri-stub resource ID

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -245,7 +245,7 @@
         "filename": "di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java",
         "hashed_secret": "6dd4a86679769d70d9aee4fedad5ccc2acb6f4c3",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 46
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json": [
@@ -499,5 +499,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-25T10:06:54Z"
+  "generated_at": "2024-06-25T14:55:08Z"
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/ApiAuthRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/ApiAuthRequest.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.stub.cred.domain;
 public record ApiAuthRequest(
         String clientId,
         String request,
-        String resourceId,
         String credentialSubjectJson,
         String evidenceJson,
         Long nbf,

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/AuthRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/AuthRequest.java
@@ -5,8 +5,6 @@ public interface AuthRequest {
 
     String request();
 
-    String resourceId();
-
     String credentialSubjectJson();
 
     String evidenceJson();

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/FormAuthRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/FormAuthRequest.java
@@ -13,7 +13,6 @@ import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.CLIENT_ID;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.EVIDENCE_JSON_PAYLOAD;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.JSON_PAYLOAD;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUEST;
-import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.RESOURCE_ID;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.VC_NOT_BEFORE_DAY;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.VC_NOT_BEFORE_FLAG;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.VC_NOT_BEFORE_HOURS;
@@ -28,7 +27,6 @@ import static uk.gov.di.ipv.stub.cred.utils.StringHelper.splitCommaDelimitedStri
 public record FormAuthRequest(
         String clientId,
         String request,
-        String resourceId,
         String credentialSubjectJson,
         String evidenceJson,
         Gpg45Scores gpg45Scores,
@@ -54,7 +52,6 @@ public record FormAuthRequest(
                 .f2f(F2fDetails.fromQueryMap(paramsMap))
                 .requestedError(RequestedError.fromQueryMap(paramsMap))
                 .nbf(generateNbf(paramsMap))
-                .resourceId(paramsMap.value(RESOURCE_ID))
                 .build();
     }
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -78,7 +78,6 @@ import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.ACTIVITY_HI
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.CI;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.F2F_STUB_QUEUE_NAME;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.FRAUD;
-import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.RESOURCE_ID;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.STRENGTH;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.VALIDITY;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.VERIFICATION;
@@ -223,7 +222,6 @@ public class AuthorizeHandler {
                 LOGGER.info("criType: {}", criType.value);
 
                 Map<String, Object> frontendParams = new HashMap<>();
-                frontendParams.put(RESOURCE_ID, UUID.randomUUID().toString());
                 frontendParams.put(
                         IS_EVIDENCE_TYPE_PARAM,
                         criType.equals(CriType.EVIDENCE_CRI_TYPE)
@@ -469,7 +467,7 @@ public class AuthorizeHandler {
             AuthorizationCode authorizationCode,
             String signedVcJwt,
             String redirectUri) {
-        String resourceId = authRequest.resourceId();
+        String resourceId = UUID.randomUUID().toString();
         this.authCodeService.persist(authorizationCode, resourceId, redirectUri);
         this.credentialService.persist(signedVcJwt, resourceId);
         this.requestedErrorResponseService.persist(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -12,7 +12,6 @@ public class RequestParamConstants {
     public static final String JSON_PAYLOAD = "jsonPayload";
     public static final String REDIRECT_URI = "redirect_uri";
     public static final String REQUEST = "request";
-    public static final String RESOURCE_ID = "resourceId";
     public static final String RESPONSE_TYPE = "response_type";
     public static final String STATE = "state";
 

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -643,7 +643,6 @@
                     </table>
                 </div>
                 <br>
-                <input type="hidden" name="resourceId" value="{{resourceId}}">
                 <input class="govuk-button" data-module="govuk-button" type="submit" name="submit" value="Submit data and generate auth code">
             </form>
         </div>

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -501,10 +501,7 @@ class AuthorizeHandlerTest {
             assertNotNull(persistedEvidence.get("strengthScore"));
             assertNotNull(persistedEvidence.get("validityScore"));
 
-            verify(mockCredentialService)
-                    .persist(
-                            eq(mockSignedJwt.serialize()),
-                            eq("26c6ad15-a595-4e13-9497-f7c891fabe1d"));
+            verify(mockCredentialService).persist(eq(mockSignedJwt.serialize()), any(String.class));
         }
 
         @Test
@@ -543,10 +540,7 @@ class AuthorizeHandlerTest {
                     ArgumentCaptor.forClass(Credential.class);
 
             verify(mockVcGenerator).generate(persistedCredential.capture());
-            verify(mockCredentialService)
-                    .persist(
-                            eq(mockSignedJwt.serialize()),
-                            eq("26c6ad15-a595-4e13-9497-f7c891fabe1d"));
+            verify(mockCredentialService).persist(eq(mockSignedJwt.serialize()), any(String.class));
         }
 
         @Test
@@ -624,10 +618,7 @@ class AuthorizeHandlerTest {
             assertNull(persistedAttributes.get("birthDate"));
             assertEquals("test-value", persistedAttributes.get("test"));
 
-            verify(mockCredentialService)
-                    .persist(
-                            eq(mockSignedJwt.serialize()),
-                            eq("26c6ad15-a595-4e13-9497-f7c891fabe1d"));
+            verify(mockCredentialService).persist(eq(mockSignedJwt.serialize()), any(String.class));
         }
     }
 
@@ -649,8 +640,7 @@ class AuthorizeHandlerTest {
                                     + signedRequestJwt(DefaultClaimSetBuilder().build()).serialize()
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
-                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\""
+                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\""
                                     + "}");
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
@@ -677,7 +667,6 @@ class AuthorizeHandlerTest {
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
                                     + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\","
                                     + "  \"nbf\": 1714577018"
                                     + "}");
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
@@ -708,7 +697,6 @@ class AuthorizeHandlerTest {
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
                                     + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\","
                                     + "  \"f2f\": {"
                                     + "    \"sendVcToQueue\": true,"
                                     + "    \"queueName\": \"stubQueue_F2FQueue_build\""
@@ -740,7 +728,6 @@ class AuthorizeHandlerTest {
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
                                     + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\","
                                     + "  \"f2f\": {"
                                     + "    \"sendErrorToQueue\": true,"
                                     + "    \"queueName\": \"stubQueue_F2FQueue_build\""
@@ -772,8 +759,7 @@ class AuthorizeHandlerTest {
                                     + signedRequestJwt(DefaultClaimSetBuilder().build()).serialize()
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"This is not JSON\","
-                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\""
+                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\""
                                     + "}");
 
             authorizeHandler.apiAuthorize.handle(mockRequest, mockResponse);
@@ -794,8 +780,7 @@ class AuthorizeHandlerTest {
                                     + signedRequestJwt(DefaultClaimSetBuilder().build()).serialize()
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
-                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\""
+                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\""
                                     + "}");
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
@@ -817,7 +802,7 @@ class AuthorizeHandlerTest {
             assertNotNull(persistedEvidence.get("strengthScore"));
             assertNotNull(persistedEvidence.get("validityScore"));
 
-            verify(mockCredentialService).persist(mockSignedJwt.serialize(), "something");
+            verify(mockCredentialService).persist(eq(mockSignedJwt.serialize()), any(String.class));
         }
 
         @Test
@@ -832,7 +817,6 @@ class AuthorizeHandlerTest {
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
                                     + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\","
                                     + "  \"mitigations\": {"
                                     + "    \"mitigatedCi\": [\"XX\"],"
                                     + "    \"cimitStubUrl\": \"https://cimit.stubs.account.gov.uk\","
@@ -865,7 +849,7 @@ class AuthorizeHandlerTest {
                     ArgumentCaptor.forClass(Credential.class);
 
             verify(mockVcGenerator).generate(persistedCredential.capture());
-            verify(mockCredentialService).persist(mockSignedJwt.serialize(), "something");
+            verify(mockCredentialService).persist(eq(mockSignedJwt.serialize()), any(String.class));
         }
 
         @Test
@@ -879,8 +863,7 @@ class AuthorizeHandlerTest {
                                     + signedRequestJwt(DefaultClaimSetBuilder().build()).serialize()
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
-                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\""
+                                    + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\""
                                     + "}");
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
@@ -932,7 +915,6 @@ class AuthorizeHandlerTest {
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
                                     + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\","
                                     + "  \"requestedError\": {"
                                     + "    \"endpoint\": \"token\","
                                     + "    \"error\": \"invalid_request\","
@@ -966,7 +948,6 @@ class AuthorizeHandlerTest {
                                     + "\","
                                     + "  \"credentialSubjectJson\": \"{\\\"passport\\\":[{\\\"expiryDate\\\":\\\"2030-01-01\\\",\\\"icaoIssuerCode\\\":\\\"GBR\\\",\\\"documentNumber\\\":\\\"321654987\\\"}],\\\"name\\\":[{\\\"nameParts\\\":[{\\\"type\\\":\\\"GivenName\\\",\\\"value\\\":\\\"Kenneth\\\"},{\\\"type\\\":\\\"FamilyName\\\",\\\"value\\\":\\\"Decerqueira\\\"}]}],\\\"birthDate\\\":[{\\\"value\\\":\\\"1965-07-08\\\"}]}\","
                                     + "  \"evidenceJson\": \"{\\\"activityHistoryScore\\\":1,\\\"checkDetails\\\":[{\\\"checkMethod\\\":\\\"vri\\\"},{\\\"biometricVerificationProcessLevel\\\":3,\\\"checkMethod\\\":\\\"bvr\\\"}],\\\"validityScore\\\":2,\\\"strengthScore\\\":3,\\\"type\\\":\\\"IdentityCheck\\\"}\","
-                                    + "  \"resourceId\": \"something\","
                                     + "  \"requestedError\": {"
                                     + "    \"userInfoError\": \"404\""
                                     + "  }"
@@ -1105,9 +1086,6 @@ class AuthorizeHandlerTest {
         Map<String, String[]> queryParams = new HashMap<>(validDoAuthorizeQueryParams());
         queryParams.put(
                 RequestParamConstants.JSON_PAYLOAD, new String[] {"{\"test\": \"test-value\"}"});
-        queryParams.put(
-                RequestParamConstants.RESOURCE_ID,
-                new String[] {"26c6ad15-a595-4e13-9497-f7c891fabe1d"});
         queryParams.put(STRENGTH, new String[] {"2"});
         queryParams.put(VALIDITY, new String[] {"3"});
         queryParams.put(VC_NOT_BEFORE_FLAG, new String[] {"on"});


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Refactor cri-stub resource ID

### Why did it change

We assign a random ID to link auth codes, access tokens, and the resource associated with them.

We were setting this as a value in the form on the page and then passing it back in. This meant that we also needed to provide a value in API calls to the CRI stub.

We can simplify all this and just generate a UUID at the point we need it.
