### PR TITLE
PYIC-7094: Bump jetty-server to fix vulnerabilities

### DIFF
--- a/di-ipv-core-stub/build.gradle
+++ b/di-ipv-core-stub/build.gradle
@@ -22,7 +22,8 @@ dependencies {
 			"org.slf4j:slf4j-simple:2.0.13",
 			"org.yaml:snakeyaml:2.2",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2"
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2",
+			"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 			"com.google.code.gson:gson:2.11.0",
 			"org.slf4j:slf4j-simple:2.0.13",
 			"software.amazon.awssdk:ssm:2.26.21"
+	"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
 
 	compileOnly 'org.projectlombok:lombok:1.18.32'
 	annotationProcessor 'org.projectlombok:lombok:1.18.32'

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -20,7 +20,8 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:9.20",
 			"com.google.code.gson:gson:2.11.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
-			"org.slf4j:slf4j-simple:2.0.13"
+			"org.slf4j:slf4j-simple:2.0.13",
+			"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }

--- a/experian-fraud-stub/build.gradle
+++ b/experian-fraud-stub/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
 	implementation 'org.apache.commons:commons-lang3:3.15.0'
+	implementation 'org.eclipse.jetty:jetty-server:9.4.55.v20240627' // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }

--- a/experian-kbv-stub/build.gradle
+++ b/experian-kbv-stub/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation 'org.javassist:javassist:3.30.2-GA'
 	implementation 'org.slf4j:slf4j-simple:2.0.13'
 	implementation group: 'com.sun.xml.messaging.saaj', name: 'saaj-impl', version: '1.5.0'
+	implementation 'org.eclipse.jetty:jetty-server:9.4.55.v20240627' // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bump jetty-server to fix vulnerabilities

### Why did it change

The version of jetty being used by Spark was vulnerable to a couple of issues.

Spark, which pulls in jetty, is now longer supported, so we're going to have to patch future vulnerabilities this way. We should move off jetty asap.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24 
https://github.com/govuk-one-login/ipv-stubs/security/dependabot/27

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7094](https://govukverify.atlassian.net/browse/PYIC-7094)


[PYIC-7094]: https://govukverify.atlassian.net/browse/PYIC-7094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ