### PR TITLE
IPS-645: Upgrade orch-stub image

### DIFF
--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -1,16 +1,17 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:17-alpine3.17-jdk AS build
 COPY . /home/gradle
 WORKDIR /home/gradle
 RUN ./gradlew build --no-daemon --stacktrace
 
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:17-alpine3.17-jdk
 
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN addgroup --system -g 1001 appgroup
+RUN adduser --system -u 1001 appuser -G appgroup
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
+RUN apk update && apk --no-cache add curl
 COPY --from=build \
     /home/gradle/build/distributions/di-ipv-orchestrator-stub.tar \
     /app/

--- a/di-ipv-orchestrator-stub/core-dev-deploy/Dockerfile
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/Dockerfile
@@ -1,16 +1,17 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:17-alpine3.17-jdk AS build
 COPY . /home/gradle
 WORKDIR /home/gradle
 RUN ./gradlew build --no-daemon --stacktrace
 
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:17-alpine3.17-jdk
 
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN addgroup --system -g 1001 appgroup
+RUN adduser --system -u 1001 appuser -G appgroup
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
+RUN apk update && apk --no-cache add curl
 COPY --from=build \
     /home/gradle/build/distributions/di-ipv-orchestrator-stub.tar \
     /app/


### PR DESCRIPTION
### What changed

- Updated Docker image
- Updated commands to alpine (apk)

### Why did it change

- openjdk image had been deprecated and had >20 critical vulns
- See https://hub.docker.com/_/openjdk

### Issue tracking

- [IPS-645](https://govukverify.atlassian.net/browse/IPS-645)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

## Evidence

- Deployed with dev-deploy to orch-stub-sre stack

### Before (openjdk):

<img width="355" alt="docker orch-stub (openjdk)" src="https://github.com/govuk-one-login/ipv-stubs/assets/153090281/fefb3b85-b4bf-4a48-a08e-f8822fec8ee6">

![ECR orch-stub (openjdk)](https://github.com/govuk-one-login/ipv-stubs/assets/153090281/23ec6a8d-fec5-4bd6-bbf3-c89e66a745aa)

### After (corretto):

<img width="1134" alt="docker orch-stub (corretto)" src="https://github.com/govuk-one-login/ipv-stubs/assets/153090281/69068a28-f2f0-49f0-880e-1498b1027094">

![ECR orch-stub (corretto)](https://github.com/govuk-one-login/ipv-stubs/assets/153090281/71d4ed70-1a3e-4754-9e51-b55faf2ec640)



[IPS-645]: https://govukverify.atlassian.net/browse/IPS-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ