### PR TITLE
PYIC-7324: Return correct serialization of jwt

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandler.java
@@ -47,6 +47,6 @@ public class GenerateCredentialHandler {
                                 request.nbf()));
         ctx.contentType(JWT_CONTENT_TYPE);
         ctx.status(HttpStatus.CREATED);
-        ctx.result(vc.toString());
+        ctx.result(vc.serialize());
     }
 }

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
@@ -46,7 +46,7 @@ public class GenerateCredentialHandlerTest {
             var mockJwt = mock(SignedJWT.class);
             when(mockCredentialGenerator.generate(any())).thenReturn(mockJwt);
             var testVcString = "test-vc-string";
-            when(mockJwt.toString()).thenReturn(testVcString);
+            when(mockJwt.serialize()).thenReturn(testVcString);
             mockedConfigService.when(ConfigService::getApiKey).thenReturn(testApiKey);
 
             // act


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Return correct serialization of jwt

### Why did it change

Calling `toString()` just gives you the qualified class name. To get the thing we want we need to use `serialize()`.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7324](https://govukverify.atlassian.net/browse/PYIC-7324)


[PYIC-7324]: https://govukverify.atlassian.net/browse/PYIC-7324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ