### PR TITLE
BAU: ignore null keys in JWT

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -334,7 +334,7 @@ public class HandlerHelper {
             claimsSetBuilder.claim(SHARED_CLAIMS, map);
         }
         if (Objects.nonNull(evidenceRequest)) {
-            claimsSetBuilder.claim(EVIDENCE_REQUESTED, evidenceRequest);
+            claimsSetBuilder.claim(EVIDENCE_REQUESTED, convertToMap(evidenceRequest));
         }
         return claimsSetBuilder;
     }


### PR DESCRIPTION
When we were generating the evidence block in JWT, if any of the keys was null, it would show as `null` in the JSON rather than ignoring it. This PR fixes that. 