### PR TITLE
LIME-1100: Added parameter for preprod api keys for hmrc kbv

### DIFF
--- a/di-ipv-core-stub/deploy/cri-preprod/template.yaml
+++ b/di-ipv-core-stub/deploy/cri-preprod/template.yaml
@@ -54,6 +54,10 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/core/cri-preprod/env/API_KEY_CRI_PASSPORTA_PRE_PROD" #pragma: allowlist secret
+  ApiKeyCriHmrcKbvPreProd:
+    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/stubs/core/cri-preprod/env/API_KEY_CRI_HMRC_KBV_PRE_PROD" #pragma: allowlist secret
   CodeSigningConfigArn:
     Type: String
     Description: >


### PR DESCRIPTION
## Proposed changes

### What changed

Added pre prod api keys for HMRC KBV

### Why did it change

To allow us to test HMRC KBV in production

