### PR TITLE
PYIC-7081: Remove powertools from cimit stub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [PYI-XXXX](https://govukverify.atlassian.net/browse/PYI-XXXX)
+- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)
 
 ## Checklists
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,7 @@ spotless {
 		endWithNewline()
 	}
 }
+
+subprojects {
+	task allDeps(type: DependencyReportTask) {}
+}

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id "java"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
 }
 
 group "uk.gov.di.ipv"
@@ -16,6 +15,7 @@ java {
 
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
+			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"com.nimbusds:oauth2-oidc-sdk:9.27",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
@@ -23,14 +23,6 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:1.18.32"
 	annotationProcessor "org.projectlombok:lombok:1.18.32"
-
-	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.16.1"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3",
 			"org.mockito:mockito-junit-jupiter:5.12.0",

--- a/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id "java"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
 }
 
 group "uk.gov.di.ipv"
@@ -16,7 +15,7 @@ java {
 
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
-			"com.fasterxml.jackson.core:jackson-annotations:2.15.3",
+			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"com.nimbusds:oauth2-oidc-sdk:9.27",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
@@ -24,14 +23,6 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:1.18.32"
 	annotationProcessor "org.projectlombok:lombok:1.18.32"
-
-	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.18.0"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3",
 			"org.mockito:mockito-junit-jupiter:5.12.0"

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id "java"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
 }
 
 group "uk.gov.di.ipv"
@@ -27,14 +26,6 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:1.18.32"
 	annotationProcessor "org.projectlombok:lombok:1.18.32"
-
-	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.18.0"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3",
 			"org.mockito:mockito-junit-jupiter:5.12.0"

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id "java"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
 }
 
 group "uk.gov.di.ipv"
@@ -26,14 +25,6 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:1.18.32"
 	annotationProcessor "org.projectlombok:lombok:1.18.32"
-
-	aspect "software.amazon.lambda:powertools-logging:1.18.0",
-			"software.amazon.lambda:powertools-tracing:1.18.0"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3",
 			"org.mockito:mockito-junit-jupiter:5.12.0"


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove powertools from cimit stub

### Why did it change

The powertools-tracing lib had a dependency on an old version of ion-java which had a vulnerability (see link below). To make things more complicated AWS have changed the package name, so forcing a newer version that's patched (which does exist), is not possible.

Turns out we're not actually using either powertools tracing or logging in the stub, so the easiest thing is to just remove the offending dependencies.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/33


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7081](https://govukverify.atlassian.net/browse/PYIC-7081)


[PYIC-7081]: https://govukverify.atlassian.net/browse/PYIC-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ