### PR TITLE
PYIC-6939: Non-evidence CRIs return other credential types

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/config/CriType.java
@@ -1,20 +1,27 @@
 package uk.gov.di.ipv.stub.cred.config;
 
 public enum CriType {
-    EVIDENCE_CRI_TYPE("EVIDENCE"),
-    EVIDENCE_DRIVING_LICENCE_CRI_TYPE("EVIDENCE_DRIVING_LICENCE"),
-    ACTIVITY_CRI_TYPE("ACTIVITY"),
-    FRAUD_CRI_TYPE("FRAUD"),
-    VERIFICATION_CRI_TYPE("VERIFICATION"),
-    USER_ASSERTED_CRI_TYPE("USER_ASSERTED"),
-    DOC_CHECK_APP_CRI_TYPE("DOC_CHECK_APP"),
-    F2F_CRI_TYPE("F2F"),
-    NINO_CRI_TYPE("NINO");
+    ADDRESS_CRI_TYPE("ADDRESS", false),
+    EVIDENCE_CRI_TYPE("EVIDENCE", true),
+    EVIDENCE_DRIVING_LICENCE_CRI_TYPE("EVIDENCE_DRIVING_LICENCE", true),
+    ACTIVITY_CRI_TYPE("ACTIVITY", true),
+    FRAUD_CRI_TYPE("FRAUD", true),
+    VERIFICATION_CRI_TYPE("VERIFICATION", true),
+    USER_ASSERTED_CRI_TYPE("USER_ASSERTED", false),
+    DOC_CHECK_APP_CRI_TYPE("DOC_CHECK_APP", true),
+    F2F_CRI_TYPE("F2F", true),
+    NINO_CRI_TYPE("NINO", true);
 
     public final String value;
+    private final boolean isIdentityCheck;
 
-    private CriType(String value) {
+    private CriType(String value, boolean isIdentityCheck) {
         this.value = value;
+        this.isIdentityCheck = isIdentityCheck;
+    }
+
+    public boolean isIdentityCheck() {
+        return isIdentityCheck;
     }
 
     public static CriType fromValue(String value) {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -72,6 +72,7 @@ import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.EVIDENCE_TXN
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.F2F_STUB_QUEUE_NAME_DEFAULT;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getConfigValue;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getCriType;
+import static uk.gov.di.ipv.stub.cred.config.CriType.ADDRESS_CRI_TYPE;
 import static uk.gov.di.ipv.stub.cred.config.CriType.DOC_CHECK_APP_CRI_TYPE;
 import static uk.gov.di.ipv.stub.cred.config.CriType.USER_ASSERTED_CRI_TYPE;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.ACTIVITY_HISTORY;
@@ -116,7 +117,7 @@ public class AuthorizeHandler {
     private static final String F2F_STUB_QUEUE_URL = "F2F_STUB_QUEUE_URL";
 
     private static final List<CriType> NO_SHARED_ATTRIBUTES_CRI_TYPES =
-            List.of(USER_ASSERTED_CRI_TYPE, DOC_CHECK_APP_CRI_TYPE);
+            List.of(ADDRESS_CRI_TYPE, USER_ASSERTED_CRI_TYPE, DOC_CHECK_APP_CRI_TYPE);
 
     private final AuthCodeService authCodeService;
     private final CredentialService credentialService;
@@ -242,7 +243,7 @@ public class AuthorizeHandler {
                         CRI_MITIGATION_ENABLED_PARAM,
                         CredentialIssuerConfig.isEnabled(
                                 CredentialIssuerConfig.CRI_MITIGATION_ENABLED, "false"));
-                frontendParams.put(IS_USER_ASSERTED_TYPE, criType.equals(USER_ASSERTED_CRI_TYPE));
+                frontendParams.put(IS_USER_ASSERTED_TYPE, !criType.isIdentityCheck());
                 frontendParams.put(REQUEST_SCOPE, requestScope);
                 frontendParams.put(REQUEST_CONTEXT, requestContext);
                 if (!criType.equals(DOC_CHECK_APP_CRI_TYPE)) {
@@ -486,7 +487,7 @@ public class AuthorizeHandler {
     private Map<String, Object> generateGpg45Score(CriType criType, Gpg45Scores gpg45Scores)
             throws CriStubException {
 
-        if (criType.equals(USER_ASSERTED_CRI_TYPE)) {
+        if (!criType.isIdentityCheck()) {
             // VCs from user asserted CRIs, like address, do not have GPG45 scores
             return Map.of();
         }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialConstants.java
@@ -4,6 +4,8 @@ public interface VerifiableCredentialConstants {
     String VC_TYPE = "type";
     String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
     String IDENTITY_CHECK_CREDENTIAL_TYPE = "IdentityCheckCredential";
+    String IDENTITY_ASSERTION_CREDENTIAL_TYPE = "IdentityAssertionCredential";
+    String ADDRESS_CREDENTIAL_TYPE = "AddressCredential";
     String CREDENTIAL_SUBJECT_NAME = "name";
     String CREDENTIAL_SUBJECT_BIRTH_DATE = "birthDate";
     String CREDENTIAL_SUBJECT_ADDRESS = "address";

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGeneratorTest.java
@@ -38,9 +38,11 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.stub.cred.config.CriType.ADDRESS_CRI_TYPE;
 import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.CLIENT_CONFIG;
 import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
 import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.EC_PUBLIC_KEY_1;
+import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.ADDRESS_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_ADDRESS;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_BIRTH_DATE;
 import static uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialConstants.CREDENTIAL_SUBJECT_NAME;
@@ -278,5 +280,24 @@ public class VerifiableCredentialGeneratorTest {
                 objectMapper.valueToTree(verifiableCredential.getJWTClaimsSet()).path("claims");
 
         assertInstanceOf(NullNode.class, claimsSetTree.get(NOT_BEFORE));
+    }
+
+    @Test
+    void shouldGenerateAnAddressCredentialForTheAddressCri() throws Exception {
+        var userId = "user-id";
+        var credential = new Credential(Map.of(), Map.of(), userId, "clientIdValid", null);
+        environmentVariables.set("CREDENTIAL_ISSUER_TYPE", ADDRESS_CRI_TYPE.value);
+
+        var verifiableCredential = vcGenerator.generate(credential);
+
+        var claimsSetTree =
+                objectMapper.valueToTree(verifiableCredential.getJWTClaimsSet()).path("claims");
+
+        assertEquals(
+                VERIFIABLE_CREDENTIAL_TYPE,
+                claimsSetTree.get(VC_CLAIM).path(VC_TYPE).path(0).asText());
+        assertEquals(
+                ADDRESS_CREDENTIAL_TYPE,
+                claimsSetTree.get(VC_CLAIM).path(VC_TYPE).path(1).asText());
     }
 }


### PR DESCRIPTION
Address and CIC credentials should not be `IdentityCheckCredential`s, they should use the appropriate type