### PR TITLE
PYIC-7109 Respect delaySeconds and allow it to be overriden in CRI stub

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -61,13 +61,10 @@ public class CredentialIssuer {
                         validator,
                         clientJwtVerifier,
                         requestedErrorResponseService);
-        credentialHandler = new CredentialHandler(credentialService, tokenService, vcGenerator);
+        credentialHandler = new CredentialHandler(credentialService, tokenService);
         docAppCredentialHandler =
                 new DocAppCredentialHandler(
-                        credentialService,
-                        tokenService,
-                        vcGenerator,
-                        requestedErrorResponseService);
+                        credentialService, tokenService, requestedErrorResponseService);
         jwksHandler = new JwksHandler();
         f2fHandler = new F2FHandler(credentialService, tokenService);
         healthCheckHandler = new HealthCheckHandler();

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2fDetails.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2fDetails.java
@@ -6,13 +6,15 @@ import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.F2F_SEND_ER
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.F2F_SEND_VC_QUEUE;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.F2F_STUB_QUEUE_NAME;
 
-public record F2fDetails(boolean sendVcToQueue, boolean sendErrorToQueue, String queueName) {
+public record F2fDetails(
+        boolean sendVcToQueue, boolean sendErrorToQueue, String queueName, Integer delaySeconds) {
     private static final String CHECKED = "checked";
 
     public static F2fDetails fromQueryMap(QueryParamsMap paramsMap) {
         return new F2fDetails(
                 CHECKED.equals(paramsMap.value(F2F_SEND_VC_QUEUE)),
                 CHECKED.equals(paramsMap.value(F2F_SEND_ERROR_QUEUE)),
-                paramsMap.value(F2F_STUB_QUEUE_NAME));
+                paramsMap.value(F2F_STUB_QUEUE_NAME),
+                null);
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -64,6 +64,7 @@ import java.util.UUID;
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static com.nimbusds.oauth2.sdk.util.CollectionUtils.isEmpty;
 import static com.nimbusds.oauth2.sdk.util.StringUtils.isBlank;
+import static java.util.Objects.requireNonNullElse;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.EVIDENCE_TXN_PARAM;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.F2F_STUB_QUEUE_NAME_DEFAULT;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getConfigValue;
@@ -113,6 +114,7 @@ public class AuthorizeHandler {
     private static final String F2F_STUB_QUEUE_URL = "F2F_STUB_QUEUE_URL";
     private static final String F2F_STUB_QUEUE_API_KEY =
             "F2F_STUB_QUEUE_API_KEY"; // pragma: allowlist secret
+    private static final int F2F_DEFAULT_DELAY_SECONDS = 10;
     private static final String X_API_KEY = "x-api-key"; // pragma: allowlist secret
 
     private static final List<CriType> NO_SHARED_ATTRIBUTES_CRI_TYPES =
@@ -855,7 +857,8 @@ public class AuthorizeHandler {
                     new F2FEnqueueLambdaRequest(
                             f2fDetails.queueName(),
                             new F2FQueueEvent(userId, state, List.of(signedVcJwt)),
-                            10);
+                            requireNonNullElse(
+                                    f2fDetails.delaySeconds(), F2F_DEFAULT_DELAY_SECONDS));
 
             HttpRequest request =
                     HttpRequest.newBuilder()
@@ -882,7 +885,8 @@ public class AuthorizeHandler {
                             f2fDetails.queueName(),
                             new F2FQueueErrorEvent(
                                     userId, state, "access_denied", "Something went wrong"),
-                            10);
+                            requireNonNullElse(
+                                    f2fDetails.delaySeconds(), F2F_DEFAULT_DELAY_SECONDS));
 
             HttpRequest request =
                     HttpRequest.newBuilder()

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
@@ -7,7 +7,6 @@ import spark.Route;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
-import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -17,15 +16,10 @@ public class CredentialHandler {
 
     private CredentialService credentialService;
     private TokenService tokenService;
-    private VerifiableCredentialGenerator verifiableCredentialGenerator;
 
-    public CredentialHandler(
-            CredentialService credentialService,
-            TokenService tokenService,
-            VerifiableCredentialGenerator verifiableCredentialGenerator) {
+    public CredentialHandler(CredentialService credentialService, TokenService tokenService) {
         this.credentialService = credentialService;
         this.tokenService = tokenService;
-        this.verifiableCredentialGenerator = verifiableCredentialGenerator;
     }
 
     public Route getResource =

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
@@ -5,8 +5,6 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.eclipse.jetty.http.HttpHeader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -14,7 +12,6 @@ import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
-import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -23,22 +20,18 @@ import java.util.UUID;
 
 public class DocAppCredentialHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CredentialHandler.class);
     private static final String JSON_RESPONSE_TYPE = "application/json;charset=UTF-8";
     private CredentialService credentialService;
     private TokenService tokenService;
-    private VerifiableCredentialGenerator verifiableCredentialGenerator;
 
     private RequestedErrorResponseService requestedErrorResponseService;
 
     public DocAppCredentialHandler(
             CredentialService credentialService,
             TokenService tokenService,
-            VerifiableCredentialGenerator verifiableCredentialGenerator,
             RequestedErrorResponseService requestedErrorResponseService) {
         this.credentialService = credentialService;
         this.tokenService = tokenService;
-        this.verifiableCredentialGenerator = verifiableCredentialGenerator;
         this.requestedErrorResponseService = requestedErrorResponseService;
     }
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandler.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 public class F2FHandler {
 
     private static final String JSON_RESPONSE_TYPE = "application/json;charset=UTF-8";
+
     private TokenService tokenService;
     private CredentialService credentialService;
 
@@ -27,6 +28,7 @@ public class F2FHandler {
     public Route getResource =
             (Request request, Response response) -> {
                 String accessTokenString = request.headers(HttpHeader.AUTHORIZATION.toString());
+
                 ValidationResult validationResult =
                         tokenService.validateAccessToken(accessTokenString);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
@@ -14,7 +14,6 @@ import spark.Response;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
-import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -35,16 +34,13 @@ public class CredentialHandlerTest {
     @Mock private Request mockRequest;
     @Mock private CredentialService mockCredentialService;
     @Mock private TokenService mockTokenService;
-    @Mock private VerifiableCredentialGenerator mockVerifiableCredentialGenerator;
     private CredentialHandler resourceHandler;
     private AccessToken accessToken;
 
     @BeforeEach
     void setup() {
         accessToken = new BearerAccessToken();
-        resourceHandler =
-                new CredentialHandler(
-                        mockCredentialService, mockTokenService, mockVerifiableCredentialGenerator);
+        resourceHandler = new CredentialHandler(mockCredentialService, mockTokenService);
     }
 
     @Test

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
-import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -45,7 +44,6 @@ public class DocAppCredentialHandlerTest {
     @Mock private Request mockRequest;
     @Mock private CredentialService mockCredentialService;
     @Mock private TokenService mockTokenService;
-    @Mock private VerifiableCredentialGenerator mockVerifiableCredentialGenerator;
     @Mock private RequestedErrorResponseService mockRequestedErrorResponseService;
     private DocAppCredentialHandler resourceHandler;
     private AccessToken accessToken;
@@ -55,10 +53,7 @@ public class DocAppCredentialHandlerTest {
         accessToken = new BearerAccessToken();
         resourceHandler =
                 new DocAppCredentialHandler(
-                        mockCredentialService,
-                        mockTokenService,
-                        mockVerifiableCredentialGenerator,
-                        mockRequestedErrorResponseService);
+                        mockCredentialService, mockTokenService, mockRequestedErrorResponseService);
     }
 
     @Test

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/enqueueEvent.ts
@@ -18,10 +18,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event, context) => {
 
     const queueUrl = await getOrCreateSqsQueueUrl(accountId, enqueueEventPayload.queueName);
 
-    await enqueueEvent(enqueueEventPayload.queueEvent, queueUrl);
+    await enqueueEvent(
+        enqueueEventPayload.queueEvent,
+        queueUrl,
+        enqueueEventPayload.delaySeconds);
 
     return jsonResponse(200, {
-        status: "enqeueued",
+        status: "enqueued",
         queueArn: `arn:aws:sqs:eu-west-2:${accountId}:${enqueueEventPayload.queueName}`
     });
 };


### PR DESCRIPTION
## Proposed changes

### What changed

The `delaySeconds` got lost in the queue-stub refactor

Also added the ability for the delay to be overriden when using the API version of the CRI stub (e.g. for API tests).

### Why did it change

To fix behaviour and allow API tests to run more quickly
