### PR TITLE
PYIC-7175 Tweak permissions

### DIFF
--- a/di-ipv-queue-stub/deploy/template.yaml
+++ b/di-ipv-queue-stub/deploy/template.yaml
@@ -381,10 +381,14 @@ Resources:
                   "lambda:VpcIds":
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - Statement:
-            - Sid: AllowSQS
+            - Sid: ListQueues
               Effect: Allow
               Action:
                 - "sqs:ListQueues"
+              Resource: "*"
+            - Sid: DeleteStubQueues
+              Effect: Allow
+              Action:
                 - "sqs:DeleteQueue"
               Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:stubQueue_*
     Metadata:


### PR DESCRIPTION
The ListQueues action cannot be restricted by prefix, so separate the list queues from delete