### PR TITLE
OJ-2612: Added evidence to generateClaimSet endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -236,7 +236,7 @@
         "filename": "di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 96
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java": [
@@ -499,5 +499,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-20T09:47:31Z"
+  "generated_at": "2024-06-25T10:06:54Z"
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/EvidenceRequestClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/EvidenceRequestClaims.java
@@ -1,25 +1,42 @@
 package uk.gov.di.ipv.stub.core.config.uatuser;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record EvidenceRequestClaims(
-        @JsonProperty("scoringPolicy") String scoringPolicy,
-        @JsonProperty("strengthScore") int strengthScore,
-        @JsonProperty("verificationScore") int verificationScore) {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EvidenceRequestClaims {
+    @JsonProperty("scoringPolicy")
+    private String scoringPolicy;
 
-    @JsonCreator
-    public EvidenceRequestClaims {}
+    @JsonProperty("strengthScore")
+    private Integer strengthScore;
 
+    @JsonProperty("verificationScore")
+    private Integer verificationScore;
+
+    public EvidenceRequestClaims() {}
+
+    public EvidenceRequestClaims(
+            String scoringPolicy, Integer strengthScore, Integer verificationScore) {
+        this.scoringPolicy = scoringPolicy;
+        this.strengthScore = strengthScore;
+        this.verificationScore = verificationScore;
+    }
+
+    @JsonProperty("scoringPolicy")
     public String getScoringPolicy() {
         return scoringPolicy;
     }
 
-    public int getStrengthScore() {
+    @JsonProperty("strengthScore")
+    public Integer getStrengthScore() {
         return strengthScore;
     }
 
-    public int getVerificationScore() {
+    @JsonProperty("verificationScore")
+    public Integer getVerificationScore() {
         return verificationScore;
     }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -359,6 +359,7 @@ public class CoreStubHandler {
                         Integer.valueOf(Objects.requireNonNull(request.queryParams("rowNumber")));
                 // NINO has been added here temporarily for testing implementation of HMRC KBV CRI
                 var nino = request.queryParams("nino");
+
                 var credentialIssuer = handlerHelper.findCredentialIssuer(credentialIssuerId);
                 var identity = handlerHelper.findIdentityByRowNumber(rowNumber).withNino(nino);
                 var claimIdentity =
@@ -375,8 +376,26 @@ public class CoreStubHandler {
                         state,
                         credentialIssuer,
                         new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID),
-                        claimIdentity);
+                        claimIdentity,
+                        getEvidenceRequestClaims(request));
             };
+
+    private EvidenceRequestClaims getEvidenceRequestClaims(Request request) {
+        String scoringPolicy = request.queryParams("scoringPolicy");
+        String strengthScore = request.queryParams("strengthScore");
+        String verificationScore = request.queryParams("verificationScore");
+
+        if (Objects.nonNull(strengthScore)
+                || Objects.nonNull(scoringPolicy)
+                || Objects.nonNull(verificationScore)) {
+
+            return new EvidenceRequestClaims(
+                    scoringPolicy,
+                    Objects.isNull(strengthScore) ? null : Integer.parseInt(strengthScore),
+                    Objects.isNull(verificationScore) ? null : Integer.parseInt(verificationScore));
+        }
+        return null;
+    }
 
     public Route backendGenerateInitialClaimsSetPostCode =
             (Request request, Response response) -> {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.stub.core.utils;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -102,6 +103,7 @@ public class HandlerHelper {
         this.ecSigningKey = ecSigningKey;
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         this.objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        this.objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
     public AuthorizationResponse getAuthorizationResponse(Request request)


### PR DESCRIPTION
## Proposed changes

Added evidenceRequest processing to the generateClaimSet endpoint when scorePolicy, strengthScore and/or verificationScore is supplied as query string parameters the claimset includes an evidence_request payload need for KBV-CRI

