### PR TITLE
BAU: Remove Gson from orch-stub

### DIFF
--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
 			"com.nimbusds:oauth2-oidc-sdk:11.13",
-			"com.google.code.gson:gson:2.11.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"org.slf4j:slf4j-simple:2.0.13",
 			"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -1,9 +1,7 @@
 package uk.gov.di.ipv.stub.orc.handlers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -378,9 +376,8 @@ public class IpvHandler {
     }
 
     private List<Map<String, Object>> buildUserInfoMustacheData(JSONObject credentials)
-            throws ParseException, JsonSyntaxException, java.text.ParseException {
+            throws java.text.ParseException, JsonProcessingException {
         List<Map<String, Object>> moustacheDataModel = new ArrayList<>();
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         List<String> vcJwts = (List<String>) credentials.get(CREDENTIALS_URL_PROPERTY);
 
@@ -390,10 +387,8 @@ public class IpvHandler {
             JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
             Map<String, Object> claims = claimsSet.toJSONObject();
 
-            String json = gson.toJson(claims);
-
             Map<String, Object> criMap = new HashMap<>();
-            criMap.put("VC", json);
+            criMap.put("VC", OBJECT_MAPPER.writeValueAsString(claims));
             criMap.put("criType", claims.get("iss"));
             moustacheDataModel.add(criMap);
         }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove Gson from orch-stub

### Why did it change

We were creating a new instance of Gson on every callback request. Rather than doing this, we can just use the ObjectMapper we already have.

This was the only use of Gson in orch-stub, so we can also remove the dependency.
