### PR TITLE
Upgrade devplatform-upload-action to v3.9 with explicit path for SAM

### DIFF
--- a/.github/workflows/cimit-stub.yml
+++ b/.github/workflows/cimit-stub.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - di-ipv-cimit-stub/**
-      - .github/workflows/deploy-cimit-stub.yml
+      - .github/workflows/cimit-stub.yml
 
 jobs:
   buildAndPush:
@@ -53,9 +53,9 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.CIMIT_STUB_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./di-ipv-cimit-stub/deploy
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -116,7 +116,7 @@ jobs:
         run: sam build -t cf-template.yaml
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
             artifact-bucket-name: ${{ secrets.CORE_CRI_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}

--- a/.github/workflows/cri-dcmaw-async-stub.yml
+++ b/.github/workflows/cri-dcmaw-async-stub.yml
@@ -61,9 +61,9 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.DCMAW_ASYNC_STUB_BUILD_S3_BUCKET }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./di-ipv-dcmaw-async-stub/deploy
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml

--- a/.github/workflows/cri-ticf-stub.yml
+++ b/.github/workflows/cri-ticf-stub.yml
@@ -71,10 +71,10 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.TICF_STUB_BUILD_S3_BUCKET }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./di-ipv-ticf-stub/deploy
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml
 

--- a/.github/workflows/deploy-queue-stub-build.yml
+++ b/.github/workflows/deploy-queue-stub-build.yml
@@ -67,10 +67,10 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.QUEUE_STUB_BUILD_S3_BUCKET }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./di-ipv-queue-stub/deploy-build
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml
 

--- a/.github/workflows/deploy-queue-stub-staging.yml
+++ b/.github/workflows/deploy-queue-stub-staging.yml
@@ -67,10 +67,10 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.QUEUE_STUB_STAGING_S3_BUCKET }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./di-ipv-queue-stub/deploy-staging
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml
 

--- a/.github/workflows/deploy-update-ecs-env-vars.yml
+++ b/.github/workflows/deploy-update-ecs-env-vars.yml
@@ -66,10 +66,10 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.UPDATE_ECS_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./update-ecs-env-vars/deploy
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml
 

--- a/.github/workflows/evcs-stub.yml
+++ b/.github/workflows/evcs-stub.yml
@@ -65,9 +65,9 @@ jobs:
         run: sam build
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ secrets.EVCS_STUB_BUILD_S3_BUCKET }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./di-ipv-evcs-stub/deploy
-          template-file: template.yaml
+          template-file: .aws-sam/build/template.yaml


### PR DESCRIPTION
### What changed

- Upgrade devplatform-upload-action to v3.9 with explicit path for SAM
- See guidance at https://govukverify.atlassian.net/wiki/spaces/DID/pages/4260626521/How+a+team+finds+out+what+version+of+Pipelines+and+GitHub+Actions+they+are+on#Which-workflows-are-using-older-versions-of-govuk-one-login-upload-action-versions

### Why did it change

- Upgrade required for DORA metrics

### Issue tracking

- [IPS-831](https://govukverify.atlassian.net/browse/IPS-831)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

## Evidence

Screenshot from [dcmaw-async-stub](https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/dcmaw-async-stub-pipeline-Pipeline-1R865YM3B6XFP/view?region=eu-west-2)

![image](https://github.com/govuk-one-login/ipv-stubs/assets/153090281/52f783d7-e886-4ea1-83fd-59689985758c)
![image](https://github.com/govuk-one-login/ipv-stubs/assets/153090281/efb41286-1ef5-41f1-9c2f-4a1815bb3cdd)
(Rebased and squashed after testing the pipeline so commitsha will no longer link to a commit)

[IPS-831]: https://govukverify.atlassian.net/browse/IPS-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ