### PR TITLE
BAU: Log errors in IPV callback

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -277,7 +277,12 @@ public class IpvHandler {
 
             ctx.render("templates/error.mustache", Map.of("error", errorObject));
         } catch (Exception e) {
-            var errorObject = List.of(Map.of("error_description", e.getMessage()));
+            LOGGER.error("Error handling IPV callback", e);
+            var errorObject =
+                    List.of(
+                            Map.of(
+                                    "error_description",
+                                    requireNonNullElse(e.getMessage(), "unknown")));
 
             ctx.render("templates/error.mustache", Map.of("error", errorObject));
         }


### PR DESCRIPTION
If an error was thrown with a `null` message (e.g. for a NPE), then it would throw a NullPointerException when trying to construct the error object and not include any useful information in the logs.

Instead, we should log the error first, and default the message if needed.