### PR TITLE
PYIC-7174 dequeue from queue-stub

### DIFF
--- a/di-ipv-queue-stub/deploy/template.yaml
+++ b/di-ipv-queue-stub/deploy/template.yaml
@@ -288,12 +288,10 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
+                - "arn:aws:iam::130355686670:root" # Dev01 account id
+                - "arn:aws:iam::175872367215:root" # Dev02 account id
                 - "arn:aws:iam::457601271792:root" # Build account id
-                - "arn:aws:iam::130355686670:root" # OldDev account id
-                - "arn:aws:iam::175872367215:root" # Dev account id
                 - "arn:aws:iam::335257547869:root" # Staging account id
-                - "arn:aws:iam::991138514218:root" # Integration account id
-                - "arn:aws:iam::075701497069:root" # Prod account id
             Action:
               - "kms:Decrypt"
             Resource: "*"

--- a/di-ipv-queue-stub/deploy/template.yaml
+++ b/di-ipv-queue-stub/deploy/template.yaml
@@ -65,7 +65,6 @@ Resources:
   EnqueueEventLambda:
     Type: AWS::Serverless::Function
     # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
-
     Properties:
       CodeUri: "../enqueue-event/src/handlers"
       Handler: enqueueEvent.handler
@@ -93,7 +92,7 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
         SecurityGroupIds:
-          - !GetAtt EnqueueEventLambdaSecurityGroup.GroupId
+          - !GetAtt QueueStubLambdaSecurityGroup.GroupId
       Policies:
         - VPCAccessPolicy: { }
         - Statement:
@@ -133,7 +132,6 @@ Resources:
                 "ForAnyValue:StringLike":
                   "kms:ResourceAliases":
                     - "alias/sqs/QueuesKmsKey"
-
     Metadata:
       # Manage esbuild properties
       BuildMethod: esbuild
@@ -144,11 +142,91 @@ Resources:
         EntryPoints:
           - enqueueEvent.ts
 
-  EnqueueEventLambdaSecurityGroup:
+  DequeueEventLambda:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    Properties:
+      CodeUri: "../enqueue-event/src/handlers"
+      Handler: dequeueEvent.handler
+      Runtime: nodejs20.x
+      Architectures:
+        - arm64
+      KmsKeyArn: !GetAtt LambdaKmsKey.Arn
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          QUEUE_KMS_KEY_ID: "alias/sqs/QueuesKmsKey"
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /queues/{queueName}
+            Method: get
+            RestApiId:
+              Ref: EnqueueEventApi
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt QueueStubLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - Statement:
+            - Sid: EnforceStayinSpecificVpc
+              Effect: Allow
+              Action:
+                - 'lambda:CreateFunction'
+                - 'lambda:UpdateFunctionConfiguration'
+              Resource:
+                - "*"
+              Condition:
+                StringEquals:
+                  "lambda:VpcIds":
+                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+        - Statement:
+            - Sid: AllowSQS
+              Effect: Allow
+              Action:
+                - "sqs:SendMessage"
+                - "sqs:ReceiveMessage"
+                - "sqs:DeleteMessage"
+                - "sqs:GetQueueAttributes"
+                - "sqs:GetQueueUrl"
+                - "sqs:CreateQueue"
+                - "sqs:AddPermission"
+              Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:stubQueue_*
+        - Statement:
+            - Sid: AllowKMS
+              Effect: Allow
+              Action:
+                - "kms:Decrypt"
+                - "kms:GenerateDataKey*"
+                - "kms:DescribeKey"
+              Resource:
+                - !Sub "arn:aws:kms:eu-west-2:${AWS::AccountId}:key/*"
+              Condition:
+                "ForAnyValue:StringLike":
+                  "kms:ResourceAliases":
+                    - "alias/sqs/QueuesKmsKey"
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - dequeueEvent.ts
+
+  QueueStubLambdaSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: >-
-        EnqueueEvent Lambda Security Group
+        Queue stub Lambda Security Group
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           Description: Allow egress HTTPS traffic to vpc cidr from port 443

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/dequeueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/dequeueEvent.ts
@@ -15,5 +15,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event, context) => {
 
   const message = await dequeueEvent(queueUrl, waitTime);
 
-  return jsonResponse(200, { message });
+  if (message) {
+    return jsonResponse(200, message);
+  } else {
+    return { statusCode: 204 };
+  }
 };

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/dequeueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/dequeueEvent.ts
@@ -1,0 +1,19 @@
+import { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { dequeueEvent, getOrCreateSqsQueueUrl } from "../services/queueService";
+import { jsonResponse } from "../services/responseService";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event, context) => {
+  const accountId = context.invokedFunctionArn.split(":")[4];
+  const queueName = event.pathParameters?.["queueName"];
+  const waitTime = event.queryStringParameters?.["waitTime"];
+
+  if (!queueName?.startsWith("stubQueue_")) {
+    return jsonResponse(400, { errorMessage: "Queue name must start with 'stubQueue_'" });
+  }
+
+  const queueUrl = await getOrCreateSqsQueueUrl(accountId, queueName);
+
+  const message = await dequeueEvent(queueUrl, waitTime);
+
+  return jsonResponse(200, { message });
+};

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
@@ -1,12 +1,6 @@
 import { APIGatewayProxyHandlerV2 } from "aws-lambda";
-import {
-    AddPermissionCommand,
-    CreateQueueCommand,
-    GetQueueUrlCommand,
-    SendMessageCommand,
-    SQSClient,
-    QueueDoesNotExist,
-} from "@aws-sdk/client-sqs";
+import { enqeueEvent, getOrCreateSqsQueueUrl } from "../services/queueService";
+import { jsonResponse } from "../services/responseService";
 
 interface EnqueueEventPayload {
     queueName: string;
@@ -14,92 +8,20 @@ interface EnqueueEventPayload {
     delaySeconds: string;
 }
 
-const sqsClient = new SQSClient({ region: "eu-west-2" });
-
-const getOrCreateSqsQueueUrl = async (accountId: string, queueName: string): Promise<string> => {
-    try {
-        const queueUrlResponse = await sqsClient.send(new GetQueueUrlCommand({
-            QueueName: queueName,
-        }));
-        console.info(`Queue already exists ${queueName}`);
-        return queueUrlResponse.QueueUrl!;
-    } catch (error) {
-        if (error instanceof QueueDoesNotExist) {
-            console.info(`Creating queue ${queueName}`);
-
-            // Create the queue if it does not exist
-            const redrivePolicy = {
-                deadLetterTargetArn: `arn:aws:sqs:eu-west-2:${accountId}:stubQueue_F2FDLQ`,
-                maxReceiveCount: "1"
-            };
-            const createQueueResponse = await sqsClient.send(new CreateQueueCommand({
-                QueueName: queueName,
-                Attributes: {
-                    KmsMasterKeyId: "alias/sqs/QueuesKmsKey",
-                    RedrivePolicy: JSON.stringify(redrivePolicy),
-                    VisibilityTimeout: "360"
-                }
-            }));
-
-            console.info(`Created queue ${queueName}`);
-
-            // Add permissions to consume the queue from IPV Core accounts
-            await sqsClient.send(new AddPermissionCommand({
-                QueueUrl: createQueueResponse.QueueUrl,
-                Label: "add read and delete from dev, build, staging, prod perms",
-                AWSAccountIds: [
-                    "457601271792",
-                    "130355686670",
-                    "175872367215",
-                    "335257547869",
-                    "991138514218",
-                    "075701497069"
-                ],
-                Actions: [
-                    "ReceiveMessage",
-                    "DeleteMessage",
-                    "GetQueueAttributes"
-                ]
-            }));
-
-            console.info("Attached permissions");
-
-            return createQueueResponse.QueueUrl!;
-        }
-        throw error;
-    }
-};
-
-const enqeueEvent = async (enqueueEventPayload: EnqueueEventPayload, queueUrl: string): Promise<void> => {
-    console.info(`Sending message to ${queueUrl}`);
-    await sqsClient.send(new SendMessageCommand({
-        QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(enqueueEventPayload.queueEvent),
-        DelaySeconds: parseInt(enqueueEventPayload.delaySeconds || "0"),
-    }));
-};
-
 export const handler: APIGatewayProxyHandlerV2 = async (event, context) => {
     const accountId = context.invokedFunctionArn.split(":")[4];
     const enqueueEventPayload = JSON.parse(event.body!) as EnqueueEventPayload;
 
     if (!enqueueEventPayload.queueName?.startsWith("stubQueue_")) {
-        throw new Error("Queue name must start 'stubQueue_'");
+        return jsonResponse(400, { errorMessage: "Queue name must start with 'stubQueue_'" });
     }
 
     const queueUrl = await getOrCreateSqsQueueUrl(accountId, enqueueEventPayload.queueName);
 
     await enqeueEvent(enqueueEventPayload, queueUrl);
 
-    return {
-        "statusCode": 200,
-        "headers": {
-            "Content-Type": "application/json"
-        },
-        "isBase64Encoded": false,
-        "body": JSON.stringify({
-            status: "enqeueued",
-            queueArn: `arn:aws:sqs:eu-west-2:${accountId}:${enqueueEventPayload.queueName}`
-        }),
-    };
+    return jsonResponse(200, {
+        status: "enqeueued",
+        queueArn: `arn:aws:sqs:eu-west-2:${accountId}:${enqueueEventPayload.queueName}`
+    });
 };

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyHandlerV2 } from "aws-lambda";
-import { enqeueEvent, getOrCreateSqsQueueUrl } from "../services/queueService";
+import { enqueueEvent, getOrCreateSqsQueueUrl } from "../services/queueService";
 import { jsonResponse } from "../services/responseService";
 
 interface EnqueueEventPayload {
@@ -18,7 +18,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event, context) => {
 
     const queueUrl = await getOrCreateSqsQueueUrl(accountId, enqueueEventPayload.queueName);
 
-    await enqeueEvent(enqueueEventPayload, queueUrl);
+    await enqueueEvent(enqueueEventPayload, queueUrl);
 
     return jsonResponse(200, {
         status: "enqeueued",

--- a/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
@@ -1,0 +1,117 @@
+import {
+  AddPermissionCommand,
+  CreateQueueCommand,
+  DeleteMessageCommand,
+  GetQueueUrlCommand,
+  Message,
+  QueueDoesNotExist,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+
+const sqsClient = new SQSClient({ region: "eu-west-2" });
+
+export const getOrCreateSqsQueueUrl = async (
+  accountId: string,
+  queueName: string,
+): Promise<string> => {
+    try {
+        const queueUrlResponse = await sqsClient.send(new GetQueueUrlCommand({
+            QueueName: queueName,
+        }));
+        console.info(`Queue already exists ${queueName}`);
+        return queueUrlResponse.QueueUrl!;
+    } catch (error) {
+        if (error instanceof QueueDoesNotExist) {
+            console.info(`Creating queue ${queueName}`);
+
+            // Create the queue if it does not exist
+            const redrivePolicy = {
+                deadLetterTargetArn: `arn:aws:sqs:eu-west-2:${accountId}:stubQueue_F2FDLQ`,
+                maxReceiveCount: "1"
+            };
+            const createQueueResponse = await sqsClient.send(new CreateQueueCommand({
+                QueueName: queueName,
+                Attributes: {
+                    KmsMasterKeyId: "alias/sqs/QueuesKmsKey",
+                    RedrivePolicy: JSON.stringify(redrivePolicy),
+                    VisibilityTimeout: "360"
+                }
+            }));
+
+            console.info(`Created queue ${queueName}`);
+
+            // Add permissions to consume the queue from IPV Core accounts
+            await sqsClient.send(new AddPermissionCommand({
+                QueueUrl: createQueueResponse.QueueUrl,
+                Label: "add read and delete from dev, build, staging, prod perms",
+                AWSAccountIds: [
+                    "457601271792",
+                    "130355686670",
+                    "175872367215",
+                    "335257547869",
+                    "991138514218",
+                    "075701497069"
+                ],
+                Actions: [
+                    "ReceiveMessage",
+                    "DeleteMessage",
+                    "GetQueueAttributes"
+                ]
+            }));
+
+            console.info("Attached permissions");
+
+            return createQueueResponse.QueueUrl!;
+        }
+        throw error;
+    }
+};
+
+export const enqeueEvent = async (
+  event: object,
+  queueUrl: string,
+  delaySeconds?: string,
+): Promise<void> => {
+    console.info(`Sending message to ${queueUrl}`);
+    await sqsClient.send(new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify(event),
+        DelaySeconds: parseInt(delaySeconds || "0"),
+    }));
+};
+
+export const dequeueEvent = async (
+  queueUrl: string,
+  waitTime?: string,
+): Promise<unknown | null> => {
+  console.info(`Retrieving from ${queueUrl}`);
+  const response = await sqsClient.send(new ReceiveMessageCommand({
+    QueueUrl: queueUrl,
+    WaitTimeSeconds: waitTime ? parseInt(waitTime) : undefined,
+  }));
+
+  if (response.Messages?.length) {
+    console.info("Received message");
+    const message = response.Messages[0];
+
+    // Ordinarily this should be done separately
+    // to indicate that a message has been successfully processed
+    // but for a stub it's ok to consume immediately
+    await sqsClient.send(new DeleteMessageCommand({
+      QueueUrl: queueUrl,
+      ReceiptHandle: message.ReceiptHandle,
+    }));
+
+    try {
+      return JSON.parse(message.Body!);
+    } catch (err) {
+      console.error(`Message contains invalid JSON: ${message.Body}`);
+      throw err;
+    }
+  } else {
+    console.info("No messages");
+    return null;
+  }
+};

--- a/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
@@ -47,12 +47,10 @@ export const getOrCreateSqsQueueUrl = async (
                 QueueUrl: createQueueResponse.QueueUrl,
                 Label: "add read and delete from dev, build, staging, prod perms",
                 AWSAccountIds: [
-                    "457601271792",
-                    "130355686670",
-                    "175872367215",
-                    "335257547869",
-                    "991138514218",
-                    "075701497069"
+                    "130355686670", // Dev01 account id
+                    "175872367215", // Dev02 account id
+                    "457601271792", // Build account id
+                    "335257547869", // Staging account id
                 ],
                 Actions: [
                     "ReceiveMessage",
@@ -69,7 +67,7 @@ export const getOrCreateSqsQueueUrl = async (
     }
 };
 
-export const enqeueEvent = async (
+export const enqueueEvent = async (
   event: object,
   queueUrl: string,
   delaySeconds?: string,

--- a/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
@@ -85,7 +85,7 @@ export const enqeueEvent = async (
 export const dequeueEvent = async (
   queueUrl: string,
   waitTime?: string,
-): Promise<unknown | null> => {
+): Promise<Message | null> => {
   console.info(`Retrieving from ${queueUrl}`);
   const response = await sqsClient.send(new ReceiveMessageCommand({
     QueueUrl: queueUrl,
@@ -104,12 +104,7 @@ export const dequeueEvent = async (
       ReceiptHandle: message.ReceiptHandle,
     }));
 
-    try {
-      return JSON.parse(message.Body!);
-    } catch (err) {
-      console.error(`Message contains invalid JSON: ${message.Body}`);
-      throw err;
-    }
+    return message;
   } else {
     console.info("No messages");
     return null;

--- a/di-ipv-queue-stub/enqueue-event/src/services/responseService.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/services/responseService.ts
@@ -1,0 +1,13 @@
+import { APIGatewayProxyResultV2 } from "aws-lambda";
+
+export const jsonResponse = (
+  statusCode: number,
+  body: object,
+): APIGatewayProxyResultV2 => ({
+  statusCode,
+  headers: {
+      "Content-Type": "application/json"
+  },
+  isBase64Encoded: false,
+  body: JSON.stringify(body),
+});


### PR DESCRIPTION
## Proposed changes

### What changed

Added dequeue capability to queue-stub

### Why did it change

Local-running cannot consume the SQS queues directly (which would require AWS permissions), so we want to provide an interface to consume them instead.

### Issue tracking

- [PYIC-7174](https://govukverify.atlassian.net/browse/PYIC-7174)


[PYIC-7174]: https://govukverify.atlassian.net/browse/PYIC-7174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ