### PR TITLE
LIME-1107 (ipv-core-stub) Fail if VC response content-type is not application/jwt

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -226,7 +226,24 @@ public class HandlerHelper {
                 state,
                 userInfoRequest.getURL());
         HTTPResponse userInfoHttpResponse = sendHttpRequest(userInfoRequest);
-        return userInfoHttpResponse.getContent();
+
+        // Try lowercase, fall back to TitleCase
+        String contentType = userInfoHttpResponse.getHeaderValue("content-type");
+        contentType =
+                contentType == null
+                        ? userInfoHttpResponse.getHeaderValue("Content-Type")
+                        : contentType;
+
+        if (!"application/jwt".equalsIgnoreCase(contentType)) {
+            // Fail now to prevent CRI's passing with a missmatch
+            String message =
+                    String.format(
+                            "Expected content-type application/jwt but VC response had content-type - %s",
+                            contentType);
+            throw new RuntimeException(message);
+        } else {
+            return userInfoHttpResponse.getContent();
+        }
     }
 
     public HTTPResponse sendHttpRequest(HTTPRequest httpRequest) {


### PR DESCRIPTION
## Proposed changes

### What changed

Add a content type check to the returned VC and fail if its not application/jwt

### Why did it change

The ipv-core-stub previously would display/attempt to decode the response from the VC endpoint irrespective of the content in the response. 
This was allowing a VC endpoint to appear to work correctly until interfacing with ipv-core which will reject the incorrect content type.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1197](https://govukverify.atlassian.net/browse/LIME-1197)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1197]: https://govukverify.atlassian.net/browse/LIME-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ