### PR TITLE
PYIC-7277: Modify apiAuthorize to return redirectUrl and jarPayload

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -243,16 +243,18 @@ public class AuthorizeHandler {
     }
 
     public void apiAuthorize(Context ctx) throws Exception {
-        JWTClaimsSet claimsSet = getClaimsSet(ctx.bodyAsClass(ApiAuthRequest.class));
-        String redirectUrl = generateResponseRedirect(ctx.bodyAsClass(ApiAuthRequest.class), claimsSet);
+        ApiAuthRequest apiAuthRequest = ctx.bodyAsClass(ApiAuthRequest.class);
+        JWTClaimsSet claimsSet = getClaimsSet(apiAuthRequest);
+        String redirectUrl = generateResponseRedirect(apiAuthRequest, claimsSet);
 
         ctx.status(200);
         ctx.json(Map.of("redirectUrl", redirectUrl, "jarPayload", claimsSet.toJSONObject()));
     }
 
     public void formAuthorize(Context ctx) throws Exception {
-        JWTClaimsSet claimsSet = getClaimsSet(ctx.bodyAsClass(ApiAuthRequest.class));
-        ctx.redirect(generateResponseRedirect(FormAuthRequest.fromFormContext(ctx), claimsSet));
+        FormAuthRequest formAuthRequest = FormAuthRequest.fromFormContext(ctx);
+        JWTClaimsSet claimsSet = getClaimsSet(formAuthRequest);
+        ctx.redirect(generateResponseRedirect(formAuthRequest, claimsSet));
     }
 
     private String generateResponseRedirect(AuthRequest authRequest, JWTClaimsSet claimsSet)

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -243,18 +243,19 @@ public class AuthorizeHandler {
     }
 
     public void apiAuthorize(Context ctx) throws Exception {
-        String redirectUrl = generateResponseRedirect(ctx.bodyAsClass(ApiAuthRequest.class));
         JWTClaimsSet claimsSet = getClaimsSet(ctx.bodyAsClass(ApiAuthRequest.class));
+        String redirectUrl = generateResponseRedirect(ctx.bodyAsClass(ApiAuthRequest.class), claimsSet);
 
         ctx.status(200);
         ctx.json(Map.of("redirectUrl", redirectUrl, "jarPayload", claimsSet.toJSONObject()));
     }
 
     public void formAuthorize(Context ctx) throws Exception {
-        ctx.redirect(generateResponseRedirect(FormAuthRequest.fromFormContext(ctx)));
+        JWTClaimsSet claimsSet = getClaimsSet(ctx.bodyAsClass(ApiAuthRequest.class));
+        ctx.redirect(generateResponseRedirect(FormAuthRequest.fromFormContext(ctx), claimsSet));
     }
 
-    private String generateResponseRedirect(AuthRequest authRequest)
+    private String generateResponseRedirect(AuthRequest authRequest, JWTClaimsSet claimsSet)
             throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     ParseException {
         AuthorizationErrorResponse requestedAuthErrorResponse = handleRequestedError(authRequest);
@@ -263,7 +264,6 @@ public class AuthorizeHandler {
         }
 
         String clientIdValue = authRequest.clientId();
-        JWTClaimsSet claimsSet = getClaimsSet(authRequest);
         String redirectUri = claimsSet.getClaim(RequestParamConstants.REDIRECT_URI).toString();
         String userId = claimsSet.getSubject();
         String state = claimsSet.getClaim(RequestParamConstants.STATE).toString();

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -623,8 +623,7 @@ class AuthorizeHandlerTest {
 
             verify(mockAuthCodeService)
                     .persist(authCoreArgumentCaptor.capture(), anyString(), eq(VALID_REDIRECT_URI));
-            verify(mockContext).status(intArgumentCaptor.capture());
-            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).status(200);
             verify(mockContext).json(jsonArgumentCaptor.capture());
             assertTrue(
                     jsonArgumentCaptor
@@ -653,8 +652,7 @@ class AuthorizeHandlerTest {
 
             verify(mockAuthCodeService)
                     .persist(authCoreArgumentCaptor.capture(), anyString(), eq(VALID_REDIRECT_URI));
-            verify(mockContext).status(intArgumentCaptor.capture());
-            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).status(200);
             verify(mockContext).json(jsonArgumentCaptor.capture());
             assertTrue(
                     jsonArgumentCaptor
@@ -739,8 +737,7 @@ class AuthorizeHandlerTest {
 
             authorizeHandler.apiAuthorize(mockContext);
 
-            verify(mockContext).status(intArgumentCaptor.capture());
-            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).status(200);
             verify(mockContext).json(jsonArgumentCaptor.capture());
             assertEquals(
                     VALID_REDIRECT_URI
@@ -852,8 +849,7 @@ class AuthorizeHandlerTest {
 
             verify(mockAuthCodeService)
                     .persist(authCoreArgumentCaptor.capture(), anyString(), eq(VALID_REDIRECT_URI));
-            verify(mockContext).status(intArgumentCaptor.capture());
-            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).status(200);
             verify(mockContext).json(jsonArgumentCaptor.capture());
             assertTrue(
                     jsonArgumentCaptor
@@ -883,8 +879,7 @@ class AuthorizeHandlerTest {
 
             authorizeHandler.apiAuthorize(mockContext);
 
-            verify(mockContext).status(intArgumentCaptor.capture());
-            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).status(200);
             verify(mockContext).json(jsonArgumentCaptor.capture());
             assertEquals(
                     VALID_REDIRECT_URI

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -149,6 +149,8 @@ class AuthorizeHandlerTest {
     @Captor ArgumentCaptor<Credential> credentialArgumentCaptor;
     @Captor ArgumentCaptor<HttpRequest> httpRequestArgumentCaptor;
     @Captor ArgumentCaptor<String> stringArgumentCaptor;
+    @Captor ArgumentCaptor<Map<String, Object>> jsonArgumentCaptor;
+    @Captor ArgumentCaptor<Integer> intArgumentCaptor;
     @Captor ArgumentCaptor<AuthorizationCode> authCoreArgumentCaptor;
 
     @BeforeAll
@@ -621,10 +623,14 @@ class AuthorizeHandlerTest {
 
             verify(mockAuthCodeService)
                     .persist(authCoreArgumentCaptor.capture(), anyString(), eq(VALID_REDIRECT_URI));
-            verify(mockContext).redirect(stringArgumentCaptor.capture());
+            verify(mockContext).status(intArgumentCaptor.capture());
+            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).json(jsonArgumentCaptor.capture());
             assertTrue(
-                    stringArgumentCaptor
+                    jsonArgumentCaptor
                             .getValue()
+                            .get("redirectUrl")
+                            .toString()
                             .contains(authCoreArgumentCaptor.getValue().getValue()));
         }
 
@@ -647,12 +653,15 @@ class AuthorizeHandlerTest {
 
             verify(mockAuthCodeService)
                     .persist(authCoreArgumentCaptor.capture(), anyString(), eq(VALID_REDIRECT_URI));
-            verify(mockContext).redirect(stringArgumentCaptor.capture());
+            verify(mockContext).status(intArgumentCaptor.capture());
+            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).json(jsonArgumentCaptor.capture());
             assertTrue(
-                    stringArgumentCaptor
+                    jsonArgumentCaptor
                             .getValue()
+                            .get("redirectUrl")
+                            .toString()
                             .contains(authCoreArgumentCaptor.getValue().getValue()));
-
             verify(mockVcGenerator).generate(credentialArgumentCaptor.capture());
             assertEquals(1714577018L, credentialArgumentCaptor.getValue().getNbf());
         }
@@ -730,10 +739,13 @@ class AuthorizeHandlerTest {
 
             authorizeHandler.apiAuthorize(mockContext);
 
-            verify(mockContext)
-                    .redirect(
-                            VALID_REDIRECT_URI
-                                    + "?error=invalid_json&iss=Credential+Issuer+Stub&error_description=Unable+to+generate+valid+JSON+Payload");
+            verify(mockContext).status(intArgumentCaptor.capture());
+            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).json(jsonArgumentCaptor.capture());
+            assertEquals(
+                    VALID_REDIRECT_URI
+                            + "?error=invalid_json&iss=Credential+Issuer+Stub&error_description=Unable+to+generate+valid+JSON+Payload",
+                    jsonArgumentCaptor.getValue().get("redirectUrl").toString());
         }
 
         @Test
@@ -840,10 +852,14 @@ class AuthorizeHandlerTest {
 
             verify(mockAuthCodeService)
                     .persist(authCoreArgumentCaptor.capture(), anyString(), eq(VALID_REDIRECT_URI));
-            verify(mockContext).redirect(stringArgumentCaptor.capture());
+            verify(mockContext).status(intArgumentCaptor.capture());
+            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).json(jsonArgumentCaptor.capture());
             assertTrue(
-                    stringArgumentCaptor
+                    jsonArgumentCaptor
                             .getValue()
+                            .get("redirectUrl")
+                            .toString()
                             .contains(authCoreArgumentCaptor.getValue().getValue()));
         }
 
@@ -867,10 +883,13 @@ class AuthorizeHandlerTest {
 
             authorizeHandler.apiAuthorize(mockContext);
 
-            verify(mockContext)
-                    .redirect(
-                            VALID_REDIRECT_URI
-                                    + "?iss=Credential+Issuer+Stub&state=test-state&error=invalid_request&error_description=a+bad+thing+happened");
+            verify(mockContext).status(intArgumentCaptor.capture());
+            assertEquals(200, intArgumentCaptor.getValue());
+            verify(mockContext).json(jsonArgumentCaptor.capture());
+            assertEquals(
+                    VALID_REDIRECT_URI
+                            + "?iss=Credential+Issuer+Stub&state=test-state&error=invalid_request&error_description=a+bad+thing+happened",
+                    jsonArgumentCaptor.getValue().get("redirectUrl").toString());
         }
 
         @Test


### PR DESCRIPTION
## Proposed changes

### What changed

- Modify `apiAuthorize` to return redirectUrl and jarPayload

### Why did it change

- So API tests can receive a decrypted version of the payload sent to the CRI, in order to assert that it was provided with the right request attributes

### Issue tracking

- [PYIC-7277](https://govukverify.atlassian.net/browse/PYIC-7277)

### Notes

- This wants to go in after https://github.com/govuk-one-login/ipv-core-back/pull/2357 has merged in (build pipeline broken at time of writing)

[PYIC-7277]: https://govukverify.atlassian.net/browse/PYIC-7277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ