### PR TITLE
PYIC-7104: Bump jetty-webapp to resolve vulnerability

### DIFF
--- a/di-ipv-core-stub/build.gradle
+++ b/di-ipv-core-stub/build.gradle
@@ -23,7 +23,8 @@ dependencies {
 			"org.yaml:snakeyaml:2.2",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2",
-			"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+			"org.eclipse.jetty:jetty-server:9.4.55.v20240627", // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+			"org.eclipse.jetty:jetty-webapp:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -24,7 +24,8 @@ dependencies {
 			"com.google.code.gson:gson:2.11.0",
 			"org.slf4j:slf4j-simple:2.0.13",
 			"software.amazon.awssdk:ssm:2.26.21",
-			"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+			"org.eclipse.jetty:jetty-server:9.4.55.v20240627", // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+			"org.eclipse.jetty:jetty-webapp:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26
 
 	compileOnly 'org.projectlombok:lombok:1.18.32'
 	annotationProcessor 'org.projectlombok:lombok:1.18.32'

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -21,7 +21,8 @@ dependencies {
 			"com.google.code.gson:gson:2.11.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"org.slf4j:slf4j-simple:2.0.13",
-			"org.eclipse.jetty:jetty-server:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+			"org.eclipse.jetty:jetty-server:9.4.55.v20240627", // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+			"org.eclipse.jetty:jetty-webapp:9.4.55.v20240627" // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }

--- a/experian-fraud-stub/build.gradle
+++ b/experian-fraud-stub/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
 	implementation 'org.apache.commons:commons-lang3:3.15.0'
 	implementation 'org.eclipse.jetty:jetty-server:9.4.55.v20240627' // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+	implementation 'org.eclipse.jetty:jetty-webapp:9.4.55.v20240627' // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }

--- a/experian-kbv-stub/build.gradle
+++ b/experian-kbv-stub/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	implementation 'org.slf4j:slf4j-simple:2.0.13'
 	implementation group: 'com.sun.xml.messaging.saaj', name: 'saaj-impl', version: '1.5.0'
 	implementation 'org.eclipse.jetty:jetty-server:9.4.55.v20240627' // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/24
+	implementation 'org.eclipse.jetty:jetty-webapp:9.4.55.v20240627' // https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bump jetty-webapp to resolve vulnerability

### Why did it change

The version of jetty-webapp brought in by spark depended on an old version of jetty-xml, which had a vulnerability.

This bumps jetty-webapp which brings in a patched version of jetty-xml.

https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7104](https://govukverify.atlassian.net/browse/PYIC-7104)


[PYIC-7104]: https://govukverify.atlassian.net/browse/PYIC-7104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ