### PR TITLE
PYIC-7175 Clean up branch queues

### DIFF
--- a/di-ipv-queue-stub/deploy/template.yaml
+++ b/di-ipv-queue-stub/deploy/template.yaml
@@ -340,6 +340,63 @@ Resources:
           CreateUsagePlan: PER_API
           UsagePlanName: "Queue Stub Usage Plan"
 
+  CleanQueuesLambda:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    Properties:
+      CodeUri: "../enqueue-event/src/handlers"
+      Handler: cleanQueues.handler
+      Runtime: nodejs20.x
+      Architectures:
+        - arm64
+      KmsKeyArn: !GetAtt LambdaKmsKey.Arn
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Events:
+        ScheduledEvent:
+          Type: Schedule
+          Properties:
+            # run 3am every day
+            Schedule: cron(0 3 * * ? *)
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt QueueStubLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - Statement:
+            - Sid: EnforceStayinSpecificVpc
+              Effect: Allow
+              Action:
+                - 'lambda:CreateFunction'
+                - 'lambda:UpdateFunctionConfiguration'
+              Resource:
+                - "*"
+              Condition:
+                StringEquals:
+                  "lambda:VpcIds":
+                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+        - Statement:
+            - Sid: AllowSQS
+              Effect: Allow
+              Action:
+                - "sqs:ListQueues"
+                - "sqs:DeleteQueue"
+              Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:stubQueue_*
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - cleanQueues.ts
+
 Outputs:
   ApiGatewayUrl:
     Description: The API URL to post the event data

--- a/di-ipv-queue-stub/enqueue-event/src/handlers/cleanQueues.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/handlers/cleanQueues.ts
@@ -1,0 +1,11 @@
+import { EventBridgeHandler } from "aws-lambda";
+import { deleteQueue, findBranchQueues } from "../services/queueService";
+
+export const handler: EventBridgeHandler<"Scheduled", {}, void> = async () => {
+  const queues = await findBranchQueues();
+  console.info(`Found ${queues.length} queues`);
+  for (const queueUrl in queues) {
+    await deleteQueue(queueUrl);
+    console.log(`Deleted ${queueUrl}`);
+  }
+};

--- a/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
@@ -2,7 +2,9 @@ import {
   AddPermissionCommand,
   CreateQueueCommand,
   DeleteMessageCommand,
+  DeleteQueueCommand,
   GetQueueUrlCommand,
+  ListQueuesCommand,
   Message,
   QueueDoesNotExist,
   ReceiveMessageCommand,
@@ -108,3 +110,17 @@ export const dequeueEvent = async (
     return null;
   }
 };
+
+export const findBranchQueues = async (): Promise<string[]> => {
+  const result = await sqsClient.send(new ListQueuesCommand({
+    QueueNamePrefix: "stubQueue_branch_",
+  }));
+
+  return result.QueueUrls ?? [];
+}
+
+export const deleteQueue = async (queueUrl: string): Promise<void> => {
+  await sqsClient.send(new DeleteQueueCommand({
+    QueueUrl: queueUrl,
+  }));
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Run a lambda on a cron schedule to delete branch-specific stub queues

### Why did it change

Once we start creating queues on-demand for every branch, we need a way to clean these up to avoid an endless proliferation of queues.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7175](https://govukverify.atlassian.net/browse/PYIC-7175)


[PYIC-7175]: https://govukverify.atlassian.net/browse/PYIC-7175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ