### PR TITLE
BAU: Fix cimit stub logging

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
+			"org.apache.logging.log4j:log4j-layout-template-json:2.23.1",
 			project(":di-ipv-cimit-stub:lib")
 
 	compileOnly "org.projectlombok:lombok:1.18.32"

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/resources/IpvLambdaJsonLayout.json
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/src/main/resources/IpvLambdaJsonLayout.json
@@ -81,8 +81,5 @@
       "$resolver": "source",
       "field": "lineNumber"
     }
-  },
-  "": {
-    "$resolver": "powertools"
   }
 }

--- a/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
+			"org.apache.logging.log4j:log4j-layout-template-json:2.23.1",
 			project(":di-ipv-cimit-stub:lib")
 
 	compileOnly "org.projectlombok:lombok:1.18.32"

--- a/di-ipv-cimit-stub/lambdas/post-mitigations/src/main/resources/IpvLambdaJsonLayout.json
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/src/main/resources/IpvLambdaJsonLayout.json
@@ -81,8 +81,5 @@
       "$resolver": "source",
       "field": "lineNumber"
     }
-  },
-  "": {
-    "$resolver": "powertools"
   }
 }

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-annotations:2.17.2",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
+			"org.apache.logging.log4j:log4j-layout-template-json:2.23.1",
 			"com.nimbusds:oauth2-oidc-sdk:11.13",
 			project(":di-ipv-cimit-stub:lib")
 

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/resources/IpvLambdaJsonLayout.json
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/resources/IpvLambdaJsonLayout.json
@@ -81,8 +81,5 @@
       "$resolver": "source",
       "field": "lineNumber"
     }
-  },
-  "": {
-    "$resolver": "powertools"
   }
 }

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-annotations:2.17.2",
 			"org.apache.logging.log4j:log4j-api:2.23.0",
 			"org.apache.logging.log4j:log4j-core:2.23.1",
+			"org.apache.logging.log4j:log4j-layout-template-json:2.23.1",
 			project(":di-ipv-cimit-stub:lib")
 
 	compileOnly "org.projectlombok:lombok:1.18.32"

--- a/di-ipv-cimit-stub/lambdas/stub-management/src/main/resources/IpvLambdaJsonLayout.json
+++ b/di-ipv-cimit-stub/lambdas/stub-management/src/main/resources/IpvLambdaJsonLayout.json
@@ -81,8 +81,5 @@
       "$resolver": "source",
       "field": "lineNumber"
     }
-  },
-  "": {
-    "$resolver": "powertools"
   }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix cimit stub logging

### Why did it change

A previous commit removed the use of powertools for logging. I wasn't thorough enough though and logging is broken.

The log4j-layout-template-json lambda needs adding - powertools must have been bringing it in.

We also need to remove the powertool resolver from the logging config, otherwise it blows up.
