### PR TITLE
PYIC-7097: Upgrade awssdk and stub-oauth-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ hs_err_pid*
 *.iml
 .DS_Store
 build
+
+node_modules

--- a/di-ipv-core-stub/deploy/cri-http-api-basic-auth/package-lock.json
+++ b/di-ipv-core-stub/deploy/cri-http-api-basic-auth/package-lock.json
@@ -5,981 +5,655 @@
   "packages": {
     "": {
       "dependencies": {
-        "@aws-sdk/client-ssm": "^3.357.0"
+        "@aws-sdk/client-ssm": "^3.616.0"
       }
-    },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
-      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.357.0.tgz",
-      "integrity": "sha512-xvyrztXKVGnBaBNEu6ONH+v78HNJ4kHVUUcMe8d57pHaathRirgQjPjPZ5QyjD2HasvS5mkBo6fmbsmsqUs9jg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.616.0.tgz",
+      "integrity": "sha512-8M4DcUxi9zD1bK8kvs8wfqAgWx2Qx0bpLHhC/DkFrHZ28tqP9TeoDgjAmSFLAVGxJf6VVvr1mHXIy+4LVdl5SQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.357.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.357.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/client-sts": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.357.0.tgz",
-      "integrity": "sha512-iNH3rTSq6J7RnYYaGEScLorAIib62lTHpOtgMxS0e82845xgmIcgwSP2c3zK6Spc8zSm2K+0YEb6lLSad7EXMA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.357.0.tgz",
-      "integrity": "sha512-ZQYAOksTYeVVToP8SKP/HqcchgNZ1t+fpMCCp6nN2/QUnCgy+qJe6KZO+2Bv/oPufs8MFBWSirifjiYL1UNE7A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.616.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.357.0.tgz",
-      "integrity": "sha512-snQ1+gwa1sAZThAl5gz4dg33qMZ8QEYXK9wm/aFaCRsdM3e+4bZsI1VllaKZ+Vq8wTdLsJf1CCL4s8aIP49RBg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-sdk-sts": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
-      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/core": "^2.2.7",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
-      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
-      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.357.0.tgz",
-      "integrity": "sha512-o2RSGTwptHi8KJGVsEDGxtAhcHBXJGHBL8C1vDZZl0RMmSA5OpIFXH+ovTWJiwDF1NDnhsGquvp/7VePoVMaJA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.616.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.357.0.tgz",
-      "integrity": "sha512-YnVASpGyV5WFSzyPO9Kf093brddt+2l9EpRyhWYZVUv7PFHM1kfvZyBKXekyYEcKCRrHdk+t7V2sIawkrSiK3A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-ini": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-ini": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
-      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.357.0.tgz",
-      "integrity": "sha512-SODuQvAVALHMSFIY2+2gVW3bePgdhlOHnCNSB0BLS9tePgzMmifncRUQTa1LTOJ0rDkfw8KZfgJ33QbPB8uQpA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/token-providers": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
-      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
-      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
-      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
-      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
+        "node": ">=16.0.0"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
-      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
-      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
-      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.609.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
-      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
-      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
-      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
-      "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
-      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
-      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
-      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/signature-v4": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
-      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
-      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
-      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
-      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
-      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
-      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
-      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
-      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
-      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
-      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
-      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
-      "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.357.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.357.0.tgz",
-      "integrity": "sha512-mYE++WPPjfkEZ/YkhCi/Lj4/Up/VYH+bud22Wg5KZ6zsG/vqLJ8oAoe1cGcH7S2SGQ27dOZazVJzQQJ1Fg+7oA==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-stream": "3.357.0",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.357.0.tgz",
-      "integrity": "sha512-IswEFNKM0CypJQKLNlu+cf4t2QCuclegBdxVOFoNYH7QCpM+5P6vRA2s4cwOFroPpwd91biDtRc1jqlTgffS9A==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
-      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
-      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.357.0.tgz",
-      "integrity": "sha512-d0W8hKBDCT5Suihs+8PXqJR5MfEGntqp1a8WY9qXFcnr8NT3ySiaS/0eo0KIlI90+ReXNdcX2JroDoGwGre5Pw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.357.0.tgz",
-      "integrity": "sha512-hsj182L49Fagz7cVs5+NzVjmqgZN4KtC8io5efBDbkwG7i32+0Bl0SKwc13mi7c1stNNQ271YHRrUFb61xGM0A==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
-      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
-      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
-      "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.357.0.tgz",
-      "integrity": "sha512-HRMPE8i0OFrNLdwuE3mxAoHWgmJ32w3FNzVsiIXHsVeptomQeDuD9uugxq76ptZJRqbOpljR7AtfGVxc4kMNeg==",
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
-      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
-      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -990,71 +664,580 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
-      "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
+      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.11",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
+      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
+      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
+      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
+      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
+      "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
+      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
+      "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
+      "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
+      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
         {
           "type": "paypal",
@@ -1065,6 +1248,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -1075,895 +1259,964 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     }
   },
   "dependencies": {
-    "@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "requires": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
     "@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "requires": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
         }
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "requires": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "requires": {
         "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
         }
       }
     },
-    "@aws-sdk/abort-controller": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
-      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
     "@aws-sdk/client-ssm": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.357.0.tgz",
-      "integrity": "sha512-xvyrztXKVGnBaBNEu6ONH+v78HNJ4kHVUUcMe8d57pHaathRirgQjPjPZ5QyjD2HasvS5mkBo6fmbsmsqUs9jg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.616.0.tgz",
+      "integrity": "sha512-8M4DcUxi9zD1bK8kvs8wfqAgWx2Qx0bpLHhC/DkFrHZ28tqP9TeoDgjAmSFLAVGxJf6VVvr1mHXIy+4LVdl5SQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.357.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.357.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/client-sts": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.357.0.tgz",
-      "integrity": "sha512-iNH3rTSq6J7RnYYaGEScLorAIib62lTHpOtgMxS0e82845xgmIcgwSP2c3zK6Spc8zSm2K+0YEb6lLSad7EXMA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.357.0.tgz",
-      "integrity": "sha512-ZQYAOksTYeVVToP8SKP/HqcchgNZ1t+fpMCCp6nN2/QUnCgy+qJe6KZO+2Bv/oPufs8MFBWSirifjiYL1UNE7A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.357.0.tgz",
-      "integrity": "sha512-snQ1+gwa1sAZThAl5gz4dg33qMZ8QEYXK9wm/aFaCRsdM3e+4bZsI1VllaKZ+Vq8wTdLsJf1CCL4s8aIP49RBg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-sdk-sts": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/config-resolver": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
-      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+    "@aws-sdk/core": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/core": "^2.2.7",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
-      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
-      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.357.0.tgz",
-      "integrity": "sha512-o2RSGTwptHi8KJGVsEDGxtAhcHBXJGHBL8C1vDZZl0RMmSA5OpIFXH+ovTWJiwDF1NDnhsGquvp/7VePoVMaJA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.357.0.tgz",
-      "integrity": "sha512-YnVASpGyV5WFSzyPO9Kf093brddt+2l9EpRyhWYZVUv7PFHM1kfvZyBKXekyYEcKCRrHdk+t7V2sIawkrSiK3A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-ini": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-ini": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
-      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.357.0.tgz",
-      "integrity": "sha512-SODuQvAVALHMSFIY2+2gVW3bePgdhlOHnCNSB0BLS9tePgzMmifncRUQTa1LTOJ0rDkfw8KZfgJ33QbPB8uQpA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/token-providers": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
-      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-codec": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
-      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
-      "requires": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
-      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
-      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
-      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
-      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
-      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
-      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
-      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
-      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
-      "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
-      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
-      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
-      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/signature-v4": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
-      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
-      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
-      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
-      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
-      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
-      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
-      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
-      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
-      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
-      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
-      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
-      "requires": {
-        "@aws-sdk/eventstream-codec": "3.357.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.357.0.tgz",
-      "integrity": "sha512-mYE++WPPjfkEZ/YkhCi/Lj4/Up/VYH+bud22Wg5KZ6zsG/vqLJ8oAoe1cGcH7S2SGQ27dOZazVJzQQJ1Fg+7oA==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-stream": "3.357.0",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.357.0.tgz",
-      "integrity": "sha512-IswEFNKM0CypJQKLNlu+cf4t2QCuclegBdxVOFoNYH7QCpM+5P6vRA2s4cwOFroPpwd91biDtRc1jqlTgffS9A==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
-      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
-      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.357.0.tgz",
-      "integrity": "sha512-d0W8hKBDCT5Suihs+8PXqJR5MfEGntqp1a8WY9qXFcnr8NT3ySiaS/0eo0KIlI90+ReXNdcX2JroDoGwGre5Pw==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.357.0.tgz",
-      "integrity": "sha512-hsj182L49Fagz7cVs5+NzVjmqgZN4KtC8io5efBDbkwG7i32+0Bl0SKwc13mi7c1stNNQ271YHRrUFb61xGM0A==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
-      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-middleware": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
-      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
-      "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-stream": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.357.0.tgz",
-      "integrity": "sha512-HRMPE8i0OFrNLdwuE3mxAoHWgmJ32w3FNzVsiIXHsVeptomQeDuD9uugxq76ptZJRqbOpljR7AtfGVxc4kMNeg==",
-      "requires": {
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
-      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
-      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+    "@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+    "@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
       "requires": {
-        "tslib": "^2.3.1"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/util-waiter": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
-      "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
+    "@smithy/core": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
+      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.11",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
+      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "requires": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
+      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "requires": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "requires": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
+      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "requires": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
+      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "requires": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "requires": {
+        "@smithy/types": "^3.3.0"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
+      "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+      "requires": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
+      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.1",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "requires": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "requires": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "requires": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
+      "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+      "requires": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
+      "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+      "requires": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "requires": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
+      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+      "requires": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "bowser": {
@@ -1972,9 +2225,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "fast-xml-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -1985,14 +2238,14 @@
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     }
   }
 }

--- a/di-ipv-core-stub/deploy/cri-http-api-basic-auth/package.json
+++ b/di-ipv-core-stub/deploy/cri-http-api-basic-auth/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@aws-sdk/client-ssm": "^3.357.0"
+    "@aws-sdk/client-ssm": "^3.616.0"
   }
 }

--- a/di-ipv-core-stub/deploy/cri-rest-api/package-lock.json
+++ b/di-ipv-core-stub/deploy/cri-rest-api/package-lock.json
@@ -5,981 +5,655 @@
   "packages": {
     "": {
       "dependencies": {
-        "@aws-sdk/client-ssm": "^3.357.0"
+        "@aws-sdk/client-ssm": "^3.616.0"
       }
-    },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
-      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.357.0.tgz",
-      "integrity": "sha512-xvyrztXKVGnBaBNEu6ONH+v78HNJ4kHVUUcMe8d57pHaathRirgQjPjPZ5QyjD2HasvS5mkBo6fmbsmsqUs9jg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.616.0.tgz",
+      "integrity": "sha512-8M4DcUxi9zD1bK8kvs8wfqAgWx2Qx0bpLHhC/DkFrHZ28tqP9TeoDgjAmSFLAVGxJf6VVvr1mHXIy+4LVdl5SQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.357.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.357.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/client-sts": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.357.0.tgz",
-      "integrity": "sha512-iNH3rTSq6J7RnYYaGEScLorAIib62lTHpOtgMxS0e82845xgmIcgwSP2c3zK6Spc8zSm2K+0YEb6lLSad7EXMA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.357.0.tgz",
-      "integrity": "sha512-ZQYAOksTYeVVToP8SKP/HqcchgNZ1t+fpMCCp6nN2/QUnCgy+qJe6KZO+2Bv/oPufs8MFBWSirifjiYL1UNE7A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.616.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.357.0.tgz",
-      "integrity": "sha512-snQ1+gwa1sAZThAl5gz4dg33qMZ8QEYXK9wm/aFaCRsdM3e+4bZsI1VllaKZ+Vq8wTdLsJf1CCL4s8aIP49RBg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-sdk-sts": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
-      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/core": "^2.2.7",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
-      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
-      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.357.0.tgz",
-      "integrity": "sha512-o2RSGTwptHi8KJGVsEDGxtAhcHBXJGHBL8C1vDZZl0RMmSA5OpIFXH+ovTWJiwDF1NDnhsGquvp/7VePoVMaJA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.616.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.357.0.tgz",
-      "integrity": "sha512-YnVASpGyV5WFSzyPO9Kf093brddt+2l9EpRyhWYZVUv7PFHM1kfvZyBKXekyYEcKCRrHdk+t7V2sIawkrSiK3A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-ini": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-ini": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
-      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.357.0.tgz",
-      "integrity": "sha512-SODuQvAVALHMSFIY2+2gVW3bePgdhlOHnCNSB0BLS9tePgzMmifncRUQTa1LTOJ0rDkfw8KZfgJ33QbPB8uQpA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/token-providers": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
-      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
-      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
-      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
-      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
+        "node": ">=16.0.0"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
-      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
-      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
-      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.609.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
-      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
-      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
-      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
-      "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
-      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
-      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
-      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/signature-v4": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
-      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
-      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
-      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
-      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
-      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
-      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
-      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
-      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
-      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
-      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
-      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
-      "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.357.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.357.0.tgz",
-      "integrity": "sha512-mYE++WPPjfkEZ/YkhCi/Lj4/Up/VYH+bud22Wg5KZ6zsG/vqLJ8oAoe1cGcH7S2SGQ27dOZazVJzQQJ1Fg+7oA==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-stream": "3.357.0",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.357.0.tgz",
-      "integrity": "sha512-IswEFNKM0CypJQKLNlu+cf4t2QCuclegBdxVOFoNYH7QCpM+5P6vRA2s4cwOFroPpwd91biDtRc1jqlTgffS9A==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
-      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
-      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.357.0.tgz",
-      "integrity": "sha512-d0W8hKBDCT5Suihs+8PXqJR5MfEGntqp1a8WY9qXFcnr8NT3ySiaS/0eo0KIlI90+ReXNdcX2JroDoGwGre5Pw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.357.0.tgz",
-      "integrity": "sha512-hsj182L49Fagz7cVs5+NzVjmqgZN4KtC8io5efBDbkwG7i32+0Bl0SKwc13mi7c1stNNQ271YHRrUFb61xGM0A==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
-      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
-      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
-      "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.357.0.tgz",
-      "integrity": "sha512-HRMPE8i0OFrNLdwuE3mxAoHWgmJ32w3FNzVsiIXHsVeptomQeDuD9uugxq76ptZJRqbOpljR7AtfGVxc4kMNeg==",
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
-      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
-      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -990,71 +664,580 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
-      "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
+      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.11",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
+      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
+      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
+      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
+      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
+      "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
+      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
+      "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
+      "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
+      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
         {
           "type": "paypal",
@@ -1065,6 +1248,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -1075,895 +1259,964 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     }
   },
   "dependencies": {
-    "@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "requires": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
     "@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "requires": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
         }
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "requires": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "requires": {
         "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
         }
       }
     },
-    "@aws-sdk/abort-controller": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
-      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
     "@aws-sdk/client-ssm": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.357.0.tgz",
-      "integrity": "sha512-xvyrztXKVGnBaBNEu6ONH+v78HNJ4kHVUUcMe8d57pHaathRirgQjPjPZ5QyjD2HasvS5mkBo6fmbsmsqUs9jg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.616.0.tgz",
+      "integrity": "sha512-8M4DcUxi9zD1bK8kvs8wfqAgWx2Qx0bpLHhC/DkFrHZ28tqP9TeoDgjAmSFLAVGxJf6VVvr1mHXIy+4LVdl5SQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.357.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.357.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/client-sts": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.357.0.tgz",
-      "integrity": "sha512-iNH3rTSq6J7RnYYaGEScLorAIib62lTHpOtgMxS0e82845xgmIcgwSP2c3zK6Spc8zSm2K+0YEb6lLSad7EXMA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.357.0.tgz",
-      "integrity": "sha512-ZQYAOksTYeVVToP8SKP/HqcchgNZ1t+fpMCCp6nN2/QUnCgy+qJe6KZO+2Bv/oPufs8MFBWSirifjiYL1UNE7A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.357.0.tgz",
-      "integrity": "sha512-snQ1+gwa1sAZThAl5gz4dg33qMZ8QEYXK9wm/aFaCRsdM3e+4bZsI1VllaKZ+Vq8wTdLsJf1CCL4s8aIP49RBg==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-node": "3.357.0",
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/hash-node": "3.357.0",
-        "@aws-sdk/invalid-dependency": "3.357.0",
-        "@aws-sdk/middleware-content-length": "3.357.0",
-        "@aws-sdk/middleware-endpoint": "3.357.0",
-        "@aws-sdk/middleware-host-header": "3.357.0",
-        "@aws-sdk/middleware-logger": "3.357.0",
-        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-        "@aws-sdk/middleware-retry": "3.357.0",
-        "@aws-sdk/middleware-sdk-sts": "3.357.0",
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/middleware-user-agent": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/smithy-client": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-        "@aws-sdk/util-defaults-mode-node": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "@aws-sdk/util-user-agent-browser": "3.357.0",
-        "@aws-sdk/util-user-agent-node": "3.357.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/config-resolver": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
-      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+    "@aws-sdk/core": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/core": "^2.2.7",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
-      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
-      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.357.0.tgz",
-      "integrity": "sha512-o2RSGTwptHi8KJGVsEDGxtAhcHBXJGHBL8C1vDZZl0RMmSA5OpIFXH+ovTWJiwDF1NDnhsGquvp/7VePoVMaJA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.357.0.tgz",
-      "integrity": "sha512-YnVASpGyV5WFSzyPO9Kf093brddt+2l9EpRyhWYZVUv7PFHM1kfvZyBKXekyYEcKCRrHdk+t7V2sIawkrSiK3A==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/credential-provider-ini": "3.357.0",
-        "@aws-sdk/credential-provider-process": "3.357.0",
-        "@aws-sdk/credential-provider-sso": "3.357.0",
-        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-ini": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
-      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.357.0.tgz",
-      "integrity": "sha512-SODuQvAVALHMSFIY2+2gVW3bePgdhlOHnCNSB0BLS9tePgzMmifncRUQTa1LTOJ0rDkfw8KZfgJ33QbPB8uQpA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/token-providers": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
-      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-codec": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
-      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
-      "requires": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
-      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
-      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
-      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
-      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
-      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/url-parser": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
-      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
-      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
-      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
-      "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-retry": "3.357.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
-      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
-      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
-      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/signature-v4": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
-      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
-      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-endpoints": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
-      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
-      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/protocol-http": "3.357.0",
-        "@aws-sdk/querystring-builder": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
-      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
-      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
-      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
-      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
-      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
-      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
-      "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
-      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
-      "requires": {
-        "@aws-sdk/eventstream-codec": "3.357.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.357.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.357.0.tgz",
-      "integrity": "sha512-mYE++WPPjfkEZ/YkhCi/Lj4/Up/VYH+bud22Wg5KZ6zsG/vqLJ8oAoe1cGcH7S2SGQ27dOZazVJzQQJ1Fg+7oA==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-stream": "3.357.0",
-        "@smithy/types": "^1.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.357.0.tgz",
-      "integrity": "sha512-IswEFNKM0CypJQKLNlu+cf4t2QCuclegBdxVOFoNYH7QCpM+5P6vRA2s4cwOFroPpwd91biDtRc1jqlTgffS9A==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
-      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
-      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.357.0.tgz",
-      "integrity": "sha512-d0W8hKBDCT5Suihs+8PXqJR5MfEGntqp1a8WY9qXFcnr8NT3ySiaS/0eo0KIlI90+ReXNdcX2JroDoGwGre5Pw==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.357.0.tgz",
-      "integrity": "sha512-hsj182L49Fagz7cVs5+NzVjmqgZN4KtC8io5efBDbkwG7i32+0Bl0SKwc13mi7c1stNNQ271YHRrUFb61xGM0A==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.357.0",
-        "@aws-sdk/credential-provider-imds": "3.357.0",
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/property-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
-      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-middleware": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
-      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
-      "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.357.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-stream": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.357.0.tgz",
-      "integrity": "sha512-HRMPE8i0OFrNLdwuE3mxAoHWgmJ32w3FNzVsiIXHsVeptomQeDuD9uugxq76ptZJRqbOpljR7AtfGVxc4kMNeg==",
-      "requires": {
-        "@aws-sdk/fetch-http-handler": "3.357.0",
-        "@aws-sdk/node-http-handler": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
-      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "requires": {
-        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
-      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+    "@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+    "@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
       "requires": {
-        "tslib": "^2.3.1"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/util-waiter": {
-      "version": "3.357.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
-      "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
+    "@smithy/core": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
+      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.357.0",
-        "@aws-sdk/types": "3.357.0",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.11",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
+      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "requires": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
+      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "requires": {
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "requires": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
+      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "requires": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
+      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "requires": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
       "requires": {
-        "@smithy/types": "^1.1.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "requires": {
+        "@smithy/types": "^3.3.0"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
+      "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+      "requires": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
+      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.1",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "requires": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "requires": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "requires": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
+      "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+      "requires": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
+      "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+      "requires": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "requires": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "requires": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
+      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+      "requires": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "bowser": {
@@ -1972,9 +2225,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "fast-xml-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -1985,14 +2238,14 @@
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     }
   }
 }

--- a/di-ipv-core-stub/deploy/cri-rest-api/package.json
+++ b/di-ipv-core-stub/deploy/cri-rest-api/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@aws-sdk/client-ssm": "^3.357.0"
+    "@aws-sdk/client-ssm": "^3.616.0"
   }
 }

--- a/di-ipv-queue-stub/enqueue-event/package-lock.json
+++ b/di-ipv-queue-stub/enqueue-event/package-lock.json
@@ -8,32 +8,20 @@
             "name": "EnqueueEvent",
             "version": "0.0.1",
             "dependencies": {
-                "di-stub-oauth-client": "git+ssh://git@github.com:alphagov/di-stub-oauth-client#main"
+                "stub-oauth-client": "git+ssh://git@github.com:govuk-one-login/stub-oauth-client#main"
             },
             "devDependencies": {
-                "@aws-sdk/client-secrets-manager": "^3.357.0",
-                "@aws-sdk/client-sqs": "^3.357.0",
-                "@aws-sdk/client-ssm": "^3.357.0",
-                "@types/dotenv": "^8.2.0",
+                "@aws-sdk/client-secrets-manager": "^3.616.0",
+                "@aws-sdk/client-sqs": "^3.616.0",
+                "@aws-sdk/client-ssm": "^3.616.0",
                 "@types/node": "^20.2.5",
                 "@types/uuid": "^9.0.2"
             }
         },
-        "node_modules/@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^1.11.1"
@@ -41,10 +29,14 @@
         },
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
@@ -59,10 +51,14 @@
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
@@ -72,10 +68,14 @@
         },
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^1.11.1"
@@ -83,10 +83,14 @@
         },
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
         },
         "node_modules/@aws-crypto/util": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
@@ -96,548 +100,4006 @@
         },
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
         },
-        "node_modules/@aws-sdk/abort-controller": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/client-kms": {
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.431.0.tgz",
+            "integrity": "sha512-X1OdSirOMQOiGzCeXSYECMFlGoi79uEDk1ZkG0UuBJem7e0HF/6z0qw0U/Tc1NfnoOpgkDYsFyirFyKLVCryPw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.431.0",
+                "@aws-sdk/credential-provider-node": "3.431.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-signing": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/region-config-resolver": "3.430.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-kms": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.430.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+            "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/types": "^2.3.5",
+                "@smithy/util-config-provider": "^2.0.0",
+                "@smithy/util-middleware": "^2.0.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/abort-controller": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+            "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/config-resolver": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+            "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/credential-provider-imds": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+            "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/fetch-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+            "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/hash-node": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+            "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/invalid-dependency": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+            "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/middleware-content-length": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+            "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/middleware-endpoint": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+            "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/middleware-retry": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+            "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/middleware-serde": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+            "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/middleware-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+            "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/node-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+            "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/querystring-builder": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+            "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+            "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/service-error-classification": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+            "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/smithy-client": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+            "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-stream": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+            "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-base64": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+            "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-body-length-browser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+            "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-body-length-node": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+            "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+            "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+            "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+            "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-hex-encoding": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+            "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-middleware": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+            "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-retry": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+            "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+            "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+            "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-kms/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.616.0.tgz",
+            "integrity": "sha512-V8WRJ7eGBm01Y9nYg4KrQJ6fpXZkAfGTR9rtjMOdPSBcAD4hOJ6gisufxAKl9MSfTPLfzqSCb5/wWkIviobRZA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/client-sts": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/md5-js": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-sdk-sqs": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
-                "tslib": "^2.5.0"
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+            "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+            "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.616.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sts": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+            "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+            "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+            "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.609.0",
+                "@aws-sdk/credential-provider-http": "3.616.0",
+                "@aws-sdk/credential-provider-process": "3.614.0",
+                "@aws-sdk/credential-provider-sso": "3.616.0",
+                "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.616.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+            "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.609.0",
+                "@aws-sdk/credential-provider-http": "3.616.0",
+                "@aws-sdk/credential-provider-ini": "3.616.0",
+                "@aws-sdk/credential-provider-process": "3.614.0",
+                "@aws-sdk/credential-provider-sso": "3.616.0",
+                "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+            "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+            "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.616.0",
+                "@aws-sdk/token-providers": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+            "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.609.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+            "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+            "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+            "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+            "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+            "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.614.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+            "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-endpoints": "^2.0.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+            "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+            "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.616.0.tgz",
+            "integrity": "sha512-79WwG5NslWMPqbW+gg1ScTGjeR7ibNoXp0ztZ0tuok8KD9cecOPcD+lMz9LjIcFlJT8FepL9hg8E9vYKBpOZsQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/client-sts": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-sdk-sqs": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/md5-js": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+            "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+            "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.616.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+            "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+            "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+            "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.609.0",
+                "@aws-sdk/credential-provider-http": "3.616.0",
+                "@aws-sdk/credential-provider-process": "3.614.0",
+                "@aws-sdk/credential-provider-sso": "3.616.0",
+                "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.616.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+            "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.609.0",
+                "@aws-sdk/credential-provider-http": "3.616.0",
+                "@aws-sdk/credential-provider-ini": "3.616.0",
+                "@aws-sdk/credential-provider-process": "3.614.0",
+                "@aws-sdk/credential-provider-sso": "3.616.0",
+                "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+            "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+            "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.616.0",
+                "@aws-sdk/token-providers": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+            "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.609.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+            "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+            "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+            "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+            "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+            "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.614.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+            "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-endpoints": "^2.0.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+            "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+            "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/client-ssm": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.616.0.tgz",
+            "integrity": "sha512-8M4DcUxi9zD1bK8kvs8wfqAgWx2Qx0bpLHhC/DkFrHZ28tqP9TeoDgjAmSFLAVGxJf6VVvr1mHXIy+4LVdl5SQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.357.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/client-sts": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/util-waiter": "^3.1.2",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+            "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+            "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.616.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+            "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+            "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+            "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.609.0",
+                "@aws-sdk/credential-provider-http": "3.616.0",
+                "@aws-sdk/credential-provider-process": "3.614.0",
+                "@aws-sdk/credential-provider-sso": "3.616.0",
+                "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.616.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+            "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.609.0",
+                "@aws-sdk/credential-provider-http": "3.616.0",
+                "@aws-sdk/credential-provider-ini": "3.616.0",
+                "@aws-sdk/credential-provider-process": "3.614.0",
+                "@aws-sdk/credential-provider-sso": "3.616.0",
+                "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+            "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+            "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.616.0",
+                "@aws-sdk/token-providers": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+            "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.609.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+            "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+            "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+            "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+            "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/token-providers": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+            "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.614.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+            "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-endpoints": "^2.0.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+            "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+            "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.431.0.tgz",
+            "integrity": "sha512-iK8RxdBHFj1HtWpdTVfFdljZHXLWFv62SuIdkDswGE7L0zNbZIqBDGfEBnbagiQuxkz5D2YtnasydC5R3BcwVw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/region-config-resolver": "3.430.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.430.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+            "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/types": "^2.3.5",
+                "@smithy/util-config-provider": "^2.0.0",
+                "@smithy/util-middleware": "^2.0.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/abort-controller": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+            "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+            "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/credential-provider-imds": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+            "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+            "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+            "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/invalid-dependency": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+            "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+            "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-endpoint": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+            "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+            "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+            "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+            "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+            "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-builder": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+            "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+            "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/service-error-classification": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+            "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+            "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-stream": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+            "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+            "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+            "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+            "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+            "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+            "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+            "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-hex-encoding": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+            "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-middleware": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+            "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+            "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+            "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+            "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.431.0.tgz",
+            "integrity": "sha512-IM/Fg3H1WuM9fnVriEoM6+sZ9LNUExxklxAnHwjLnprPRTDGbUXUfYjSry52LaQsZffP3RgWP11CYyjCYC8CfQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-sdk-sts": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
+                "@aws-sdk/credential-provider-node": "3.431.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-sdk-sts": "3.428.0",
+                "@aws-sdk/middleware-signing": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/region-config-resolver": "3.430.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.430.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+            "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.357.0",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/types": "^2.3.5",
+                "@smithy/util-config-provider": "^2.0.0",
+                "@smithy/util-middleware": "^2.0.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+            "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+            "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/credential-provider-imds": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+            "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+            "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+            "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/invalid-dependency": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+            "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+            "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-endpoint": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+            "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+            "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+            "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+            "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+            "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+            "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+            "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+            "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+            "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-stream": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+            "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+            "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+            "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+            "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+            "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+            "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+            "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-hex-encoding": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+            "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-middleware": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+            "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+            "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+            "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+            "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+            "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^2.2.7",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/signature-v4": "^4.0.0",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.428.0.tgz",
+            "integrity": "sha512-e6fbY174Idzw0r5ZMT1qkDh+dpOp1DX3ickhr7J6ipo3cUGLI45Y5lnR9nYXWfB5o/wiNv4zXgN+Y3ORJJHzyA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+            "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.431.0.tgz",
+            "integrity": "sha512-SILMZuscwxeqB4kuZjWiu24wfvmvN3Tx7/j5n0t0Ob+cdpweK0IqkBQ/QkTbTiG0M1l8trMtMkrTb5510fupcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.357.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/credential-provider-env": "3.428.0",
+                "@aws-sdk/credential-provider-process": "3.428.0",
+                "@aws-sdk/credential-provider-sso": "3.431.0",
+                "@aws-sdk/credential-provider-web-identity": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/credential-provider-imds": "^2.0.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/credential-provider-imds": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+            "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+            "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+            "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.431.0.tgz",
+            "integrity": "sha512-jj2gm92nfsFw5e48+7OCYM5PfiW3pd9FvhEoBfvKANwM6ztXzmNpQcz3iWsGVfzd+MUooVBoO2exhH9M8t+VDg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-ini": "3.357.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.357.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/credential-provider-env": "3.428.0",
+                "@aws-sdk/credential-provider-ini": "3.431.0",
+                "@aws-sdk/credential-provider-process": "3.428.0",
+                "@aws-sdk/credential-provider-sso": "3.431.0",
+                "@aws-sdk/credential-provider-web-identity": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/credential-provider-imds": "^2.0.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/credential-provider-imds": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+            "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+            "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+            "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.428.0.tgz",
+            "integrity": "sha512-UG2S2/4Wrskbkbgt9fBlnzwQ2hfTXvLJwUgGOluSOf6+mGCcoDku4zzc9EQdk1MwN5Us+ziyMrIMNY5sbdLg6g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.431.0.tgz",
+            "integrity": "sha512-fh/yWKJtgEpxfuzd/KTVPQz0FjykbiPnU0OLm1wKgNZAyKTE9EyNvWR6P57TWv/sU8faa5uLaxdD0TBPxWReDA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/token-providers": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/client-sso": "3.431.0",
+                "@aws-sdk/token-providers": "3.431.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.428.0.tgz",
+            "integrity": "sha512-ueuUPPlrJFvtDUVTGnClUGt1wxCbEiKArknah/w9cfcc/c1HtFd/M7x/z2Sm0gSItR45sVcK54qjzmhm29DMzg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/eventstream-codec": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/querystring-builder": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/hash-node": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/is-array-buffer": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/md5-js": {
-            "version": "3.357.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.431.0.tgz",
+            "integrity": "sha512-j+OBsCDDRXlMEQ4GCtTxVaMwxIHNKiwbDIZVyB6CDor8AFflKxWbO3cPSpUuGKlUN9OEexMR+XgwsjmaI6AGwg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -645,10 +4107,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.428.0.tgz",
+            "integrity": "sha512-1P0V0quL9u2amdNOn6yYT7/ToQUmkLJqCKHPxsRyDB829vBThWndvvH5MkoItj/VgE1zWqMtrzN3xtzD7zx6Qg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -656,64 +4121,74 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.428.0.tgz",
+            "integrity": "sha512-xC0OMduCByyRdiQz324RXy4kunnCG4LUJCfvdoegM33Elp9ex0D3fcfO1mUgV8qiLwSennIsSRVXHuhNxE2HZA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/service-error-classification": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.616.0.tgz",
+            "integrity": "sha512-r4Ogloy6Rg0cx0rccQ34fUuHRTvFE303U6RMuvOs31x+cRD8GZs6y/pN3hC065nvSOpNK04jV1IHARVd/sWj5g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.428.0.tgz",
+            "integrity": "sha512-Uutl2niYXTnNP8v84v6umWDHD5no7d5/OqkZE1DsmeKR/dje90J5unJWf7MOsqvYm0JGDEWF4lk9xGVyqsw+Aw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/middleware-signing": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -721,289 +4196,743 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.428.0.tgz",
+            "integrity": "sha512-oMSerTPwtsQAR7fIU/G0b0BA30wF+MC4gZSrJjbypF8MK8nPC2yMfKLR8+QavGOGEW7rUMQ0uklThMTTwQEXNQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/signature-v4": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-middleware": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/signature-v4": "^2.0.0",
+                "@smithy/types": "^2.3.5",
+                "@smithy/util-middleware": "^2.0.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/signature-v4": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
+            "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/util-hex-encoding": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+            "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/util-middleware": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+            "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+            "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.428.0.tgz",
+            "integrity": "sha512-+GAhObeHRick2D5jr3YkPckjcggt5v6uUVtEUQW2AdD65cE5PjIvmksv6FuM/mME/9nNA+wufQnHbLI8teLeaw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+            "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
+            "version": "3.609.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+            "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.357.0",
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/querystring-builder": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/property-provider": {
-            "version": "3.357.0",
+        "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/protocol-http": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-uri-escape": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.357.0",
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "@aws-sdk/util-uri-escape": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/smithy-client": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-stream": "3.357.0",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.431.0.tgz",
+            "integrity": "sha512-0ksZogF3Gy2i+yBb7T2g2e7QXzwZeQHmf09ihR1cwXwg7UIjsap6P3gPtC085bDkOD9iY8OdpL0Esp06N6xmCg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/abort-controller": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+            "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/config-resolver": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+            "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/credential-provider-imds": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+            "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/fetch-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+            "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/hash-node": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+            "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/invalid-dependency": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+            "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/middleware-content-length": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+            "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/middleware-endpoint": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+            "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/middleware-retry": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+            "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/middleware-serde": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+            "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/middleware-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+            "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/node-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+            "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/querystring-builder": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+            "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+            "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/service-error-classification": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+            "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/smithy-client": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+            "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-stream": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+            "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-base64": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+            "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-body-length-browser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+            "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-body-length-node": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+            "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+            "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+            "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+            "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-hex-encoding": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+            "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-middleware": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+            "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-retry": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+            "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+            "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+            "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.428.0.tgz",
+            "integrity": "sha512-4T0Ps2spjg3qbWE6ZK13Vd3FnzpfliaiotqjxUK5YhjDrKXeT36HJp46JhDupElQuHtTkpdiJOSYk2lvY2H4IA==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/url-parser": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-base64": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-body-length-browser": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-body-length-node": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-buffer-from": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-config-provider": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.428.0.tgz",
+            "integrity": "sha512-ToKMhYlUWJ0YrbggpJLZeyZZNDXtQ4NITxqo/oeGltTT9KG4o/LqVY59EveV0f8P32ObDyj9Vh1mnjxeo3DxGw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@aws-sdk/types": "3.428.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1020,69 +4949,27 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-middleware": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-retry": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/service-error-classification": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-stream": {
-            "version": "3.357.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-uri-escape": {
-            "version": "3.310.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.428.0.tgz",
+            "integrity": "sha512-qlc2UoGsmCpuh1ErY3VayZuAGl74TWWcLmhhQMkeByFSb6KooBlwOmDpDzJRtgwJoe0KXnyHBO6lzl9iczcozg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/types": "^2.3.5",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.357.0",
+            "version": "3.430.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.430.0.tgz",
+            "integrity": "sha512-DPpFPL3mFMPtipFxjY7TKQBjnhmsPzYCr4Y+qna0oR6ij8jZOz2ILQDK33GxTRNh3+bV9YYbx+ZGDOnxoK5Mhw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1097,12 +4984,42 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/util-utf8": {
-            "version": "3.310.0",
+        "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+            "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/property-provider": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+            "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+            "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -1110,53 +5027,1113 @@
         },
         "node_modules/@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.3.1"
             }
         },
-        "node_modules/@aws-sdk/util-waiter": {
-            "version": "3.357.0",
+        "node_modules/@smithy/abort-controller": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+            "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+            "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
+            "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.11",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+            "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
+            "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+            "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+            "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/md5-js": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
+            "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
+            "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+            "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
+            "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+            "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+            "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+            "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
+            "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+            "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "1.1.0",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+            "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^1.1.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+            "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+            "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+            "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+            "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
+            "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
+            "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client/node_modules/@smithy/protocol-http": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+            "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/types": {
-            "version": "1.1.0",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+            "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@types/dotenv": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-            "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-            "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
+        "node_modules/@smithy/url-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+            "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "dotenv": "*"
+                "@smithy/querystring-parser": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+            "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
+            "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
+            "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+            "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+            "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+            "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
+            "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+            "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@types/node": {
@@ -1170,48 +6147,32 @@
             "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
             "dev": true
         },
-        "node_modules/@types/uuid": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-            "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
-            "dev": true
-        },
         "node_modules/bowser": {
             "version": "2.11.0",
             "license": "MIT"
         },
-        "node_modules/di-stub-oauth-client": {
-            "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/alphagov/di-stub-oauth-client.git#2c2af7fdf678e7f6c7093c1c7fb8496d2cfdb8fd",
-            "hasInstallScript": true,
-            "license": "ISC",
-            "dependencies": {
-                "@aws-sdk/client-kms": "3.357.0",
-                "jose": "4.11.1",
-                "uuid": "9.0.0"
-            }
-        },
-        "node_modules/di-stub-oauth-client/node_modules/uuid": {
-            "version": "9.0.0",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/dotenv": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-            "dev": true,
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/motdotla/dotenv?sponsor=1"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.4",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
             "funding": [
                 {
                     "type": "paypal",
@@ -1237,49 +6198,103 @@
                 "url": "https://github.com/sponsors/panva"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/strnum": {
             "version": "1.0.5",
             "license": "MIT"
         },
+        "node_modules/stub-oauth-client": {
+            "name": "di-stub-oauth-client",
+            "version": "1.0.0",
+            "resolved": "git+ssh://git@github.com/govuk-one-login/stub-oauth-client.git#1b9d980fd6df8162df6002140e715c39d085080a",
+            "hasInstallScript": true,
+            "license": "ISC",
+            "dependencies": {
+                "@aws-sdk/client-kms": "3.431.0",
+                "@types/uuid": "9.0.0",
+                "dotenv": "16.0.3",
+                "ecdsa-sig-formatter": "1.0.11",
+                "jose": "4.11.1",
+                "uuidv4": "6.2.13"
+            }
+        },
+        "node_modules/stub-oauth-client/node_modules/@types/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+            "license": "MIT"
+        },
         "node_modules/tslib": {
-            "version": "2.5.3",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
             "license": "0BSD"
         },
         "node_modules/uuid": {
             "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/uuidv4": {
+            "version": "6.2.13",
+            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+            "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/uuid": "8.3.4",
+                "uuid": "8.3.2"
+            }
+        },
+        "node_modules/uuidv4/node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "license": "MIT"
         }
     },
     "dependencies": {
-        "@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "requires": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1"
-                }
-            }
-        },
         "@aws-crypto/ie11-detection": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
             "requires": {
                 "tslib": "^1.11.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.14.1"
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/sha256-browser": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
             "requires": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
                 "@aws-crypto/sha256-js": "^3.0.0",
@@ -1292,12 +6307,16 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.14.1"
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/sha256-js": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -1305,23 +6324,31 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.14.1"
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/supports-web-crypto": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
             "requires": {
                 "tslib": "^1.11.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.14.1"
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@aws-crypto/util": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
             "requires": {
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1329,713 +6356,3742 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.14.1"
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
-        "@aws-sdk/abort-controller": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
         "@aws-sdk/client-kms": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.431.0.tgz",
+            "integrity": "sha512-X1OdSirOMQOiGzCeXSYECMFlGoi79uEDk1ZkG0UuBJem7e0HF/6z0qw0U/Tc1NfnoOpgkDYsFyirFyKLVCryPw==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
+                "@aws-sdk/client-sts": "3.431.0",
+                "@aws-sdk/credential-provider-node": "3.431.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-signing": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/region-config-resolver": "3.430.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@aws-sdk/region-config-resolver": {
+                    "version": "3.430.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+                    "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.1.2",
+                        "@smithy/types": "^2.3.5",
+                        "@smithy/util-config-provider": "^2.0.0",
+                        "@smithy/util-middleware": "^2.0.4",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@smithy/abort-controller": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+                    "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/config-resolver": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+                    "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-config-provider": "^2.3.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/credential-provider-imds": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+                    "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/fetch-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/hash-node": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+                    "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/invalid-dependency": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+                    "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-content-length": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+                    "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-endpoint": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+                    "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+                    "requires": {
+                        "@smithy/middleware-serde": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-retry": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+                    "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "@smithy/util-retry": "^2.2.0",
+                        "tslib": "^2.6.2",
+                        "uuid": "^9.0.1"
+                    }
+                },
+                "@smithy/middleware-serde": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+                    "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-stack": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+                    "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+                    "requires": {
+                        "@smithy/abort-controller": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-builder": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+                    "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-uri-escape": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+                    "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/service-error-classification": {
+                    "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+                    "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/smithy-client": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+                    "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+                    "requires": {
+                        "@smithy/middleware-endpoint": "^2.5.1",
+                        "@smithy/middleware-stack": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-stream": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/url-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+                    "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+                    "requires": {
+                        "@smithy/querystring-parser": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-base64": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+                    "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-browser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+                    "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-node": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+                    "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-browser": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+                    "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-node": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+                    "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+                    "requires": {
+                        "@smithy/config-resolver": "^2.2.0",
+                        "@smithy/credential-provider-imds": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-hex-encoding": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+                    "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-middleware": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+                    "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-retry": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+                    "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+                    "requires": {
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-stream": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+                    "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+                    "requires": {
+                        "@smithy/fetch-http-handler": "^2.5.0",
+                        "@smithy/node-http-handler": "^2.5.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-hex-encoding": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-uri-escape": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+                    "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
             }
         },
         "@aws-sdk/client-secrets-manager": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.616.0.tgz",
+            "integrity": "sha512-V8WRJ7eGBm01Y9nYg4KrQJ6fpXZkAfGTR9rtjMOdPSBcAD4hOJ6gisufxAKl9MSfTPLfzqSCb5/wWkIviobRZA==",
             "dev": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/client-sts": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "dependencies": {
+                "@aws-crypto/sha256-browser": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+                    "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-js": "^5.2.0",
+                        "@aws-crypto/supports-web-crypto": "^5.2.0",
+                        "@aws-crypto/util": "^5.2.0",
+                        "@aws-sdk/types": "^3.222.0",
+                        "@aws-sdk/util-locate-window": "^3.0.0",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.6.2"
+                    },
+                    "dependencies": {
+                        "@smithy/util-utf8": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                            "dev": true,
+                            "requires": {
+                                "@smithy/util-buffer-from": "^2.2.0",
+                                "tslib": "^2.6.2"
+                            }
+                        }
+                    }
+                },
+                "@aws-crypto/sha256-js": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+                    "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/util": "^5.2.0",
+                        "@aws-sdk/types": "^3.222.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-crypto/supports-web-crypto": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+                    "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-crypto/util": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+                    "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "^3.222.0",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.6.2"
+                    },
+                    "dependencies": {
+                        "@smithy/util-utf8": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                            "dev": true,
+                            "requires": {
+                                "@smithy/util-buffer-from": "^2.2.0",
+                                "tslib": "^2.6.2"
+                            }
+                        }
+                    }
+                },
+                "@aws-sdk/client-sso": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+                    "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/client-sso-oidc": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+                    "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/credential-provider-node": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/client-sts": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+                    "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/client-sso-oidc": "3.616.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/credential-provider-node": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-env": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+                    "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-ini": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+                    "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.609.0",
+                        "@aws-sdk/credential-provider-http": "3.616.0",
+                        "@aws-sdk/credential-provider-process": "3.614.0",
+                        "@aws-sdk/credential-provider-sso": "3.616.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/credential-provider-imds": "^3.1.4",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-node": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+                    "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.609.0",
+                        "@aws-sdk/credential-provider-http": "3.616.0",
+                        "@aws-sdk/credential-provider-ini": "3.616.0",
+                        "@aws-sdk/credential-provider-process": "3.614.0",
+                        "@aws-sdk/credential-provider-sso": "3.616.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/credential-provider-imds": "^3.1.4",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-process": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+                    "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-sso": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+                    "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/client-sso": "3.616.0",
+                        "@aws-sdk/token-providers": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-web-identity": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+                    "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-host-header": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+                    "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-logger": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+                    "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-recursion-detection": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+                    "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-user-agent": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+                    "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/token-providers": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+                    "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+                    "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-endpoints": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+                    "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-user-agent-browser": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+                    "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-user-agent-node": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+                    "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+                    "dev": true
+                }
             }
         },
         "@aws-sdk/client-sqs": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.616.0.tgz",
+            "integrity": "sha512-79WwG5NslWMPqbW+gg1ScTGjeR7ibNoXp0ztZ0tuok8KD9cecOPcD+lMz9LjIcFlJT8FepL9hg8E9vYKBpOZsQ==",
             "dev": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/md5-js": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-sdk-sqs": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/client-sts": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-sdk-sqs": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/md5-js": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@aws-crypto/sha256-browser": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+                    "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-js": "^5.2.0",
+                        "@aws-crypto/supports-web-crypto": "^5.2.0",
+                        "@aws-crypto/util": "^5.2.0",
+                        "@aws-sdk/types": "^3.222.0",
+                        "@aws-sdk/util-locate-window": "^3.0.0",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.6.2"
+                    },
+                    "dependencies": {
+                        "@smithy/util-utf8": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                            "dev": true,
+                            "requires": {
+                                "@smithy/util-buffer-from": "^2.2.0",
+                                "tslib": "^2.6.2"
+                            }
+                        }
+                    }
+                },
+                "@aws-crypto/sha256-js": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+                    "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/util": "^5.2.0",
+                        "@aws-sdk/types": "^3.222.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-crypto/supports-web-crypto": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+                    "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-crypto/util": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+                    "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "^3.222.0",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.6.2"
+                    },
+                    "dependencies": {
+                        "@smithy/util-utf8": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                            "dev": true,
+                            "requires": {
+                                "@smithy/util-buffer-from": "^2.2.0",
+                                "tslib": "^2.6.2"
+                            }
+                        }
+                    }
+                },
+                "@aws-sdk/client-sso": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+                    "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/client-sso-oidc": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+                    "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/credential-provider-node": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/client-sts": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+                    "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/client-sso-oidc": "3.616.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/credential-provider-node": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-env": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+                    "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-ini": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+                    "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.609.0",
+                        "@aws-sdk/credential-provider-http": "3.616.0",
+                        "@aws-sdk/credential-provider-process": "3.614.0",
+                        "@aws-sdk/credential-provider-sso": "3.616.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/credential-provider-imds": "^3.1.4",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-node": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+                    "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.609.0",
+                        "@aws-sdk/credential-provider-http": "3.616.0",
+                        "@aws-sdk/credential-provider-ini": "3.616.0",
+                        "@aws-sdk/credential-provider-process": "3.614.0",
+                        "@aws-sdk/credential-provider-sso": "3.616.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/credential-provider-imds": "^3.1.4",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-process": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+                    "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-sso": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+                    "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/client-sso": "3.616.0",
+                        "@aws-sdk/token-providers": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-web-identity": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+                    "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-host-header": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+                    "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-logger": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+                    "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-recursion-detection": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+                    "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-user-agent": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+                    "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/token-providers": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+                    "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+                    "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-endpoints": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+                    "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-user-agent-browser": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+                    "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-user-agent-node": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+                    "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/client-ssm": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.616.0.tgz",
+            "integrity": "sha512-8M4DcUxi9zD1bK8kvs8wfqAgWx2Qx0bpLHhC/DkFrHZ28tqP9TeoDgjAmSFLAVGxJf6VVvr1mHXIy+4LVdl5SQ==",
             "dev": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.357.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.357.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.616.0",
+                "@aws-sdk/client-sts": "3.616.0",
+                "@aws-sdk/core": "3.616.0",
+                "@aws-sdk/credential-provider-node": "3.616.0",
+                "@aws-sdk/middleware-host-header": "3.616.0",
+                "@aws-sdk/middleware-logger": "3.609.0",
+                "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                "@aws-sdk/middleware-user-agent": "3.616.0",
+                "@aws-sdk/region-config-resolver": "3.614.0",
+                "@aws-sdk/types": "3.609.0",
+                "@aws-sdk/util-endpoints": "3.614.0",
+                "@aws-sdk/util-user-agent-browser": "3.609.0",
+                "@aws-sdk/util-user-agent-node": "3.614.0",
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/core": "^2.2.7",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/hash-node": "^3.0.3",
+                "@smithy/invalid-dependency": "^3.0.3",
+                "@smithy/middleware-content-length": "^3.0.4",
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.10",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.10",
+                "@smithy/util-defaults-mode-node": "^3.0.10",
+                "@smithy/util-endpoints": "^2.0.5",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/util-waiter": "^3.1.2",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "dependencies": {
+                "@aws-crypto/sha256-browser": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+                    "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-js": "^5.2.0",
+                        "@aws-crypto/supports-web-crypto": "^5.2.0",
+                        "@aws-crypto/util": "^5.2.0",
+                        "@aws-sdk/types": "^3.222.0",
+                        "@aws-sdk/util-locate-window": "^3.0.0",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.6.2"
+                    },
+                    "dependencies": {
+                        "@smithy/util-utf8": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                            "dev": true,
+                            "requires": {
+                                "@smithy/util-buffer-from": "^2.2.0",
+                                "tslib": "^2.6.2"
+                            }
+                        }
+                    }
+                },
+                "@aws-crypto/sha256-js": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+                    "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/util": "^5.2.0",
+                        "@aws-sdk/types": "^3.222.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-crypto/supports-web-crypto": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+                    "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-crypto/util": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+                    "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "^3.222.0",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.6.2"
+                    },
+                    "dependencies": {
+                        "@smithy/util-utf8": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                            "dev": true,
+                            "requires": {
+                                "@smithy/util-buffer-from": "^2.2.0",
+                                "tslib": "^2.6.2"
+                            }
+                        }
+                    }
+                },
+                "@aws-sdk/client-sso": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+                    "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/client-sso-oidc": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+                    "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/credential-provider-node": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/client-sts": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+                    "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "5.2.0",
+                        "@aws-crypto/sha256-js": "5.2.0",
+                        "@aws-sdk/client-sso-oidc": "3.616.0",
+                        "@aws-sdk/core": "3.616.0",
+                        "@aws-sdk/credential-provider-node": "3.616.0",
+                        "@aws-sdk/middleware-host-header": "3.616.0",
+                        "@aws-sdk/middleware-logger": "3.609.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+                        "@aws-sdk/middleware-user-agent": "3.616.0",
+                        "@aws-sdk/region-config-resolver": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@aws-sdk/util-user-agent-browser": "3.609.0",
+                        "@aws-sdk/util-user-agent-node": "3.614.0",
+                        "@smithy/config-resolver": "^3.0.5",
+                        "@smithy/core": "^2.2.7",
+                        "@smithy/fetch-http-handler": "^3.2.2",
+                        "@smithy/hash-node": "^3.0.3",
+                        "@smithy/invalid-dependency": "^3.0.3",
+                        "@smithy/middleware-content-length": "^3.0.4",
+                        "@smithy/middleware-endpoint": "^3.0.5",
+                        "@smithy/middleware-retry": "^3.0.10",
+                        "@smithy/middleware-serde": "^3.0.3",
+                        "@smithy/middleware-stack": "^3.0.3",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/node-http-handler": "^3.1.3",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/smithy-client": "^3.1.8",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/url-parser": "^3.0.3",
+                        "@smithy/util-base64": "^3.0.0",
+                        "@smithy/util-body-length-browser": "^3.0.0",
+                        "@smithy/util-body-length-node": "^3.0.0",
+                        "@smithy/util-defaults-mode-browser": "^3.0.10",
+                        "@smithy/util-defaults-mode-node": "^3.0.10",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "@smithy/util-middleware": "^3.0.3",
+                        "@smithy/util-retry": "^3.0.3",
+                        "@smithy/util-utf8": "^3.0.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-env": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+                    "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-ini": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+                    "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.609.0",
+                        "@aws-sdk/credential-provider-http": "3.616.0",
+                        "@aws-sdk/credential-provider-process": "3.614.0",
+                        "@aws-sdk/credential-provider-sso": "3.616.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/credential-provider-imds": "^3.1.4",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-node": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+                    "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.609.0",
+                        "@aws-sdk/credential-provider-http": "3.616.0",
+                        "@aws-sdk/credential-provider-ini": "3.616.0",
+                        "@aws-sdk/credential-provider-process": "3.614.0",
+                        "@aws-sdk/credential-provider-sso": "3.616.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/credential-provider-imds": "^3.1.4",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-process": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+                    "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-sso": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+                    "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/client-sso": "3.616.0",
+                        "@aws-sdk/token-providers": "3.614.0",
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-web-identity": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+                    "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-host-header": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+                    "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-logger": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+                    "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-recursion-detection": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+                    "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/middleware-user-agent": {
+                    "version": "3.616.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+                    "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@aws-sdk/util-endpoints": "3.614.0",
+                        "@smithy/protocol-http": "^4.0.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/token-providers": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+                    "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/property-provider": "^3.1.3",
+                        "@smithy/shared-ini-file-loader": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+                    "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-endpoints": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+                    "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "@smithy/util-endpoints": "^2.0.5",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-user-agent-browser": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+                    "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/types": "^3.3.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/util-user-agent-node": {
+                    "version": "3.614.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+                    "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+                    "dev": true,
+                    "requires": {
+                        "@aws-sdk/types": "3.609.0",
+                        "@smithy/node-config-provider": "^3.1.4",
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+                    "dev": true
+                }
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.431.0.tgz",
+            "integrity": "sha512-iK8RxdBHFj1HtWpdTVfFdljZHXLWFv62SuIdkDswGE7L0zNbZIqBDGfEBnbagiQuxkz5D2YtnasydC5R3BcwVw==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/region-config-resolver": "3.430.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/client-sso-oidc": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@aws-sdk/region-config-resolver": {
+                    "version": "3.430.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+                    "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.1.2",
+                        "@smithy/types": "^2.3.5",
+                        "@smithy/util-config-provider": "^2.0.0",
+                        "@smithy/util-middleware": "^2.0.4",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@smithy/abort-controller": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+                    "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/config-resolver": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+                    "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-config-provider": "^2.3.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/credential-provider-imds": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+                    "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/fetch-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/hash-node": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+                    "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/invalid-dependency": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+                    "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-content-length": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+                    "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-endpoint": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+                    "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+                    "requires": {
+                        "@smithy/middleware-serde": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-retry": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+                    "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "@smithy/util-retry": "^2.2.0",
+                        "tslib": "^2.6.2",
+                        "uuid": "^9.0.1"
+                    }
+                },
+                "@smithy/middleware-serde": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+                    "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-stack": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+                    "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+                    "requires": {
+                        "@smithy/abort-controller": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-builder": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+                    "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-uri-escape": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+                    "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/service-error-classification": {
+                    "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+                    "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/smithy-client": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+                    "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+                    "requires": {
+                        "@smithy/middleware-endpoint": "^2.5.1",
+                        "@smithy/middleware-stack": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-stream": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/url-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+                    "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+                    "requires": {
+                        "@smithy/querystring-parser": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-base64": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+                    "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-browser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+                    "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-node": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+                    "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-browser": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+                    "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-node": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+                    "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+                    "requires": {
+                        "@smithy/config-resolver": "^2.2.0",
+                        "@smithy/credential-provider-imds": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-hex-encoding": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+                    "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-middleware": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+                    "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-retry": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+                    "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+                    "requires": {
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-stream": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+                    "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+                    "requires": {
+                        "@smithy/fetch-http-handler": "^2.5.0",
+                        "@smithy/node-http-handler": "^2.5.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-hex-encoding": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-uri-escape": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+                    "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.431.0.tgz",
+            "integrity": "sha512-IM/Fg3H1WuM9fnVriEoM6+sZ9LNUExxklxAnHwjLnprPRTDGbUXUfYjSry52LaQsZffP3RgWP11CYyjCYC8CfQ==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-node": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-sdk-sts": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.357.0",
-                "@aws-sdk/util-defaults-mode-node": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
+                "@aws-sdk/credential-provider-node": "3.431.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-sdk-sts": "3.428.0",
+                "@aws-sdk/middleware-signing": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/region-config-resolver": "3.430.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@aws-sdk/region-config-resolver": {
+                    "version": "3.430.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.430.0.tgz",
+                    "integrity": "sha512-9lqgtkcd4dqsQ2yN6V/i06blyDh4yLmS+fAS7LwEZih/NZZ2cBIR+5kb9c236auvTcuMcL1zFxVRloWwesYZjA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.1.2",
+                        "@smithy/types": "^2.3.5",
+                        "@smithy/util-config-provider": "^2.0.0",
+                        "@smithy/util-middleware": "^2.0.4",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@smithy/abort-controller": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+                    "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/config-resolver": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+                    "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-config-provider": "^2.3.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/credential-provider-imds": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+                    "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/fetch-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/hash-node": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+                    "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/invalid-dependency": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+                    "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-content-length": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+                    "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-endpoint": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+                    "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+                    "requires": {
+                        "@smithy/middleware-serde": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-retry": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+                    "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "@smithy/util-retry": "^2.2.0",
+                        "tslib": "^2.6.2",
+                        "uuid": "^9.0.1"
+                    }
+                },
+                "@smithy/middleware-serde": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+                    "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-stack": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+                    "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+                    "requires": {
+                        "@smithy/abort-controller": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-builder": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+                    "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-uri-escape": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+                    "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/service-error-classification": {
+                    "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+                    "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/smithy-client": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+                    "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+                    "requires": {
+                        "@smithy/middleware-endpoint": "^2.5.1",
+                        "@smithy/middleware-stack": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-stream": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/url-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+                    "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+                    "requires": {
+                        "@smithy/querystring-parser": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-base64": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+                    "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-browser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+                    "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-node": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+                    "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-browser": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+                    "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-node": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+                    "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+                    "requires": {
+                        "@smithy/config-resolver": "^2.2.0",
+                        "@smithy/credential-provider-imds": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-hex-encoding": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+                    "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-middleware": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+                    "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-retry": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+                    "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+                    "requires": {
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-stream": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+                    "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+                    "requires": {
+                        "@smithy/fetch-http-handler": "^2.5.0",
+                        "@smithy/node-http-handler": "^2.5.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-hex-encoding": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-uri-escape": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+                    "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
             }
         },
-        "@aws-sdk/config-resolver": {
-            "version": "3.357.0",
+        "@aws-sdk/core": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+            "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "tslib": "^2.5.0"
+                "@smithy/core": "^2.2.7",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/signature-v4": "^4.0.0",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/credential-provider-env": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.428.0.tgz",
+            "integrity": "sha512-e6fbY174Idzw0r5ZMT1qkDh+dpOp1DX3ickhr7J6ipo3cUGLI45Y5lnR9nYXWfB5o/wiNv4zXgN+Y3ORJJHzyA==",
             "requires": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
-        "@aws-sdk/credential-provider-imds": {
-            "version": "3.357.0",
+        "@aws-sdk/credential-provider-http": {
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+            "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@aws-sdk/types": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+                    "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.431.0.tgz",
+            "integrity": "sha512-SILMZuscwxeqB4kuZjWiu24wfvmvN3Tx7/j5n0t0Ob+cdpweK0IqkBQ/QkTbTiG0M1l8trMtMkrTb5510fupcQ==",
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.357.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/credential-provider-env": "3.428.0",
+                "@aws-sdk/credential-provider-process": "3.428.0",
+                "@aws-sdk/credential-provider-sso": "3.431.0",
+                "@aws-sdk/credential-provider-web-identity": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/credential-provider-imds": "^2.0.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/credential-provider-imds": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+                    "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+                    "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/url-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+                    "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+                    "requires": {
+                        "@smithy/querystring-parser": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.431.0.tgz",
+            "integrity": "sha512-jj2gm92nfsFw5e48+7OCYM5PfiW3pd9FvhEoBfvKANwM6ztXzmNpQcz3iWsGVfzd+MUooVBoO2exhH9M8t+VDg==",
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-ini": "3.357.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.357.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/credential-provider-env": "3.428.0",
+                "@aws-sdk/credential-provider-ini": "3.431.0",
+                "@aws-sdk/credential-provider-process": "3.428.0",
+                "@aws-sdk/credential-provider-sso": "3.431.0",
+                "@aws-sdk/credential-provider-web-identity": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/credential-provider-imds": "^2.0.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/credential-provider-imds": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+                    "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+                    "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/url-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+                    "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+                    "requires": {
+                        "@smithy/querystring-parser": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/credential-provider-process": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.428.0.tgz",
+            "integrity": "sha512-UG2S2/4Wrskbkbgt9fBlnzwQ2hfTXvLJwUgGOluSOf6+mGCcoDku4zzc9EQdk1MwN5Us+ziyMrIMNY5sbdLg6g==",
             "requires": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.431.0.tgz",
+            "integrity": "sha512-fh/yWKJtgEpxfuzd/KTVPQz0FjykbiPnU0OLm1wKgNZAyKTE9EyNvWR6P57TWv/sU8faa5uLaxdD0TBPxWReDA==",
             "requires": {
-                "@aws-sdk/client-sso": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/token-providers": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/client-sso": "3.431.0",
+                "@aws-sdk/token-providers": "3.431.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/credential-provider-web-identity": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.428.0.tgz",
+            "integrity": "sha512-ueuUPPlrJFvtDUVTGnClUGt1wxCbEiKArknah/w9cfcc/c1HtFd/M7x/z2Sm0gSItR45sVcK54qjzmhm29DMzg==",
             "requires": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/eventstream-codec": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/fetch-http-handler": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/querystring-builder": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/hash-node": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/invalid-dependency": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/is-array-buffer": {
-            "version": "3.310.0",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/md5-js": {
-            "version": "3.357.0",
-            "dev": true,
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-content-length": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-endpoint": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/middleware-host-header": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.431.0.tgz",
+            "integrity": "sha512-j+OBsCDDRXlMEQ4GCtTxVaMwxIHNKiwbDIZVyB6CDor8AFflKxWbO3cPSpUuGKlUN9OEexMR+XgwsjmaI6AGwg==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/middleware-logger": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.428.0.tgz",
+            "integrity": "sha512-1P0V0quL9u2amdNOn6yYT7/ToQUmkLJqCKHPxsRyDB829vBThWndvvH5MkoItj/VgE1zWqMtrzN3xtzD7zx6Qg==",
             "requires": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/middleware-recursion-detection": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.428.0.tgz",
+            "integrity": "sha512-xC0OMduCByyRdiQz324RXy4kunnCG4LUJCfvdoegM33Elp9ex0D3fcfO1mUgV8qiLwSennIsSRVXHuhNxE2HZA==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-retry": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/service-error-classification": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
             }
         },
         "@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.357.0",
+            "version": "3.616.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.616.0.tgz",
+            "integrity": "sha512-r4Ogloy6Rg0cx0rccQ34fUuHRTvFE303U6RMuvOs31x+cRD8GZs6y/pN3hC065nvSOpNK04jV1IHARVd/sWj5g==",
             "dev": true,
             "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/smithy-client": "^3.1.8",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@aws-sdk/types": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+                    "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/middleware-sdk-sts": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.428.0.tgz",
+            "integrity": "sha512-Uutl2niYXTnNP8v84v6umWDHD5no7d5/OqkZE1DsmeKR/dje90J5unJWf7MOsqvYm0JGDEWF4lk9xGVyqsw+Aw==",
             "requires": {
-                "@aws-sdk/middleware-signing": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-serde": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/middleware-signing": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/middleware-signing": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.428.0.tgz",
+            "integrity": "sha512-oMSerTPwtsQAR7fIU/G0b0BA30wF+MC4gZSrJjbypF8MK8nPC2yMfKLR8+QavGOGEW7rUMQ0uklThMTTwQEXNQ==",
             "requires": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/signature-v4": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-middleware": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/signature-v4": "^2.0.0",
+                "@smithy/types": "^2.3.5",
+                "@smithy/util-middleware": "^2.0.4",
                 "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-stack": {
-            "version": "3.357.0",
-            "requires": {
-                "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/signature-v4": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
+                    "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-hex-encoding": "^2.2.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "@smithy/util-uri-escape": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-hex-encoding": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+                    "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-middleware": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+                    "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-uri-escape": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+                    "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/middleware-user-agent": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.428.0.tgz",
+            "integrity": "sha512-+GAhObeHRick2D5jr3YkPckjcggt5v6uUVtEUQW2AdD65cE5PjIvmksv6FuM/mME/9nNA+wufQnHbLI8teLeaw==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             }
         },
-        "@aws-sdk/node-config-provider": {
-            "version": "3.357.0",
+        "@aws-sdk/region-config-resolver": {
+            "version": "3.614.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+            "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/node-http-handler": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/abort-controller": "3.357.0",
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/querystring-builder": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/property-provider": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/protocol-http": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/querystring-builder": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-uri-escape": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/querystring-parser": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/service-error-classification": {
-            "version": "3.357.0"
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/signature-v4": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/eventstream-codec": "3.357.0",
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.357.0",
-                "@aws-sdk/util-uri-escape": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/smithy-client": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-stream": "3.357.0",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.609.0",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@aws-sdk/types": {
+                    "version": "3.609.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+                    "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.357.0",
+            "version": "3.431.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.431.0.tgz",
+            "integrity": "sha512-0ksZogF3Gy2i+yBb7T2g2e7QXzwZeQHmf09ihR1cwXwg7UIjsap6P3gPtC085bDkOD9iY8OdpL0Esp06N6xmCg==",
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/middleware-host-header": "3.431.0",
+                "@aws-sdk/middleware-logger": "3.428.0",
+                "@aws-sdk/middleware-recursion-detection": "3.428.0",
+                "@aws-sdk/middleware-user-agent": "3.428.0",
+                "@aws-sdk/types": "3.428.0",
+                "@aws-sdk/util-endpoints": "3.428.0",
+                "@aws-sdk/util-user-agent-browser": "3.428.0",
+                "@aws-sdk/util-user-agent-node": "3.430.0",
+                "@smithy/config-resolver": "^2.0.15",
+                "@smithy/fetch-http-handler": "^2.2.3",
+                "@smithy/hash-node": "^2.0.11",
+                "@smithy/invalid-dependency": "^2.0.11",
+                "@smithy/middleware-content-length": "^2.0.13",
+                "@smithy/middleware-endpoint": "^2.1.2",
+                "@smithy/middleware-retry": "^2.0.17",
+                "@smithy/middleware-serde": "^2.0.11",
+                "@smithy/middleware-stack": "^2.0.5",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/node-http-handler": "^2.1.7",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.7",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/smithy-client": "^2.1.11",
+                "@smithy/types": "^2.3.5",
+                "@smithy/url-parser": "^2.0.11",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.15",
+                "@smithy/util-defaults-mode-node": "^2.0.20",
+                "@smithy/util-retry": "^2.0.4",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/abort-controller": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+                    "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/config-resolver": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+                    "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-config-provider": "^2.3.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/credential-provider-imds": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+                    "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/fetch-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/hash-node": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+                    "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/invalid-dependency": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+                    "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-content-length": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+                    "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+                    "requires": {
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-endpoint": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+                    "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+                    "requires": {
+                        "@smithy/middleware-serde": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/url-parser": "^2.2.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-retry": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+                    "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+                    "requires": {
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-middleware": "^2.2.0",
+                        "@smithy/util-retry": "^2.2.0",
+                        "tslib": "^2.6.2",
+                        "uuid": "^9.0.1"
+                    }
+                },
+                "@smithy/middleware-serde": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+                    "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/middleware-stack": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+                    "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/node-http-handler": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+                    "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+                    "requires": {
+                        "@smithy/abort-controller": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/querystring-builder": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-builder": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+                    "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-uri-escape": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/querystring-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+                    "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/service-error-classification": {
+                    "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+                    "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/smithy-client": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+                    "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+                    "requires": {
+                        "@smithy/middleware-endpoint": "^2.5.1",
+                        "@smithy/middleware-stack": "^2.2.0",
+                        "@smithy/protocol-http": "^3.3.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-stream": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/url-parser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+                    "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+                    "requires": {
+                        "@smithy/querystring-parser": "^2.2.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-base64": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+                    "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-browser": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+                    "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-body-length-node": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+                    "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-browser": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+                    "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-defaults-mode-node": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+                    "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+                    "requires": {
+                        "@smithy/config-resolver": "^2.2.0",
+                        "@smithy/credential-provider-imds": "^2.3.0",
+                        "@smithy/node-config-provider": "^2.3.0",
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/smithy-client": "^2.5.1",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-hex-encoding": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+                    "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-middleware": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+                    "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-retry": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+                    "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+                    "requires": {
+                        "@smithy/service-error-classification": "^2.1.5",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-stream": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+                    "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+                    "requires": {
+                        "@smithy/fetch-http-handler": "^2.5.0",
+                        "@smithy/node-http-handler": "^2.5.0",
+                        "@smithy/types": "^2.12.0",
+                        "@smithy/util-base64": "^2.3.0",
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "@smithy/util-hex-encoding": "^2.2.0",
+                        "@smithy/util-utf8": "^2.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-uri-escape": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+                    "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
             }
         },
         "@aws-sdk/types": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.428.0.tgz",
+            "integrity": "sha512-4T0Ps2spjg3qbWE6ZK13Vd3FnzpfliaiotqjxUK5YhjDrKXeT36HJp46JhDupElQuHtTkpdiJOSYk2lvY2H4IA==",
             "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/url-parser": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/querystring-parser": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-base64": {
-            "version": "3.310.0",
-            "requires": {
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-body-length-browser": {
-            "version": "3.310.0",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-body-length-node": {
-            "version": "3.310.0",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-buffer-from": {
-            "version": "3.310.0",
-            "requires": {
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-config-provider": {
-            "version": "3.310.0",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.428.0.tgz",
+            "integrity": "sha512-ToKMhYlUWJ0YrbggpJLZeyZZNDXtQ4NITxqo/oeGltTT9KG4o/LqVY59EveV0f8P32ObDyj9Vh1mnjxeo3DxGw==",
             "requires": {
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-hex-encoding": {
-            "version": "3.310.0",
-            "requires": {
+                "@aws-sdk/types": "3.428.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -2045,96 +10101,926 @@
                 "tslib": "^2.5.0"
             }
         },
-        "@aws-sdk/util-middleware": {
-            "version": "3.357.0",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-retry": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/service-error-classification": "3.357.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-stream": {
-            "version": "3.357.0",
-            "requires": {
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-uri-escape": {
-            "version": "3.310.0",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
         "@aws-sdk/util-user-agent-browser": {
-            "version": "3.357.0",
+            "version": "3.428.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.428.0.tgz",
+            "integrity": "sha512-qlc2UoGsmCpuh1ErY3VayZuAGl74TWWcLmhhQMkeByFSb6KooBlwOmDpDzJRtgwJoe0KXnyHBO6lzl9iczcozg==",
             "requires": {
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/types": "^2.3.5",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "@aws-sdk/util-user-agent-node": {
-            "version": "3.357.0",
+            "version": "3.430.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.430.0.tgz",
+            "integrity": "sha512-DPpFPL3mFMPtipFxjY7TKQBjnhmsPzYCr4Y+qna0oR6ij8jZOz2ILQDK33GxTRNh3+bV9YYbx+ZGDOnxoK5Mhw==",
             "requires": {
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/types": "3.428.0",
+                "@smithy/node-config-provider": "^2.1.2",
+                "@smithy/types": "^2.3.5",
                 "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-utf8": {
-            "version": "3.310.0",
-            "requires": {
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@smithy/node-config-provider": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+                    "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+                    "requires": {
+                        "@smithy/property-provider": "^2.2.0",
+                        "@smithy/shared-ini-file-loader": "^2.4.0",
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/property-provider": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+                    "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/shared-ini-file-loader": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+                    "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+                    "requires": {
+                        "@smithy/types": "^2.12.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
             "requires": {
                 "tslib": "^2.3.1"
             }
         },
-        "@aws-sdk/util-waiter": {
-            "version": "3.357.0",
+        "@smithy/abort-controller": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+            "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
             "dev": true,
             "requires": {
-                "@aws-sdk/abort-controller": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/config-resolver": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+            "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+            "dev": true,
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/core": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
+            "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+            "dev": true,
+            "requires": {
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-retry": "^3.0.11",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/credential-provider-imds": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
+            "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/fetch-http-handler": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
+            "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+            "dev": true,
+            "requires": {
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/hash-node": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+            "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/invalid-dependency": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+            "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/md5-js": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
+            "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/middleware-content-length": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
+            "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+            "dev": true,
+            "requires": {
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/middleware-endpoint": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
+            "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+            "dev": true,
+            "requires": {
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/middleware-retry": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
+            "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+            "dev": true,
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+                    "dev": true
+                }
+            }
+        },
+        "@smithy/middleware-serde": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+            "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/middleware-stack": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+            "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/node-config-provider": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+            "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/node-http-handler": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
+            "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+            "dev": true,
+            "requires": {
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/property-provider": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+            "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@smithy/protocol-http": {
-            "version": "1.1.0",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+            "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
             "requires": {
-                "@smithy/types": "^1.1.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/querystring-builder": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+            "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/querystring-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+            "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/service-error-classification": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+            "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/shared-ini-file-loader": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+            "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/signature-v4": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
+            "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+            "dev": true,
+            "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/smithy-client": {
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
+            "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+            "dev": true,
+            "requires": {
+                "@smithy/middleware-endpoint": "^3.0.5",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.4",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.1.1",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/protocol-http": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
+                    "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@smithy/types": "^3.3.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@smithy/types": {
-            "version": "1.1.0",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+            "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
-        "@types/dotenv": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-            "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
+        "@smithy/url-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+            "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
             "dev": true,
             "requires": {
-                "dotenv": "*"
+                "@smithy/querystring-parser": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-base64": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "dev": true,
+            "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-config-provider": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+            "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-defaults-mode-browser": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
+            "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+            "dev": true,
+            "requires": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-defaults-mode-node": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
+            "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+            "dev": true,
+            "requires": {
+                "@smithy/config-resolver": "^3.0.5",
+                "@smithy/credential-provider-imds": "^3.1.4",
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.9",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-endpoints": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+            "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+            "dev": true,
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.4",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-middleware": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+            "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+            "dev": true,
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-retry": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+            "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+            "dev": true,
+            "requires": {
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-stream": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
+            "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+            "dev": true,
+            "requires": {
+                "@smithy/fetch-http-handler": "^3.2.2",
+                "@smithy/node-http-handler": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@smithy/util-uri-escape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "dev": true,
+            "requires": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-waiter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+            "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+            "dev": true,
+            "requires": {
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/types": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+                    "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@types/node": {
@@ -2147,37 +11033,26 @@
             "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
             "dev": true
         },
-        "@types/uuid": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-            "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
-            "dev": true
-        },
         "bowser": {
             "version": "2.11.0"
         },
-        "di-stub-oauth-client": {
-            "version": "git+ssh://git@github.com/alphagov/di-stub-oauth-client.git#2c2af7fdf678e7f6c7093c1c7fb8496d2cfdb8fd",
-            "from": "di-stub-oauth-client@git+ssh://git@github.com:alphagov/di-stub-oauth-client#main",
+        "dotenv": {
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "requires": {
-                "@aws-sdk/client-kms": "3.357.0",
-                "jose": "4.11.1",
-                "uuid": "9.0.0"
-            },
-            "dependencies": {
-                "uuid": {
-                    "version": "9.0.0"
-                }
+                "safe-buffer": "^5.0.1"
             }
         },
-        "dotenv": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-            "dev": true
-        },
         "fast-xml-parser": {
-            "version": "4.2.4",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -2185,14 +11060,58 @@
         "jose": {
             "version": "4.11.1"
         },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
         "strnum": {
             "version": "1.0.5"
         },
+        "stub-oauth-client": {
+            "version": "git+ssh://git@github.com/govuk-one-login/stub-oauth-client.git#1b9d980fd6df8162df6002140e715c39d085080a",
+            "from": "stub-oauth-client@git+ssh://git@github.com:govuk-one-login/stub-oauth-client#main",
+            "requires": {
+                "@aws-sdk/client-kms": "3.431.0",
+                "@types/uuid": "9.0.0",
+                "dotenv": "16.0.3",
+                "ecdsa-sig-formatter": "1.0.11",
+                "jose": "4.11.1",
+                "uuidv4": "6.2.13"
+            },
+            "dependencies": {
+                "@types/uuid": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+                    "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q=="
+                }
+            }
+        },
         "tslib": {
-            "version": "2.5.3"
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "uuid": {
-            "version": "8.3.2"
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "uuidv4": {
+            "version": "6.2.13",
+            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+            "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+            "requires": {
+                "@types/uuid": "8.3.4",
+                "uuid": "8.3.2"
+            },
+            "dependencies": {
+                "@types/uuid": {
+                    "version": "8.3.4",
+                    "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+                    "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+                }
+            }
         }
     }
 }

--- a/di-ipv-queue-stub/enqueue-event/package.json
+++ b/di-ipv-queue-stub/enqueue-event/package.json
@@ -4,13 +4,13 @@
     "version": "0.0.1",
     "private": true,
     "devDependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.357.0",
-        "@aws-sdk/client-sqs": "^3.357.0",
-        "@aws-sdk/client-ssm": "^3.357.0",
+        "@aws-sdk/client-secrets-manager": "^3.616.0",
+        "@aws-sdk/client-sqs": "^3.616.0",
+        "@aws-sdk/client-ssm": "^3.616.0",
         "@types/node": "^20.2.5",
         "@types/uuid": "^9.0.2"
     },
     "dependencies": {
-        "di-stub-oauth-client": "git+ssh://git@github.com:alphagov/di-stub-oauth-client#main"
+        "stub-oauth-client": "git+ssh://git@github.com:govuk-one-login/stub-oauth-client#main"
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Upgrade awssdk and stub-oauth-client

### Why did it change

The older version of the awssdk were pulling in an old version of fast-xml-parser which had a vulnerability.

The stub-oauth-client lib dependencies were also using the old version. The lib has already been updated upstream, so just running npm install has brought in the newer version. This changes the git address to the new GitHub org from alphagov - the repo has been migrated.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/7

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7097](https://govukverify.atlassian.net/browse/PYIC-7097)


[PYIC-7097]: https://govukverify.atlassian.net/browse/PYIC-7097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ