### PR TITLE
PYIC-7198: Add response delay option to TICF stub

### DIFF
--- a/di-ipv-ticf-stub/README.md
+++ b/di-ipv-ticf-stub/README.md
@@ -99,6 +99,16 @@ The format of the POST request to the API gateway should look like
 }
 ```
 
+2) To force the ticf stub to wait before returning a response to core (to simulate slow requests),
+the request can include a `responseDelay`property - the delay in seconds.
+```
+{
+    "type": "RiskAssessment",
+    "txn": "uuid",
+    "responseDelay": 3
+}
+```
+
 Response
 ```
 {

--- a/di-ipv-ticf-stub/lambdas/.eslintrc.js
+++ b/di-ipv-ticf-stub/lambdas/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   rules: {
     "no-console": 0,
     "@typescript-eslint/no-explicit-any": ["error"],
-    '@typescript-eslint/no-var-requires': 0,
+    "@typescript-eslint/no-var-requires": 0,
     "padding-line-between-statements": [
       "error",
       { blankLine: "any", prev: "*", next: "*" },

--- a/di-ipv-ticf-stub/lambdas/package-lock.json
+++ b/di-ipv-ticf-stub/lambdas/package-lock.json
@@ -29,6 +29,7 @@
         "@typescript-eslint/parser": "^6.12.0",
         "eslint": "^8.54.0",
         "jest": "^29.7.0",
+        "prettier": "^3.3.3",
         "typescript": "^5.3.2"
       }
     },
@@ -14491,6 +14492,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -26610,6 +26626,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true
     },
     "pretty-format": {

--- a/di-ipv-ticf-stub/lambdas/package.json
+++ b/di-ipv-ticf-stub/lambdas/package.json
@@ -20,12 +20,13 @@
     "@shelf/jest-dynamodb": "^3.4.2",
     "@types/aws-lambda": "^8.10.109",
     "@types/jest": "^29.5.10",
+    "@types/node": "^20.11.20",
     "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
-    "@types/node": "^20.11.20",
     "@typescript-eslint/parser": "^6.12.0",
     "eslint": "^8.54.0",
     "jest": "^29.7.0",
+    "prettier": "^3.3.3",
     "typescript": "^5.3.2"
   },
   "scripts": {

--- a/di-ipv-ticf-stub/lambdas/src/common/apiResponses.ts
+++ b/di-ipv-ticf-stub/lambdas/src/common/apiResponses.ts
@@ -2,7 +2,7 @@ import { APIGatewayProxyResultV2 } from "aws-lambda";
 
 export function buildApiResponse(
   body: object,
-  statusCode: number = 200
+  statusCode: number = 200,
 ): APIGatewayProxyResultV2 {
   return {
     statusCode,

--- a/di-ipv-ticf-stub/lambdas/src/domain/ticfManagementRequest.ts
+++ b/di-ipv-ticf-stub/lambdas/src/domain/ticfManagementRequest.ts
@@ -1,0 +1,6 @@
+export default interface TicfManagementRequest {
+  type?: string;
+  ci?: string[];
+  txn?: string;
+  responseDelay?: number;
+}

--- a/di-ipv-ticf-stub/lambdas/src/handlers/ticfHandler.ts
+++ b/di-ipv-ticf-stub/lambdas/src/handlers/ticfHandler.ts
@@ -4,7 +4,7 @@ import TicfRequest from "../domain/ticfRequest";
 import { processGetVCRequest } from "../services/ticfService";
 
 export async function handler(
-  event: APIGatewayProxyEventV2
+  event: APIGatewayProxyEventV2,
 ): Promise<APIGatewayProxyResultV2> {
   let ticfRequest;
   try {

--- a/di-ipv-ticf-stub/lambdas/src/management/model/userEvidenceItem.ts
+++ b/di-ipv-ticf-stub/lambdas/src/management/model/userEvidenceItem.ts
@@ -5,4 +5,5 @@ export default interface UserEvidenceItem {
   evidence: TicfEvidenceItem;
   statusCode: number;
   ttl: number;
+  responseDelay: number;
 }

--- a/di-ipv-ticf-stub/lambdas/src/services/signingService.ts
+++ b/di-ipv-ticf-stub/lambdas/src/services/signingService.ts
@@ -2,11 +2,11 @@ import { JWTPayload, SignJWT, importPKCS8 } from "jose";
 
 export async function signJwt(
   payload: JWTPayload,
-  signingKey: string
+  signingKey: string,
 ): Promise<string> {
   const key = await importPKCS8(
     `-----BEGIN PRIVATE KEY-----\n${signingKey}\n-----END PRIVATE KEY-----`,
-    "ES256"
+    "ES256",
   );
 
   return new SignJWT(payload)

--- a/di-ipv-ticf-stub/lambdas/test/ticfHandler.test.ts
+++ b/di-ipv-ticf-stub/lambdas/test/ticfHandler.test.ts
@@ -47,7 +47,7 @@ const TEST_EVENT = {
 async function parseTicfVc(jwt: string): Promise<TicfVc> {
   const key = await importSPKI(
     `-----BEGIN PUBLIC KEY-----\n${EC_PUBLIC_KEY}\n-----END PUBLIC KEY-----`,
-    "ES256"
+    "ES256",
   );
   return (await jwtVerify(jwt, key)).payload as TicfVc;
 }
@@ -64,7 +64,7 @@ describe("TICF handler", function () {
 
     // act
     const result = (await handler(
-      TEST_EVENT
+      TEST_EVENT,
     )) as APIGatewayProxyStructuredResultV2;
 
     // assert
@@ -76,14 +76,14 @@ describe("TICF handler", function () {
     expect(response.vtm).toEqual(TEST_REQUEST.vtm);
     expect(response.sub).toEqual(TEST_REQUEST.sub);
     expect(response.govuk_signin_journey_id).toEqual(
-      TEST_REQUEST.govuk_signin_journey_id
+      TEST_REQUEST.govuk_signin_journey_id,
     );
     expect(
-      response["https://vocab.account.gov.uk/v1/credentialJWT"]
+      response["https://vocab.account.gov.uk/v1/credentialJWT"],
     ).toHaveLength(1);
 
     const ticfVc = await parseTicfVc(
-      response["https://vocab.account.gov.uk/v1/credentialJWT"][0]
+      response["https://vocab.account.gov.uk/v1/credentialJWT"][0],
     );
     expect(ticfVc.iss).toEqual(TEST_COMPONENT_ID);
     expect(ticfVc.sub).toEqual(TEST_REQUEST.sub);
@@ -116,11 +116,12 @@ describe("TICF handler", function () {
       },
       statusCode: 200,
       ttl: 3123123,
+      responseDelay: 0,
     };
     jest.mocked(getUserEvidence).mockResolvedValue(userEvidence);
     // act
     const result = (await handler(
-      TEST_EVENT
+      TEST_EVENT,
     )) as APIGatewayProxyStructuredResultV2;
 
     // assert
@@ -128,7 +129,7 @@ describe("TICF handler", function () {
 
     const response = JSON.parse(result.body!) as TicfResponse;
     const ticfVc = await parseTicfVc(
-      response["https://vocab.account.gov.uk/v1/credentialJWT"][0]
+      response["https://vocab.account.gov.uk/v1/credentialJWT"][0],
     );
     expect(ticfVc.vc.evidence).toHaveLength(1);
     expect(ticfVc.vc.evidence[0].type).toEqual("RiskAssessment");
@@ -147,7 +148,7 @@ describe("TICF handler", function () {
     jest.mocked(getUserEvidence).mockResolvedValue(null);
     // act
     const result = (await handler(
-      TEST_EVENT
+      TEST_EVENT,
     )) as APIGatewayProxyStructuredResultV2;
 
     // assert
@@ -155,7 +156,7 @@ describe("TICF handler", function () {
 
     const response = JSON.parse(result.body!) as TicfResponse;
     const ticfVc = await parseTicfVc(
-      response["https://vocab.account.gov.uk/v1/credentialJWT"][0]
+      response["https://vocab.account.gov.uk/v1/credentialJWT"][0],
     );
     expect(ticfVc.vc.evidence).toHaveLength(1);
     expect(ticfVc.vc.evidence[0].type).toEqual("RiskAssessment");
@@ -174,7 +175,7 @@ describe("TICF handler", function () {
     jest.mocked(getUserEvidence).mockResolvedValue(null);
     // act
     const result = (await handler(
-      TEST_EVENT
+      TEST_EVENT,
     )) as APIGatewayProxyStructuredResultV2;
 
     // assert
@@ -182,7 +183,7 @@ describe("TICF handler", function () {
 
     const response = JSON.parse(result.body!) as TicfResponse;
     const ticfVc = await parseTicfVc(
-      response["https://vocab.account.gov.uk/v1/credentialJWT"][0]
+      response["https://vocab.account.gov.uk/v1/credentialJWT"][0],
     );
     expect(ticfVc.vc.evidence).toHaveLength(1);
     expect(ticfVc.vc.evidence[0].type).toEqual("RiskAssessment");
@@ -240,7 +241,7 @@ describe("TICF handler", function () {
 
     // act
     const result = (await handler(
-      TEST_EVENT
+      TEST_EVENT,
     )) as APIGatewayProxyStructuredResultV2;
 
     // assert

--- a/di-ipv-ticf-stub/openAPI/ticf-external.yaml
+++ b/di-ipv-ticf-stub/openAPI/ticf-external.yaml
@@ -68,7 +68,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserEvidenceRequestBody"
+              $ref: "#/components/schemas/TicfManagementRequestBody"
       responses:
         200:
           description: "Success response "
@@ -109,7 +109,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserEvidenceRequestBody"
+              $ref: "#/components/schemas/TicfManagementRequestBody"
       responses:
         200:
           description: "Success response "
@@ -160,7 +160,7 @@ components:
           items:
             type: string
           description: An array of VC's from CRI's
-    UserEvidenceRequestBody:
+    TicfManagementRequestBody:
       description: Request body for Ticf management
       type: object
       properties:
@@ -171,8 +171,11 @@ components:
           type: array
           items:
             type: string
-          desxcription: The array of ci codes data
+          description: The array of ci codes data
         txn:
           type: string
           description: The txn code (riskEngineAssessmentId) data
+        responseDelay:
+          type: number
+          description: The period in seconds to wait before sending a response from the risk-assessment endpoint.
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add response delay option to TICF stub

### Why did it change

We want to be able to test slow resonses from ticf in core. This adds a configuration option to the management api that causes ticf stub to sleep for a configured period.

It also adds prettier which seemed to be missing and runs the `fix` script. Shoould have done that in a separate commit. Sorry.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7198](https://govukverify.atlassian.net/browse/PYIC-7198)


[PYIC-7198]: https://govukverify.atlassian.net/browse/PYIC-7198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ