### PR TITLE
PYIC-7084: Bump oauth2-oidc-sdk to 11.13

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
@@ -16,7 +16,7 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
-			"com.nimbusds:oauth2-oidc-sdk:9.27",
+			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
 			project(":di-ipv-cimit-stub:lib")

--- a/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
@@ -16,7 +16,7 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
-			"com.nimbusds:oauth2-oidc-sdk:9.27",
+			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
 			project(":di-ipv-cimit-stub:lib")

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-annotations:2.17.2",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
-			"com.nimbusds:oauth2-oidc-sdk:9.27",
+			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			project(":di-ipv-cimit-stub:lib")
 
 	compileOnly "org.projectlombok:lombok:1.18.32"

--- a/di-ipv-core-stub/build.gradle
+++ b/di-ipv-core-stub/build.gradle
@@ -17,7 +17,7 @@ java {
 dependencies {
 	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
-			"com.nimbusds:oauth2-oidc-sdk:9.22.1",
+			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"com.google.code.gson:gson:2.11.0",
 			"org.slf4j:slf4j-simple:2.0.13",
 			"org.yaml:snakeyaml:2.2",

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -17,7 +17,7 @@ java {
 dependencies {
 	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
-			"com.nimbusds:oauth2-oidc-sdk:9.20",
+			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"com.fasterxml.jackson.core:jackson-core:2.16.1",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"com.fasterxml.jackson.core:jackson-annotations:2.17.2",

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.crypto.RSADecrypter;
-import com.nimbusds.jose.shaded.json.JSONObject;
-import com.nimbusds.jose.shaded.json.parser.JSONParser;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -44,7 +42,6 @@ import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -65,7 +62,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
-import static com.nimbusds.jose.shaded.json.parser.JSONParser.MODE_JSON_SIMPLE;
 import static com.nimbusds.oauth2.sdk.util.CollectionUtils.isEmpty;
 import static com.nimbusds.oauth2.sdk.util.StringUtils.isBlank;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.EVIDENCE_TXN_PARAM;
@@ -193,8 +189,8 @@ public class AuthorizeHandler {
                     return null;
                 }
 
-                Object criStubData = getCriStubData();
-                Object criStubEvidencePayloads = getCriStubEvidencePayloads();
+                var criStubData = getCriStubData();
+                var criStubEvidencePayloads = getCriStubEvidencePayloads();
 
                 String sharedAttributesJson;
                 String evidenceRequestedJson;
@@ -739,30 +735,20 @@ public class AuthorizeHandler {
         }
     }
 
-    private Object getCriStubData()
-            throws UnsupportedEncodingException,
-                    com.nimbusds.jose.shaded.json.parser.ParseException {
-        JSONObject js =
-                (JSONObject)
-                        new JSONParser(MODE_JSON_SIMPLE)
-                                .parse(
-                                        AuthorizeHandler.class.getResourceAsStream(
-                                                "/data/criStubData.json"));
-
-        return js.get("data");
+    private String getCriStubData() throws IOException {
+        return OBJECT_MAPPER
+                .readTree(AuthorizeHandler.class.getResourceAsStream("/data/criStubData.json"))
+                .get("data")
+                .toString();
     }
 
-    private Object getCriStubEvidencePayloads()
-            throws UnsupportedEncodingException,
-                    com.nimbusds.jose.shaded.json.parser.ParseException {
-        JSONObject js =
-                (JSONObject)
-                        new JSONParser(MODE_JSON_SIMPLE)
-                                .parse(
-                                        AuthorizeHandler.class.getResourceAsStream(
-                                                "/data/criStubEvidencePayloads.json"));
-
-        return js.get("data");
+    private String getCriStubEvidencePayloads() throws IOException {
+        return OBJECT_MAPPER
+                .readTree(
+                        AuthorizeHandler.class.getResourceAsStream(
+                                "/data/criStubEvidencePayloads.json"))
+                .get("data")
+                .toString();
     }
 
     private JWTClaimsSet getJwtClaimsSet(QueryParamsMap queryParamsMap) throws Exception {

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifierTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifierTest.java
@@ -147,7 +147,7 @@ public class ClientJwtVerifierTest {
                 exception
                         .getMessage()
                         .contains(
-                                "Issuer and subject in client JWT assertion must designate the same client identifier"));
+                                "Bad / expired JWT claims: Issuer and subject JWT claims don't match"));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class ClientJwtVerifierTest {
                 exception
                         .getMessage()
                         .contains(
-                                "Invalid JWT audience claim, expected [https://test-server.example.com/token]"));
+                                "Bad / expired JWT claims: JWT audience rejected: [NOT_THE_AUDIENCE_YOU_ARE_LOOKING_FOR]"));
     }
 
     @Test

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -308,7 +308,7 @@ public class TokenHandlerTest {
                 (String) tokenHandler.issueAccessToken.handle(mockRequest, mockResponse);
 
         assertEquals(
-                "{\"error_description\":\"an error description\",\"error\":\"access_denied\"}",
+                "{\"error\":\"access_denied\",\"error_description\":\"an error description\"}",
                 errorResponse);
         verify(mockResponse).status(HTTPResponse.SC_BAD_REQUEST);
     }

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -17,7 +17,7 @@ java {
 dependencies {
 	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
-			"com.nimbusds:oauth2-oidc-sdk:9.20",
+			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"com.google.code.gson:gson:2.11.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"org.slf4j:slf4j-simple:2.0.13"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bump oauth2-oidc-sdk to 11.13

### Why did it change

The old version of the oauth-oidc-sdk we were using was pulling in a vulnerable version of json-smart - see link.

This bumps it to the latest and greatest which doesn't suffer.

This also fixes a medium criticalitly DoS vulnerability

Had to make a few changes to the CRI stub, as the JSON parser that came with the lib is no longer present, so using Jackson instead.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/23
https://github.com/govuk-one-login/ipv-stubs/security/dependabot/30


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7084](https://govukverify.atlassian.net/browse/PYIC-7084)


[PYIC-7084]: https://govukverify.atlassian.net/browse/PYIC-7084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ