### PR TITLE
IPS-608: Remove rusty-actions

### DIFF
--- a/.github/workflows/cimit-stub.yml
+++ b/.github/workflows/cimit-stub.yml
@@ -41,13 +41,6 @@ jobs:
         working-directory: ./di-ipv-cimit-stub/deploy
         run: sam validate --region ${{ env.AWS_REGION }}
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-cimit-stub/deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM build and test
         working-directory: ./di-ipv-cimit-stub/deploy
         run: sam build

--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -104,13 +104,6 @@ jobs:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-core-stub/deploy/cri-3rdparty/cf-template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM build and test
         working-directory: ./di-ipv-core-stub/deploy/cri-3rdparty
         run: sam build -t cf-template.yaml

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -104,13 +104,6 @@ jobs:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-core-stub/deploy/cri-preprod/cf-template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM build and test
         working-directory: ./di-ipv-core-stub/deploy/cri-preprod
         run: sam build -t cf-template.yaml

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -104,13 +104,6 @@ jobs:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-core-stub/deploy/cri/cf-template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM build and test
         working-directory: ./di-ipv-core-stub/deploy/cri
         run: sam build -t cf-template.yaml

--- a/.github/workflows/cri-dcmaw-async-stub.yml
+++ b/.github/workflows/cri-dcmaw-async-stub.yml
@@ -45,13 +45,6 @@ jobs:
         working-directory: ./di-ipv-dcmaw-async-stub/deploy
         run: sam validate --region ${{ env.AWS_REGION }}
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-dcmaw-async-stub/deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: npm install
         working-directory: ./di-ipv-dcmaw-async-stub/lambdas
         run: npm ci

--- a/.github/workflows/cri-ticf-stub.yml
+++ b/.github/workflows/cri-ticf-stub.yml
@@ -51,13 +51,6 @@ jobs:
       #    ARTIFACT_BUCKET: ${{ secrets.UPDATE_ECS_ARTIFACT_BUCKET_NAME }}
       #  run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-ticf-stub/deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: npm install
         working-directory: ./di-ipv-ticf-stub/lambdas
         run: npm ci

--- a/.github/workflows/deploy-orch-stub.yml
+++ b/.github/workflows/deploy-orch-stub.yml
@@ -87,13 +87,6 @@ jobs:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-orchestrator-stub/deploy/cf-template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM build and test
         working-directory: ./di-ipv-orchestrator-stub/deploy
         run: sam build -t cf-template.yaml

--- a/.github/workflows/deploy-queue-stub-build.yml
+++ b/.github/workflows/deploy-queue-stub-build.yml
@@ -51,13 +51,6 @@ jobs:
       #    ARTIFACT_BUCKET: ${{ secrets.UPDATE_ECS_ARTIFACT_BUCKET_NAME }}
       #  run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-queue-stub/deploy-build/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: npm install
         working-directory: ./di-ipv-queue-stub/enqueue-event
         run: npm ci

--- a/.github/workflows/deploy-queue-stub-staging.yml
+++ b/.github/workflows/deploy-queue-stub-staging.yml
@@ -51,13 +51,6 @@ jobs:
       #    ARTIFACT_BUCKET: ${{ secrets.UPDATE_ECS_ARTIFACT_BUCKET_NAME }}
       #  run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-queue-stub/deploy-staging/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: npm install
         working-directory: ./di-ipv-queue-stub/enqueue-event
         run: npm ci

--- a/.github/workflows/deploy-update-ecs-env-vars.yml
+++ b/.github/workflows/deploy-update-ecs-env-vars.yml
@@ -54,13 +54,6 @@ jobs:
       #    ARTIFACT_BUCKET: ${{ secrets.UPDATE_ECS_ARTIFACT_BUCKET_NAME }}
       #  run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./update-ecs-env-vars/deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM build and test
         working-directory: ./update-ecs-env-vars/deploy
         run: sam build

--- a/.github/workflows/evcs-stub.yml
+++ b/.github/workflows/evcs-stub.yml
@@ -45,13 +45,6 @@ jobs:
         working-directory: ./di-ipv-evcs-stub/deploy
         run: sam validate --region ${{ env.AWS_REGION }}
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./di-ipv-evcs-stub/deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: npm install
         working-directory: ./di-ipv-evcs-stub/lambdas
         run: npm ci


### PR DESCRIPTION
### What changed

- Removed obsolete and redundant rusty-actions workflow step
 
### Why did it change

- This is obsolete and now handled by the dev-platform upload action

### Issue tracking

- [IPS-608](https://govukverify.atlassian.net/browse/IPS-608)
- These changes have been made in Lime already, e.g. https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/132/files

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

![image](https://github.com/govuk-one-login/ipv-stubs/assets/153090281/d93b7e0e-b43a-417e-82cd-d2227cd5c01d)

[IPS-608]: https://govukverify.atlassian.net/browse/IPS-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ