### PR TITLE
PYIC-7260: Update packages for di-ipv-credential-issuer

### DIFF
--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -16,10 +16,10 @@ java {
 
 dependencies {
 	implementation "io.javalin:javalin:6.2.0",
-			"io.javalin:javalin-rendering:6.2.0",
+			"io.javalin:javalin-rendering:6.3.0",
 			"com.github.spullara.mustache.java:compiler:0.9.14",
-			"com.nimbusds:oauth2-oidc-sdk:11.13",
-			"com.fasterxml.jackson.core:jackson-core:2.16.1",
+			"com.nimbusds:oauth2-oidc-sdk:11.19.1",
+			"com.fasterxml.jackson.core:jackson-core:2.17.2",
 			"com.fasterxml.jackson.core:jackson-databind:2.17.2",
 			"com.fasterxml.jackson.core:jackson-annotations:2.17.2",
 			"com.google.code.gson:gson:2.11.0",
@@ -32,8 +32,7 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3',
 			'org.mockito:mockito-core:5.12.0',
 			"org.mockito:mockito-junit-jupiter:5.12.0",
-			'uk.org.webcompere:system-stubs-jupiter:2.1.6',
-			"org.hamcrest:hamcrest:2.2"
+			'uk.org.webcompere:system-stubs-jupiter:2.1.6'
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -22,10 +22,9 @@ import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.startsWithIgnoringCase;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,16 +71,12 @@ public class DocAppCredentialHandlerTest {
         verify(mockTokenService).revoke(accessToken.toAuthorizationHeader());
 
         var docAppUserInfo = new UserInfo(responseCaptor.getValue());
-        assertThat(
-                docAppUserInfo.getSubject().getValue(),
-                startsWithIgnoringCase("urn:fdc:gov.uk:2022:"));
-        assertThat(
-                docAppUserInfo.getClaim("https://vocab.account.gov.uk/v1/credentialJWT"),
-                notNullValue());
+        assertTrue(docAppUserInfo.getSubject().getValue().startsWith("urn:fdc:gov.uk:2022:"));
+        assertNotNull(docAppUserInfo.getClaim("https://vocab.account.gov.uk/v1/credentialJWT"));
         List<?> verifiedCredentials =
                 (List<?>) docAppUserInfo.getClaim("https://vocab.account.gov.uk/v1/credentialJWT");
-        assertThat(verifiedCredentials.size(), equalTo(1));
-        assertThat(verifiedCredentials.get(0), equalTo("A.VERIFIABLE.CREDENTIAL"));
+        assertEquals(1, verifiedCredentials.size());
+        assertEquals("A.VERIFIABLE.CREDENTIAL", verifiedCredentials.get(0));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

- io.javalin:javalin-rendering to 6.3.0
- com.nimbusds:oauth2-oidc-sdk to 11.19.1
- com.fasterxml.jackson.core:jackson-core to 2.17.2
- Remove unnecessary hamcrest package

### Why did it change

- Dependabot suggests these updates.
- To keep up to date with packages.

### Issue tracking

- [PYIC-7260](https://govukverify.atlassian.net/browse/PYIC-7260)

[PYIC-7260]: https://govukverify.atlassian.net/browse/PYIC-7260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ