### PR TITLE
OJ-2746: Fix issue caused by nimbus library update

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -204,6 +204,8 @@ public class HandlerHelper {
         HTTPRequest userInfoRequest =
                 new HTTPRequest(HTTPRequest.Method.POST, credentialIssuer.credentialUrl());
 
+        userInfoRequest.setHeader("Content-Type", "");
+
         String apiKey =
                 CoreStubConfig.getConfigValue(credentialIssuer.apiKeyEnvVar(), UNKNOWN_ENV_VAR);
         if (!apiKey.equals(UNKNOWN_ENV_VAR)) {


### PR DESCRIPTION
This is a quick fix

We get this error on Check-hmrc stub

![image](https://github.com/user-attachments/assets/6f156f9b-ec45-4612-9da0-587dec77d2ef)

Core stub nimubs library was recently updated, it was sending request to issue/credential endpoint for check-hmrc as Content-type=application/x-www-form-urlencoded. as result we get an http 415 error. i.e. unsupported media type

Related issue see here: https://gds.slack.com/archives/C02PYH8AKLN/p1711631482054049

