### PR TITLE
LS-2207 Get JMX metrics published to Cloudwatch Insights

### DIFF
--- a/di-ipv-orchestrator-stub/.dockerignore
+++ b/di-ipv-orchestrator-stub/.dockerignore
@@ -1,6 +1,5 @@
 Dockerfile*
 .dockerignore
 README.md
-*.sh
 .idea
 .vscode

--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=build \
 
 RUN mkdir -p /opt/jmx_exporter
 COPY ./jmx_prometheus_javaagent-1.0.1.jar /opt/jmx_exporter
-COPY ./build/libs/di-ipv-orchestrator-stub-all.jar /opt/jmx_exporter
+COPY ./build/libs/di-ipv-orchestrator-stub.jar /opt/jmx_exporter
 COPY ./start.sh /opt/jmx_exporter
 COPY ./config.yaml /opt/jmx_exporter
 
@@ -34,9 +34,9 @@ RUN chown -R appuser:appgroup /app/
 USER appuser
 
 
-# Add in dynatrace layer
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+# # Add in dynatrace layer
+# COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
+# ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 EXPOSE $PORT
 EXPOSE 5007

--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -33,10 +33,9 @@ RUN tar -xvf di-ipv-orchestrator-stub.tar \
 RUN chown -R appuser:appgroup /app/
 USER appuser
 
-
-# # Add in dynatrace layer
-# COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
-# ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+# Add in dynatrace layer
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 EXPOSE $PORT
 EXPOSE 5007

--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -34,9 +34,9 @@ RUN chown -R appuser:appgroup /app/
 USER appuser
 
 
-# # Add in dynatrace layer
-# COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
-# ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+# Add in dynatrace layer
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 EXPOSE $PORT
 EXPOSE 5007

--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -15,6 +15,17 @@ COPY --from=build \
     /home/gradle/build/distributions/di-ipv-orchestrator-stub.tar \
     /app/
 
+
+## Add in jmx exporter
+
+RUN mkdir -p /opt/jmx_exporter
+COPY ./jmx_prometheus_javaagent-1.0.1.jar /opt/jmx_exporter
+COPY ./build/libs/di-ipv-orchestrator-stub-all.jar /opt/jmx_exporter
+COPY ./start.sh /opt/jmx_exporter
+COPY ./config.yaml /opt/jmx_exporter
+
+RUN chmod -R o+x /opt/jmx_exporter
+
 WORKDIR /app
 RUN tar -xvf di-ipv-orchestrator-stub.tar \
     && rm di-ipv-orchestrator-stub.tar
@@ -22,12 +33,14 @@ RUN tar -xvf di-ipv-orchestrator-stub.tar \
 RUN chown -R appuser:appgroup /app/
 USER appuser
 
-# Add in dynatrace layer
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+# # Add in dynatrace layer
+# COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:java / /
+# ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 EXPOSE $PORT
 EXPOSE 5007
+EXPOSE 9404
 
-ENTRYPOINT ["./di-ipv-orchestrator-stub/bin/di-ipv-orchestrator-stub"]
+ENTRYPOINT exec /opt/jmx_exporter/start.sh
 LABEL project="di-ipv-orchestrator-stub"

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'com.github.johnrengelman.shadow' version '8.1.1'
 	id 'idea'
 	id 'application'
 	id 'java'

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-	id 'com.github.johnrengelman.shadow' version '8.1.1'
 	id 'idea'
 	id 'application'
 	id 'java'
@@ -37,4 +36,14 @@ run {
 
 application {
 	mainClass = 'uk.gov.di.ipv.stub.orc.App'
+}
+
+jar {
+    manifest {
+		attributes 'Main-Class': application.mainClass
+	}
+	from {
+    	configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -39,11 +39,11 @@ application {
 }
 
 jar {
-    manifest {
+	manifest {
 		attributes 'Main-Class': application.mainClass
 	}
 	from {
-    	configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+		configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+	}
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/di-ipv-orchestrator-stub/config.yaml
+++ b/di-ipv-orchestrator-stub/config.yaml
@@ -1,0 +1,45 @@
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+
+rules:
+- pattern: 'java.lang<type=OperatingSystem><>(FreePhysicalMemorySize|TotalPhysicalMemorySize|FreeSwapSpaceSize|TotalSwapSpaceSize|SystemCpuLoad|ProcessCpuLoad|OpenFileDescriptorCount|AvailableProcessors)'
+  name: java_lang_OperatingSystem_$1
+  type: GAUGE
+
+- pattern: 'java.lang<type=Threading><>(TotalStartedThreadCount|ThreadCount)'
+  name: java_lang_threading_$1
+  type: GAUGE
+
+- pattern: 'Catalina<type=GlobalRequestProcessor, name=\"(\w+-\w+)-(\d+)\"><>(\w+)'
+  name: catalina_globalrequestprocessor_$3_total
+  labels:
+    port: "$2"
+    protocol: "$1"
+  help: Catalina global $3
+  type: COUNTER
+
+- pattern: 'Catalina<j2eeType=Servlet, WebModule=//([-a-zA-Z0-9+&@#/%?=~_|!:.,;]*[-a-zA-Z0-9+&@#/%=~_|]), name=([-a-zA-Z0-9+/$%~_-|!.]*), J2EEApplication=none, J2EEServer=none><>(requestCount|maxTime|processingTime|errorCount)'
+  name: catalina_servlet_$3_total
+  labels:
+    module: "$1"
+    servlet: "$2"
+  help: Catalina servlet $3 total
+  type: COUNTER
+
+- pattern: 'Catalina<type=ThreadPool, name="(\w+-\w+)-(\d+)"><>(currentThreadCount|currentThreadsBusy|keepAliveCount|pollerThreadCount|connectionCount)'
+  name: catalina_threadpool_$3
+  labels:
+    port: "$2"
+    protocol: "$1"
+  help: Catalina threadpool $3
+  type: GAUGE
+
+- pattern: 'Catalina<type=Manager, host=([-a-zA-Z0-9+&@#/%?=~_|!:.,;]*[-a-zA-Z0-9+&@#/%=~_|]), context=([-a-zA-Z0-9+/$%~_-|!.]*)><>(processingTime|sessionCounter|rejectedSessions|expiredSessions)'
+  name: catalina_session_$3_total
+  labels:
+    context: "$2"
+    host: "$1"
+  help: Catalina session $3 total
+  type: COUNTER
+
+- pattern: ".*"

--- a/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
@@ -610,12 +610,17 @@ Resources:
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp
+            - ContainerPort: 9404
+              Protocol: tcp
           LogConfiguration:
             LogDriver: awslogs
             Options:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub orch-stub-${Environment}
+          DockerLabels:
+            ECS_PROMETHEUS_EXPORTER_PORT: 9404
+            Java_EMF_Metrics: true
       Cpu: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, fargateCPUsize ]
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       Memory: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, fargateRAMsize ]

--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -675,12 +675,17 @@ Resources:
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp
+            - ContainerPort: 9404
+              Protocol: tcp
           LogConfiguration:
             LogDriver: awslogs
             Options:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub orch-stub-${Environment}
+          DockerLabels:
+            ECS_PROMETHEUS_EXPORTER_PORT: 9404
+            Java_EMF_Metrics: true
       Cpu:
         !FindInMap [
           EnvironmentConfiguration,

--- a/di-ipv-orchestrator-stub/start.sh
+++ b/di-ipv-orchestrator-stub/start.sh
@@ -1,0 +1,1 @@
+java -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-1.0.1.jar=9404:/opt/jmx_exporter/config.yaml -jar /opt/jmx_exporter/di-ipv-orchestrator-stub-all.jar

--- a/di-ipv-orchestrator-stub/start.sh
+++ b/di-ipv-orchestrator-stub/start.sh
@@ -1,1 +1,1 @@
-java -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-1.0.1.jar=9404:/opt/jmx_exporter/config.yaml -jar /opt/jmx_exporter/di-ipv-orchestrator-stub-all.jar
+java -javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-1.0.1.jar=9404:/opt/jmx_exporter/config.yaml -jar /opt/jmx_exporter/di-ipv-orchestrator-stub.jar


### PR DESCRIPTION

## Proposed changes

### What changed

Wraps the mocks in a jmx_exporter class to show metrics on port 9404.  CloudWatch + containerinsights will then ingest those metrics.

### Why did it change

To better understand mock behaviour under load.
