### PR TITLE
PYIC-7303 Add credential generation endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,6 +109,13 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "^x-api-key$",
+        "^test-api-key$"
+      ]
     }
   ],
   "results": {
@@ -209,15 +216,6 @@
         "hashed_secret": "7980f46d5ba13b727c38a3891addf39c6ab6b0bf",
         "is_verified": false,
         "line_number": 40
-      }
-    ],
-    "di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java": [
-      {
-        "type": "Secret Keyword",
-        "filename": "di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java",
-        "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false,
-        "line_number": 96
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java": [
@@ -462,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-16T15:50:53Z"
+  "generated_at": "2024-08-28T07:53:41Z"
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -9,6 +9,7 @@ import uk.gov.di.ipv.stub.cred.handlers.AuthorizeHandler;
 import uk.gov.di.ipv.stub.cred.handlers.CredentialHandler;
 import uk.gov.di.ipv.stub.cred.handlers.DocAppCredentialHandler;
 import uk.gov.di.ipv.stub.cred.handlers.F2FHandler;
+import uk.gov.di.ipv.stub.cred.handlers.GenerateCredentialHandler;
 import uk.gov.di.ipv.stub.cred.handlers.HealthCheckHandler;
 import uk.gov.di.ipv.stub.cred.handlers.JwksHandler;
 import uk.gov.di.ipv.stub.cred.handlers.TokenHandler;
@@ -32,6 +33,7 @@ public class CredentialIssuer {
     private final JwksHandler jwksHandler;
     private final F2FHandler f2fHandler;
     private final HealthCheckHandler healthCheckHandler;
+    private final GenerateCredentialHandler generateCredentialHandler;
 
     public CredentialIssuer() {
         var app =
@@ -72,6 +74,7 @@ public class CredentialIssuer {
         jwksHandler = new JwksHandler();
         f2fHandler = new F2FHandler(credentialService, tokenService);
         healthCheckHandler = new HealthCheckHandler();
+        generateCredentialHandler = new GenerateCredentialHandler(vcGenerator);
 
         initRoutes(app);
         initErrorMapping(app);
@@ -92,6 +95,7 @@ public class CredentialIssuer {
         } else {
             app.post("/credentials/issue", credentialHandler::getResource);
         }
+        app.post("/credentials/generate", generateCredentialHandler::generateCredential);
         app.get("/.well-known/jwks.json", jwksHandler::getResource);
     }
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/GenerateCredentialRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/GenerateCredentialRequest.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.stub.cred.domain;
+
+public record GenerateCredentialRequest(
+        String userId,
+        String clientId,
+        String credentialSubjectJson,
+        String evidenceJson,
+        Long nbf) {}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -109,7 +109,7 @@ public class AuthorizeHandler {
     private static final String F2F_STUB_QUEUE_API_KEY =
             "F2F_STUB_QUEUE_API_KEY"; // pragma: allowlist secret
     private static final int F2F_DEFAULT_DELAY_SECONDS = 10;
-    private static final String X_API_KEY = "x-api-key"; // pragma: allowlist secret
+    private static final String X_API_KEY = "x-api-key";
 
     private static final List<CriType> NO_SHARED_ATTRIBUTES_CRI_TYPES =
             List.of(ADDRESS_CRI_TYPE, USER_ASSERTED_CRI_TYPE, DOC_CHECK_APP_CRI_TYPE);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandler.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
+import io.javalin.http.UnauthorizedResponse;
 import uk.gov.di.ipv.stub.cred.domain.Credential;
 import uk.gov.di.ipv.stub.cred.domain.GenerateCredentialRequest;
+import uk.gov.di.ipv.stub.cred.service.ConfigService;
 import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 
 import java.util.Map;
@@ -19,6 +21,7 @@ public class GenerateCredentialHandler {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
             new TypeReference<>() {};
+    private static final String API_KEY_HEADER = "x-api-key";
 
     private final VerifiableCredentialGenerator verifiableCredentialGenerator;
 
@@ -27,6 +30,11 @@ public class GenerateCredentialHandler {
     }
 
     public void generateCredential(Context ctx) throws Exception {
+        var apiKey = ConfigService.getApiKey();
+        if (apiKey != null && !apiKey.equals(ctx.header(API_KEY_HEADER))) {
+            throw new UnauthorizedResponse("Invalid or missing API key");
+        }
+
         var request = ctx.bodyAsClass(GenerateCredentialRequest.class);
         var vc =
                 verifiableCredentialGenerator.generate(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandler.java
@@ -1,0 +1,44 @@
+package uk.gov.di.ipv.stub.cred.handlers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
+import uk.gov.di.ipv.stub.cred.domain.Credential;
+import uk.gov.di.ipv.stub.cred.domain.GenerateCredentialRequest;
+import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
+
+import java.util.Map;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+
+// This endpoint generates stub VCs without going through an OAuth flow
+// It is only intended to be used as part of test setup
+public class GenerateCredentialHandler {
+    public static final String JWT_CONTENT_TYPE = "application/jwt;charset=UTF-8";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
+            new TypeReference<>() {};
+
+    private final VerifiableCredentialGenerator verifiableCredentialGenerator;
+
+    public GenerateCredentialHandler(VerifiableCredentialGenerator verifiableCredentialGenerator) {
+        this.verifiableCredentialGenerator = verifiableCredentialGenerator;
+    }
+
+    public void generateCredential(Context ctx) throws Exception {
+        var request = ctx.bodyAsClass(GenerateCredentialRequest.class);
+        var vc =
+                verifiableCredentialGenerator.generate(
+                        new Credential(
+                                OBJECT_MAPPER.readValue(
+                                        request.credentialSubjectJson(), MAP_TYPE_REFERENCE),
+                                OBJECT_MAPPER.readValue(request.evidenceJson(), MAP_TYPE_REFERENCE),
+                                request.userId(),
+                                request.clientId(),
+                                request.nbf()));
+        ctx.contentType(JWT_CONTENT_TYPE);
+        ctx.status(HttpStatus.CREATED);
+        ctx.result(vc.toString());
+    }
+}

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/ConfigService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/ConfigService.java
@@ -22,7 +22,7 @@ public class ConfigService {
     private static final Gson GSON = new Gson();
     private static final SsmClient SSM_CLIENT = getSsmClient();
     private static final String CLIENT_CONFIG_BASE_PATH = "/stubs/credential-issuer-stub-clients";
-    private static final String API_KEY_PATH = "/stubs/credential-issuer-stub-api-key";
+    private static final String API_KEY_PATH = "/stubs/credentialIssuers/generateCredentialApiKey";
     private static final String ENVIRONMENT_ENV_VAR = "ENVIRONMENT";
     private static final String TEST = "TEST";
     private static final String CONFIG_CACHE_SECONDS_ENV_VAR = "CONFIG_CACHE_SECONDS";

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
@@ -1,0 +1,51 @@
+package uk.gov.di.ipv.stub.cred.handlers;
+
+import com.nimbusds.jwt.SignedJWT;
+import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.stub.cred.domain.GenerateCredentialRequest;
+import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.stub.cred.handlers.GenerateCredentialHandler.JWT_CONTENT_TYPE;
+
+@ExtendWith(MockitoExtension.class)
+public class GenerateCredentialHandlerTest {
+    @Mock private Context mockContext;
+    @Mock private VerifiableCredentialGenerator mockCredentialGenerator;
+    @InjectMocks private GenerateCredentialHandler generateCredentialHandler;
+
+    @Test
+    void shouldGenerateAndReturnCredential() throws Exception {
+        // arrange
+        var testCredentialRequest =
+                new GenerateCredentialRequest(
+                        "test-user-id",
+                        "test-client-id",
+                        "{\"subject\": \"foo\"}",
+                        "{\"evidence\": \"bar\"}",
+                        null);
+        when(mockContext.bodyAsClass(GenerateCredentialRequest.class))
+                .thenReturn(testCredentialRequest);
+        var mockJwt = mock(SignedJWT.class);
+        when(mockCredentialGenerator.generate(any())).thenReturn(mockJwt);
+        var testVcString = "test-vc-string";
+        when(mockJwt.toString()).thenReturn(testVcString);
+
+        // act
+        generateCredentialHandler.generateCredential(mockContext);
+
+        // assert
+        verify(mockContext).contentType(JWT_CONTENT_TYPE);
+        verify(mockContext).status(HttpStatus.CREATED);
+        verify(mockContext).result(testVcString);
+    }
+}

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
@@ -3,16 +3,21 @@ package uk.gov.di.ipv.stub.cred.handlers;
 import com.nimbusds.jwt.SignedJWT;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
+import io.javalin.http.UnauthorizedResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.stub.cred.domain.GenerateCredentialRequest;
+import uk.gov.di.ipv.stub.cred.service.ConfigService;
 import uk.gov.di.ipv.stub.cred.vc.VerifiableCredentialGenerator;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.stub.cred.handlers.GenerateCredentialHandler.JWT_CONTENT_TYPE;
@@ -25,27 +30,47 @@ public class GenerateCredentialHandlerTest {
 
     @Test
     void shouldGenerateAndReturnCredential() throws Exception {
-        // arrange
-        var testCredentialRequest =
-                new GenerateCredentialRequest(
-                        "test-user-id",
-                        "test-client-id",
-                        "{\"subject\": \"foo\"}",
-                        "{\"evidence\": \"bar\"}",
-                        null);
-        when(mockContext.bodyAsClass(GenerateCredentialRequest.class))
-                .thenReturn(testCredentialRequest);
-        var mockJwt = mock(SignedJWT.class);
-        when(mockCredentialGenerator.generate(any())).thenReturn(mockJwt);
-        var testVcString = "test-vc-string";
-        when(mockJwt.toString()).thenReturn(testVcString);
+        try (MockedStatic<ConfigService> mockedConfigService = mockStatic(ConfigService.class)) {
+            // arrange
+            var testCredentialRequest =
+                    new GenerateCredentialRequest(
+                            "test-user-id",
+                            "test-client-id",
+                            "{\"subject\": \"foo\"}",
+                            "{\"evidence\": \"bar\"}",
+                            null);
+            var testApiKey = "test-api-key";
+            when(mockContext.bodyAsClass(GenerateCredentialRequest.class))
+                    .thenReturn(testCredentialRequest);
+            when(mockContext.header("x-api-key")).thenReturn(testApiKey);
+            var mockJwt = mock(SignedJWT.class);
+            when(mockCredentialGenerator.generate(any())).thenReturn(mockJwt);
+            var testVcString = "test-vc-string";
+            when(mockJwt.toString()).thenReturn(testVcString);
+            mockedConfigService.when(ConfigService::getApiKey).thenReturn(testApiKey);
 
-        // act
-        generateCredentialHandler.generateCredential(mockContext);
+            // act
+            generateCredentialHandler.generateCredential(mockContext);
 
-        // assert
-        verify(mockContext).contentType(JWT_CONTENT_TYPE);
-        verify(mockContext).status(HttpStatus.CREATED);
-        verify(mockContext).result(testVcString);
+            // assert
+            verify(mockContext).contentType(JWT_CONTENT_TYPE);
+            verify(mockContext).status(HttpStatus.CREATED);
+            verify(mockContext).result(testVcString);
+        }
+    }
+
+    @Test
+    void shouldThrowUnauthorizedIfApiKeyIsInvalid() {
+        try (MockedStatic<ConfigService> mockedConfigService = mockStatic(ConfigService.class)) {
+            // arrange
+            var testApiKey = "test-api-key";
+            when(mockContext.header("x-api-key")).thenReturn("invalid-api-key");
+            mockedConfigService.when(ConfigService::getApiKey).thenReturn(testApiKey);
+
+            // act/assert
+            assertThrows(
+                    UnauthorizedResponse.class,
+                    () -> generateCredentialHandler.generateCredential(mockContext));
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add a new endpoint for generating VCs, for use by the API tests

### Why did it change

When running API tests, it is often convenient to set up a user's VCs in advance, to save the effort of running through a complete journey first.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7303](https://govukverify.atlassian.net/browse/PYIC-7303)


[PYIC-7303]: https://govukverify.atlassian.net/browse/PYIC-7303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ