### PR TITLE
PYIC-7140 Token request uses form params not query params

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifier.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifier.java
@@ -33,10 +33,10 @@ public class ClientJwtVerifier {
 
     public void authenticateClient(Context ctx) throws ClientAuthenticationException {
 
-        Map<String, List<String>> queryParams = ctx.queryParamMap();
+        Map<String, List<String>> formParams = ctx.formParamMap();
         PrivateKeyJWT authenticationJwt;
         try {
-            authenticationJwt = PrivateKeyJWT.parse(queryParams);
+            authenticationJwt = PrivateKeyJWT.parse(formParams);
         } catch (ParseException e) {
             throw new ClientAuthenticationException(e);
         }
@@ -59,7 +59,7 @@ public class ClientJwtVerifier {
             if (es256SignatureVerifier.signatureIsDerFormat(
                     authenticationJwt.getClientAssertion())) {
                 concatSignatureAuthJwt =
-                        transcodeSignatureToConcatFormat(authenticationJwt, queryParams);
+                        transcodeSignatureToConcatFormat(authenticationJwt, formParams);
             } else {
                 concatSignatureAuthJwt = authenticationJwt;
             }
@@ -73,12 +73,12 @@ public class ClientJwtVerifier {
     }
 
     private PrivateKeyJWT transcodeSignatureToConcatFormat(
-            PrivateKeyJWT authJwt, Map<String, List<String>> queryParams)
+            PrivateKeyJWT authJwt, Map<String, List<String>> formParams)
             throws java.text.ParseException, JOSEException, ParseException {
         SignedJWT transcodedSignedJwt =
                 es256SignatureVerifier.transcodeSignature(authJwt.getClientAssertion());
-        queryParams.put(CLIENT_ASSERTION_PARAM, List.of(transcodedSignedJwt.serialize()));
-        return PrivateKeyJWT.parse(queryParams);
+        formParams.put(CLIENT_ASSERTION_PARAM, List.of(transcodedSignedJwt.serialize()));
+        return PrivateKeyJWT.parse(formParams);
     }
 
     private ClientAuthenticationVerifier<Object> getPopulatedClientAuthVerifier() {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
@@ -51,7 +51,7 @@ public class TokenHandler {
 
     public void issueAccessToken(Context ctx) {
         TokenErrorResponse requestedTokenErrorResponse =
-                handleRequestedError(ctx.queryParam(RequestParamConstants.AUTH_CODE));
+                handleRequestedError(ctx.formParam(RequestParamConstants.AUTH_CODE));
         if (requestedTokenErrorResponse != null) {
             ctx.status(HttpStatus.BAD_REQUEST_400);
             ctx.json(requestedTokenErrorResponse.toJSONObject());
@@ -67,7 +67,7 @@ public class TokenHandler {
         }
 
         if (getCriType().equals(CriType.DOC_CHECK_APP_CRI_TYPE)
-                || Validator.isNullBlankOrEmpty(ctx.queryParam(RequestParamConstants.CLIENT_ID))) {
+                || Validator.isNullBlankOrEmpty(ctx.formParam(RequestParamConstants.CLIENT_ID))) {
             try {
                 clientJwtVerifier.authenticateClient(ctx);
             } catch (ClientAuthenticationException e) {
@@ -81,7 +81,7 @@ public class TokenHandler {
 
         } else {
             ClientConfig clientConfig =
-                    ConfigService.getClientConfig(ctx.queryParam(RequestParamConstants.CLIENT_ID));
+                    ConfigService.getClientConfig(ctx.formParam(RequestParamConstants.CLIENT_ID));
             String authMethod = clientConfig.getJwtAuthentication().getAuthenticationMethod();
             if (!authMethod.equals(NONE_AUTHENTICATION_METHOD)) {
                 TokenErrorResponse errorResponse =
@@ -92,11 +92,11 @@ public class TokenHandler {
             }
         }
 
-        String code = ctx.queryParam(RequestParamConstants.AUTH_CODE);
+        String code = ctx.formParam(RequestParamConstants.AUTH_CODE);
         var redirectValidationResult =
                 validator.validateRedirectUrlsMatch(
                         authCodeService.getRedirectUrl(code),
-                        ctx.queryParam(RequestParamConstants.REDIRECT_URI));
+                        ctx.formParam(RequestParamConstants.REDIRECT_URI));
 
         if (!redirectValidationResult.isValid()) {
             TokenErrorResponse errorResponse =

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -162,9 +162,9 @@ public class Validator {
     }
 
     public ValidationResult validateTokenRequest(Context ctx) {
-        String clientIdValue = ctx.queryParam(RequestParamConstants.CLIENT_ID);
-        String assertionType = ctx.queryParam(RequestParamConstants.CLIENT_ASSERTION_TYPE);
-        String assertion = ctx.queryParam(RequestParamConstants.CLIENT_ASSERTION);
+        String clientIdValue = ctx.formParam(RequestParamConstants.CLIENT_ID);
+        String assertionType = ctx.formParam(RequestParamConstants.CLIENT_ASSERTION_TYPE);
+        String assertion = ctx.formParam(RequestParamConstants.CLIENT_ASSERTION);
 
         if (Validator.isNullBlankOrEmpty(clientIdValue)
                 && (Validator.isNullBlankOrEmpty(assertionType)
@@ -179,13 +179,13 @@ public class Validator {
             return new ValidationResult(false, OAuth2Error.INVALID_CLIENT);
         }
 
-        String grantTypeValue = ctx.queryParam(RequestParamConstants.GRANT_TYPE);
+        String grantTypeValue = ctx.formParam(RequestParamConstants.GRANT_TYPE);
         if (Validator.isNullBlankOrEmpty(grantTypeValue)
                 || !grantTypeValue.equalsIgnoreCase(GrantType.AUTHORIZATION_CODE.getValue())) {
             return new ValidationResult(false, OAuth2Error.UNSUPPORTED_GRANT_TYPE);
         }
 
-        String authCodeValue = ctx.queryParam(RequestParamConstants.AUTH_CODE);
+        String authCodeValue = ctx.formParam(RequestParamConstants.AUTH_CODE);
         if (Validator.isNullBlankOrEmpty(authCodeValue)) {
             LOGGER.error("Missing authorization code");
             return new ValidationResult(false, OAuth2Error.INVALID_GRANT);
@@ -195,7 +195,7 @@ public class Validator {
             return new ValidationResult(false, OAuth2Error.INVALID_GRANT);
         }
 
-        String redirectUriValue = ctx.queryParam(RequestParamConstants.REDIRECT_URI);
+        String redirectUriValue = ctx.formParam(RequestParamConstants.REDIRECT_URI);
         if (Validator.isNullBlankOrEmpty(redirectUriValue)) {
             LOGGER.error("Invalid Redirect URI: {}", redirectUriValue);
             return new ValidationResult(false, OAuth2Error.INVALID_REQUEST);

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifierTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/auth/ClientJwtVerifierTest.java
@@ -72,9 +72,9 @@ public class ClientJwtVerifierTest {
     void itShouldNotThrowForValidJwt()
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         var validQueryParams =
-                getValidQueryParams(generateClientAssertion(getValidClaimsSetValues()));
+                getValidFormParams(generateClientAssertion(getValidClaimsSetValues()));
 
-        when(mockContext.queryParamMap()).thenReturn(validQueryParams);
+        when(mockContext.formParamMap()).thenReturn(validQueryParams);
 
         assertDoesNotThrow(() -> jwtAuthenticationService.authenticateClient(mockContext));
     }
@@ -87,9 +87,9 @@ public class ClientJwtVerifierTest {
                 Base64URL.encode(ECDSA.transcodeSignatureToDER(signedJwt.getSignature().decode()));
         SignedJWT derSignatureJwt =
                 SignedJWT.parse(String.format("%s.%s.%s", jwtParts[0], jwtParts[1], derSignature));
-        var validQueryParams = getValidQueryParams(derSignatureJwt.serialize());
+        var validQueryParams = getValidFormParams(derSignatureJwt.serialize());
 
-        when(mockContext.queryParamMap()).thenReturn(validQueryParams);
+        when(mockContext.formParamMap()).thenReturn(validQueryParams);
 
         assertDoesNotThrow(() -> jwtAuthenticationService.authenticateClient(mockContext));
     }
@@ -98,12 +98,12 @@ public class ClientJwtVerifierTest {
     void itShouldThrowIfInvalidSignature() throws Exception {
         var invalidSignatureQueryParams =
                 new HashMap<>(
-                        getValidQueryParams(generateClientAssertion(getValidClaimsSetValues())));
+                        getValidFormParams(generateClientAssertion(getValidClaimsSetValues())));
         String client_assertion = invalidSignatureQueryParams.get("client_assertion").get(0);
         String badSignatureAssertion =
                 client_assertion.substring(0, client_assertion.length() - 4) + "nope";
         invalidSignatureQueryParams.put("client_assertion", List.of(badSignatureAssertion));
-        when(mockContext.queryParamMap()).thenReturn(invalidSignatureQueryParams);
+        when(mockContext.formParamMap()).thenReturn(invalidSignatureQueryParams);
 
         ClientAuthenticationException exception =
                 assertThrows(
@@ -119,9 +119,9 @@ public class ClientJwtVerifierTest {
         differentIssuerAndSubjectClaimsSetValues.put(
                 JWTClaimNames.ISSUER, "NOT_THE_SAME_AS_SUBJECT");
         var differentIssuerAndSubjectQueryParams =
-                getValidQueryParams(
+                getValidFormParams(
                         generateClientAssertion(differentIssuerAndSubjectClaimsSetValues));
-        when(mockContext.queryParamMap()).thenReturn(differentIssuerAndSubjectQueryParams);
+        when(mockContext.formParamMap()).thenReturn(differentIssuerAndSubjectQueryParams);
 
         ClientAuthenticationException exception =
                 assertThrows(
@@ -144,9 +144,9 @@ public class ClientJwtVerifierTest {
         wrongIssuerAndSubjectClaimsSetValues.put(
                 JWTClaimNames.SUBJECT, "THIS_BECOMES_THE_CLIENT_ID");
         var wrongIssuerAndSubjectQueryParams =
-                getValidQueryParams(generateClientAssertion(wrongIssuerAndSubjectClaimsSetValues));
+                getValidFormParams(generateClientAssertion(wrongIssuerAndSubjectClaimsSetValues));
 
-        when(mockContext.queryParamMap()).thenReturn(wrongIssuerAndSubjectQueryParams);
+        when(mockContext.formParamMap()).thenReturn(wrongIssuerAndSubjectQueryParams);
 
         ClientAuthenticationException exception =
                 assertThrows(
@@ -165,9 +165,9 @@ public class ClientJwtVerifierTest {
         wrongAudienceClaimsSetValues.put(
                 JWTClaimNames.AUDIENCE, "NOT_THE_AUDIENCE_YOU_ARE_LOOKING_FOR");
         var wrongAudienceQueryParams =
-                getValidQueryParams(generateClientAssertion(wrongAudienceClaimsSetValues));
+                getValidFormParams(generateClientAssertion(wrongAudienceClaimsSetValues));
 
-        when(mockContext.queryParamMap()).thenReturn(wrongAudienceQueryParams);
+        when(mockContext.formParamMap()).thenReturn(wrongAudienceQueryParams);
 
         ClientAuthenticationException exception =
                 assertThrows(
@@ -189,9 +189,9 @@ public class ClientJwtVerifierTest {
                 JWTClaimNames.EXPIRATION_TIME,
                 new Date(new Date().getTime() - 61000).getTime() / 1000);
         var expiredQueryParams =
-                getValidQueryParams(generateClientAssertion(expiredClaimsSetValues));
+                getValidFormParams(generateClientAssertion(expiredClaimsSetValues));
 
-        when(mockContext.queryParamMap()).thenReturn(expiredQueryParams);
+        when(mockContext.formParamMap()).thenReturn(expiredQueryParams);
 
         ClientAuthenticationException exception =
                 assertThrows(
@@ -201,7 +201,7 @@ public class ClientJwtVerifierTest {
         assertTrue(exception.getMessage().contains("Expired JWT"));
     }
 
-    private Map<String, List<String>> getValidQueryParams(String clientAssertion) {
+    private Map<String, List<String>> getValidFormParams(String clientAssertion) {
         return new HashMap<>(
                 Map.of(
                         "client_assertion",

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -90,7 +90,7 @@ public class TokenHandlerTest {
             throws Exception {
         String resourceId = UUID.randomUUID().toString();
 
-        setupMockQueryParams(
+        setupMockFormParams(
                 Map.of(
                         RequestParamConstants.GRANT_TYPE, GrantType.AUTHORIZATION_CODE.getValue(),
                         RequestParamConstants.CLIENT_ASSERTION, "a-client-assertion",
@@ -129,7 +129,7 @@ public class TokenHandlerTest {
         // authentication
         String resourceId = UUID.randomUUID().toString();
 
-        setupMockQueryParams(
+        setupMockFormParams(
                 Map.of(
                         RequestParamConstants.GRANT_TYPE,
                         GrantType.AUTHORIZATION_CODE.getValue(),
@@ -201,7 +201,7 @@ public class TokenHandlerTest {
 
     @Test
     void shouldReturn400IfClientConfigureForAuthenticationProvidesClientId() throws Exception {
-        setupMockQueryParams(Map.of(RequestParamConstants.CLIENT_ID, "clientIdValid"));
+        setupMockFormParams(Map.of(RequestParamConstants.CLIENT_ID, "clientIdValid"));
         when(mockValidator.validateTokenRequest(any()))
                 .thenReturn(ValidationResult.createValidResult());
 
@@ -218,7 +218,7 @@ public class TokenHandlerTest {
 
     @Test
     void shouldReturn400ResponseWhenRedirectUrlsDoNotMatch() throws Exception {
-        setupMockQueryParams(Map.of(RequestParamConstants.CLIENT_ID, "noAuthenticationClient"));
+        setupMockFormParams(Map.of(RequestParamConstants.CLIENT_ID, "noAuthenticationClient"));
 
         when(mockValidator.validateTokenRequest(any()))
                 .thenReturn(ValidationResult.createValidResult());
@@ -238,7 +238,7 @@ public class TokenHandlerTest {
 
     @Test
     void shouldReturn400WithRequestedOAuthError() throws Exception {
-        setupMockQueryParams(
+        setupMockFormParams(
                 Map.of(
                         RequestParamConstants.AUTH_CODE, "anAuthCode",
                         RequestParamConstants.REQUESTED_OAUTH_ERROR, "access_denied",
@@ -259,7 +259,7 @@ public class TokenHandlerTest {
         assertEquals("an error description", resultCaptor.getValue().get("error_description"));
     }
 
-    private void setupMockQueryParams(Map<String, String> params) {
-        params.forEach((key, value) -> when(mockContext.queryParam(key)).thenReturn(value));
+    private void setupMockFormParams(Map<String, String> params) {
+        params.forEach((key, value) -> when(mockContext.formParam(key)).thenReturn(value));
     }
 }

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
@@ -180,7 +180,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoClientIdAndNoClientAssertion() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "some-assertion-type",
@@ -198,7 +198,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoClientIdAndNoClientAssertionType() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "",
@@ -216,7 +216,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoClientIdAndNoClientAssertionTypeOrClientAssertion() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "",
@@ -234,7 +234,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoClientIdAndNoClientConfig() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "No-config-for-me",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -252,7 +252,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoGrantType() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "clientIdValid",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -271,7 +271,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoWrongType() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "clientIdValid",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -290,7 +290,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoAuthCode() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "clientIdValid",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -310,7 +310,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoPayloadAssociatedWithAuthCode() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "clientIdValid",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -331,7 +331,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldFailIfNoRedirectUri() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "clientIdValid",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -353,7 +353,7 @@ class ValidatorTest {
 
     @Test
     void validateTokenRequestShouldPassForValidParams() {
-        setupQueryParamsMap(
+        setupFormParamsMap(
                 Map.of(
                         RequestParamConstants.CLIENT_ID, "clientIdValid",
                         RequestParamConstants.CLIENT_ASSERTION_TYPE, "a-client-assertion-type",
@@ -438,7 +438,7 @@ class ValidatorTest {
         assertEquals("Invalid grant", validationError.getDescription());
     }
 
-    private void setupQueryParamsMap(Map<String, String> params) {
-        params.forEach((key, value) -> when(mockContext.queryParam(key)).thenReturn(value));
+    private void setupFormParamsMap(Map<String, String> params) {
+        params.forEach((key, value) -> when(mockContext.formParam(key)).thenReturn(value));
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

The token request uses form params from a POST, not query params

### Why did it change

Spark apparently munged all the params together?
