### PR TITLE
PYIC-7277: Add apiDecryptJar to enable API tests to decrypt jars

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -84,6 +84,8 @@ public class CredentialIssuer {
         app.get("/authorize", authorizeHandler::doAuthorize);
         app.post("/authorize", authorizeHandler::formAuthorize);
         app.post("/api/authorize", authorizeHandler::apiAuthorize);
+        // This enables API tests to check the request
+        app.post("/api/decrypt-jar", authorizeHandler::apiDecryptJar);
         app.post("/token", tokenHandler::issueAccessToken);
         if (getCriType().equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
             app.post("/credentials/issue", docAppCredentialHandler::getResource);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/ApiDecryptJarRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/ApiDecryptJarRequest.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.stub.cred.domain;
+
+public record ApiDecryptJarRequest (
+        String clientId,
+        String request) implements DecryptJarRequest {}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/AuthRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/AuthRequest.java
@@ -1,10 +1,6 @@
 package uk.gov.di.ipv.stub.cred.domain;
 
-public interface AuthRequest {
-    String clientId();
-
-    String request();
-
+public interface AuthRequest extends DecryptJarRequest {
     String credentialSubjectJson();
 
     String evidenceJson();

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/DecryptJarRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/DecryptJarRequest.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.stub.cred.domain;
+
+public interface DecryptJarRequest {
+    String clientId();
+
+    String request();
+}


### PR DESCRIPTION
## Proposed changes

### What changed

- Add apiDecryptJar to enable API tests to decrypt jars

### Why did it change

- to enable API tests to decrypt jars to assert on request attributes sent to CRI stubs

### Issue tracking

- [PYIC-7277](https://govukverify.atlassian.net/browse/PYIC-7277)

[PYIC-7277]: https://govukverify.atlassian.net/browse/PYIC-7277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ