### PR TITLE
BAU: Filter shared claims played back in the credential subject

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/Credential.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/Credential.java
@@ -2,43 +2,9 @@ package uk.gov.di.ipv.stub.cred.domain;
 
 import java.util.Map;
 
-public class Credential {
-    private final Map<String, Object> attributes;
-    private final Map<String, Object> evidence;
-    private final String userId;
-    private final String clientId;
-    private final Long nbf;
-
-    public Credential(
-            Map<String, Object> attributes,
-            Map<String, Object> evidence,
-            String userId,
-            String clientId,
-            Long nbf) {
-        this.attributes = attributes;
-        this.evidence = evidence;
-        this.userId = userId;
-        this.clientId = clientId;
-        this.nbf = nbf;
-    }
-
-    public Map<String, Object> getAttributes() {
-        return attributes;
-    }
-
-    public Map<String, Object> getEvidence() {
-        return evidence;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public Long getNbf() {
-        return nbf;
-    }
-}
+public record Credential(
+        Map<String, Object> credentialSubject,
+        Map<String, Object> evidence,
+        String userId,
+        String clientId,
+        Long nbf) {}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -48,7 +48,7 @@ public class VerifiableCredentialGenerator {
 
         Map<String, Object> credentialSubject = new LinkedHashMap<>();
 
-        Map<String, Object> attributes = new HashMap<>(credential.getAttributes());
+        Map<String, Object> attributes = new HashMap<>(credential.credentialSubject());
 
         if (isPopulatedList(attributes, CREDENTIAL_SUBJECT_NAME)) {
             credentialSubject.put(CREDENTIAL_SUBJECT_NAME, attributes.get(CREDENTIAL_SUBJECT_NAME));
@@ -72,7 +72,7 @@ public class VerifiableCredentialGenerator {
 
         // VCs from user asserted CRI types, like address, should not contain an evidence attribute
         if (getCriType().isIdentityCheck()) {
-            vc.put(VC_EVIDENCE, List.of(credential.getEvidence()));
+            vc.put(VC_EVIDENCE, List.of(credential.evidence()));
         }
 
         return generateAndSignVerifiableCredentialJwt(credential, vc);
@@ -103,13 +103,13 @@ public class VerifiableCredentialGenerator {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         JWTClaimsSet.Builder claim =
                 new JWTClaimsSet.Builder()
-                        .claim(SUBJECT, credential.getUserId())
+                        .claim(SUBJECT, credential.userId())
                         .claim(ISSUER, CredentialIssuerConfig.getVerifiableCredentialIssuer())
                         .claim(
                                 AUDIENCE,
-                                ConfigService.getClientConfig(credential.getClientId())
+                                ConfigService.getClientConfig(credential.clientId())
                                         .getAudienceForVcJwt())
-                        .claim(NOT_BEFORE, credential.getNbf())
+                        .claim(NOT_BEFORE, credential.nbf())
                         .claim(
                                 JWT_ID,
                                 String.format(

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -463,10 +463,9 @@ class AuthorizeHandlerTest {
 
             verify(mockVcGenerator).generate(persistedCredential.capture());
             Map<String, Object> persistedAttributes =
-                    persistedCredential.getValue().getAttributes();
-            Map<String, Object> persistedEvidence = persistedCredential.getValue().getEvidence();
-            assertEquals(
-                    List.of("123 random street, M13 7GE"), persistedAttributes.get("addresses"));
+                    persistedCredential.getValue().credentialSubject();
+            Map<String, Object> persistedEvidence = persistedCredential.getValue().evidence();
+            assertEquals(List.of("123 random street, M13 7GE"), persistedAttributes.get("address"));
             assertEquals("test-value", persistedAttributes.get("test"));
             assertEquals("IdentityCheck", persistedEvidence.get("type"));
             assertNotNull(persistedEvidence.get("txn"));
@@ -586,9 +585,9 @@ class AuthorizeHandlerTest {
 
             verify(mockVcGenerator).generate(persistedCredential.capture());
             Map<String, Object> persistedAttributes =
-                    persistedCredential.getValue().getAttributes();
-            assertNull(persistedAttributes.get("addresses"));
-            assertNull(persistedAttributes.get("names"));
+                    persistedCredential.getValue().credentialSubject();
+            assertNull(persistedAttributes.get("address"));
+            assertNull(persistedAttributes.get("name"));
             assertNull(persistedAttributes.get("birthDate"));
             assertEquals("test-value", persistedAttributes.get("test"));
 
@@ -661,7 +660,7 @@ class AuthorizeHandlerTest {
                             .toString()
                             .contains(authCoreArgumentCaptor.getValue().getValue()));
             verify(mockVcGenerator).generate(credentialArgumentCaptor.capture());
-            assertEquals(1714577018L, credentialArgumentCaptor.getValue().getNbf());
+            assertEquals(1714577018L, credentialArgumentCaptor.getValue().nbf());
         }
 
         @Test
@@ -767,10 +766,9 @@ class AuthorizeHandlerTest {
 
             verify(mockVcGenerator).generate(persistedCredential.capture());
             Map<String, Object> persistedAttributes =
-                    persistedCredential.getValue().getAttributes();
-            Map<String, Object> persistedEvidence = persistedCredential.getValue().getEvidence();
-            assertEquals(
-                    List.of("123 random street, M13 7GE"), persistedAttributes.get("addresses"));
+                    persistedCredential.getValue().credentialSubject();
+            Map<String, Object> persistedEvidence = persistedCredential.getValue().evidence();
+            assertEquals(List.of("123 random street, M13 7GE"), persistedAttributes.get("address"));
             assertEquals(
                     List.of(Map.of("value", "1965-07-08")), persistedAttributes.get("birthDate"));
             assertEquals("IdentityCheck", persistedEvidence.get("type"));
@@ -1051,9 +1049,9 @@ class AuthorizeHandlerTest {
 
     private Map<String, Object> defaultSharedClaims() {
         Map<String, Object> sharedClaims = new LinkedHashMap<>();
-        sharedClaims.put("addresses", Collections.singletonList("123 random street, M13 7GE"));
+        sharedClaims.put("address", Collections.singletonList("123 random street, M13 7GE"));
         sharedClaims.put(
-                "names",
+                "name",
                 List.of(
                         Map.of(
                                 "nameParts",


### PR DESCRIPTION
## Proposed changes

### What changed

When generating a VC credentialSubject, only add shared claims in a known list (address, name, birthDate, socialSecurityRecord)

### Why did it change

More consistent behaviour from CRI stub and suppression of warnings in IPV Core when adding invalid properties for a credential subject (e.g. `emailAddress`)
