### PR TITLE
PYIC-6946: Remove expiry form inputs from CRI stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -520,54 +520,6 @@
                                 </fieldset>
                             </td>
                         </tr>
-
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">
-                                <fieldset class="govuk-fieldset">
-                                    <div class="govuk-date-input" id="vcJwtExpiry">
-                                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                                            <h1 class="govuk-fieldset__heading">
-                                                VC Jwt Expiry
-                                            </h1>
-                                        </legend>
-                                        <div class="govuk-form-group">
-                                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                                <div class="govuk-checkboxes__item">
-                                                    <input class="govuk-checkboxes__input" type="checkbox" name="vcExpiryFlg" id="vcExpiryFlg">
-                                                    <label class="govuk-label govuk-checkboxes__label" for="vc_expiry">Include VC expiry</label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="govuk-form-group" id="additionalInputs" style="display: none;">
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <label class="govuk-label" for="strength">
-                                                        Hours
-                                                    </label>
-                                                    <input class="govuk-input govuk-input--width-2" id="expHours" name="expHours" type="number" min="0" step="1" value="0">
-                                                </div>
-                                            </div>
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <label class="govuk-label" for="validity">
-                                                        Minutes
-                                                    </label>
-                                                    <input class="govuk-input govuk-input--width-2" id="expMins" name="expMinutes" type="number" min="0" step="1" value="0">
-                                                </div>
-                                            </div>
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <label class="govuk-label" for="activityHistory">
-                                                        Seconds
-                                                    </label>
-                                                    <input class="govuk-input govuk-input--width-2" id="expSeconds" name="expSeconds" type="number" min="0" step="1" value="0">
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </fieldset>
-                            </td>
-                        </tr>
                         </tbody>
                     </table>
                 </div>
@@ -711,17 +663,6 @@
             var {payload} = evidenceBlocksFiltered.find(x => x.label === val)
             $("#evidenceJsonPayload").val(JSON.stringify(payload, undefined, 4))
         });
-    });
-
-    const checkbox = document.getElementById('vcExpiryFlg');
-    const additionalInputs = document.getElementById('additionalInputs');
-
-    checkbox.addEventListener('change', function() {
-      if(this.checked) {
-        additionalInputs.style.display = 'block';
-      } else {
-        additionalInputs.style.display = 'none';
-      }
     });
 
     const expandCheckbox = document.getElementById("expand_evidence");


### PR DESCRIPTION
**Not to be merged before https://github.com/govuk-one-login/ipv-core-tests/pull/638**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Remove expiry form inputs from CRI stub

### Why did it change

VCs do not use the `exp` property, which these inputs are designed to control. There functionality has actually already been removed in a previous piece of work.

This should only get merged once we're happy the acceptance tests are no longer using any of these inputs.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-6946](https://govukverify.atlassian.net/browse/PYI-6946)
