### PR TITLE
PYIC-7093: Bump awssdk ssm to 2.26.21

### DIFF
--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-annotations:2.17.2",
 			"com.google.code.gson:gson:2.11.0",
 			"org.slf4j:slf4j-simple:2.0.13",
-			"software.amazon.awssdk:ssm:2.25.11"
+			"software.amazon.awssdk:ssm:2.26.21"
 
 	compileOnly 'org.projectlombok:lombok:1.18.32'
 	annotationProcessor 'org.projectlombok:lombok:1.18.32'


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bump awssdk ssm to 2.26.21

### Why did it change

The previous version was pulling in an old version of netty-codec-http that suffered from a moderate security vulnerability. The latest version uses a patched version.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/32

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7093](https://govukverify.atlassian.net/browse/PYIC-7093)


[PYIC-7093]: https://govukverify.atlassian.net/browse/PYIC-7093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ