### PR TITLE
PYIC-7083: Bump Spark to 2.9.4

### DIFF
--- a/di-ipv-core-stub/build.gradle
+++ b/di-ipv-core-stub/build.gradle
@@ -15,7 +15,7 @@ java {
 }
 
 dependencies {
-	implementation "com.sparkjava:spark-core:2.9.3",
+	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
 			"com.nimbusds:oauth2-oidc-sdk:9.22.1",
 			"com.google.code.gson:gson:2.10.1",

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -15,7 +15,7 @@ java {
 }
 
 dependencies {
-	implementation "com.sparkjava:spark-core:2.9.3",
+	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
 			"com.nimbusds:oauth2-oidc-sdk:9.20",
 			"com.fasterxml.jackson.core:jackson-core:2.16.1",

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -15,7 +15,7 @@ java {
 }
 
 dependencies {
-	implementation "com.sparkjava:spark-core:2.9.3",
+	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
 			"com.nimbusds:oauth2-oidc-sdk:9.20",
 			"com.google.code.gson:gson:2.10.1",

--- a/experian-fraud-stub/build.gradle
+++ b/experian-fraud-stub/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-	implementation "com.sparkjava:spark-core:2.9.3"
+	implementation "com.sparkjava:spark-core:2.9.4"
 	implementation 'org.javassist:javassist:3.30.2-GA'
 	implementation 'org.slf4j:slf4j-simple:2.0.13'
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'

--- a/public-jwk-creator/build.gradle
+++ b/public-jwk-creator/build.gradle
@@ -14,7 +14,7 @@ repositories {
 sourceCompatibility = 17
 
 dependencies {
-	implementation  'com.sparkjava:spark-core:2.9.3',
+	implementation  'com.sparkjava:spark-core:2.9.4',
 			'com.sparkjava:spark-template-mustache:2.7.1',
 			'com.nimbusds:nimbus-jose-jwt:9.21',
 			'org.slf4j:slf4j-simple:1.7.36'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bump Spark to 2.9.4

### Why did it change

2.9.3 was pulling in version 9.4.31 of jetty-webapp which has been flagged by dependabot has having a high vulnerability (see link). 2.9.4 uses 9.4.48 which is not affected.

It was also pulling in 9.4.31 of jetty-server which had a high vulnerability. 2.9.4 bumps jetty-server to 9.4.48 which is patched.

Interestingly, this is the last version of spark and was released in
2022. It's a largely abandoned project. We should probably move to something else.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/29
https://github.com/govuk-one-login/ipv-stubs/security/dependabot/28


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-7083](https://govukverify.atlassian.net/browse/PYI-7083)
