### PR TITLE
BAU: Clean up CIMIT stub template permissions

### DIFF
--- a/di-ipv-cimit-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-cimit-stub/core-dev-deploy/template.yaml
@@ -103,57 +103,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
 
-  PostMitigationsFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PostMitigationsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  PostMitigationsLiveAliasFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  PostMitigationsFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PostMitigationsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  PostMitigationsLiveAliasFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  PostMitigationsFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PostMitigationsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-
-  PostMitigationsLiveAliasFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  PostMitigationsFunctionInternalRestApiInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PostMitigationsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/mitigate"
-
   PostMitigationsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -203,56 +152,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
 
-  PutContraIndicatorsFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PutContraIndicatorsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  PutContraIndicatorsLiveAliasFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  PutContraIndicatorsFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PutContraIndicatorsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  PutContraIndicatorsLiveAliasFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  PutContraIndicatorsFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PutContraIndicatorsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  PutContraIndicatorsLiveAliasFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  PutContraIndicatorsFunctionInternalRestApiInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PutContraIndicatorsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/detect"
-
   PutContraIndicatorsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -300,56 +199,6 @@ Resources:
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
-
-  GetContraIndicatorCredentialFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref GetContraIndicatorCredentialFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  GetContraIndicatorCredentialLiveAliasFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  GetContraIndicatorCredentialFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref GetContraIndicatorCredentialFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  GetContraIndicatorCredentialLiveAliasFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  GetContraIndicatorCredentialFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref GetContraIndicatorCredentialFunction
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  GetContraIndicatorCredentialLiveAliasFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  GetContraIndicatorCredentialFunctionInternalRestApiInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref GetContraIndicatorCredentialFunction
-      Action: "lambda:InvokeFunction"
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/GET/contra-indicators"
 
   GetContraIndicatorCredentialLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -141,35 +141,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
 
-  PostMitigationsLiveAliasFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  PostMitigationsLiveAliasFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  PostMitigationsLiveAliasFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  PostMitigationsFunctionInternalRestApiInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PostMitigationsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/mitigate"
-
   PostMitigationsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -219,35 +190,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
 
-  PutContraIndicatorsLiveAliasFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  PutContraIndicatorsLiveAliasFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  PutContraIndicatorsLiveAliasFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  PutContraIndicatorsFunctionInternalRestApiInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref PutContraIndicatorsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/detect"
-
   PutContraIndicatorsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -255,7 +197,6 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/detect"
-
 
   # lambda to stub cimit getContraIndicatorCredential
   GetContraIndicatorCredentialFunction:
@@ -296,35 +237,6 @@ Resources:
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
       AutoPublishAlias: live
-
-  GetContraIndicatorCredentialLiveAliasFunctionCoreDev01InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
-
-  GetContraIndicatorCredentialLiveAliasFunctionCoreDev02InvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
-
-  GetContraIndicatorCredentialLiveAliasFunctionCoreBuildInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
-      Action: "lambda:InvokeFunction"
-      Principal: !FindInMap [ CoreAccounts, build, accountId ]
-
-  GetContraIndicatorCredentialFunctionInternalRestApiInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref GetContraIndicatorCredentialFunction
-      Action: "lambda:InvokeFunction"
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/GET/contra-indicators"
 
   GetContraIndicatorCredentialLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission

--- a/di-ipv-cimit-stub/openAPI/cimit-internal.yaml
+++ b/di-ipv-cimit-stub/openAPI/cimit-internal.yaml
@@ -50,7 +50,7 @@ paths:
         type: "aws"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetContraIndicatorCredentialFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetContraIndicatorCredentialFunction.Arn}:live/invocations
         # Method request path: {user_id=111}
         requestTemplates:
           application/json:
@@ -126,7 +126,7 @@ paths:
         type: "aws"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PutContraIndicatorsFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PutContraIndicatorsFunction.Arn}:live/invocations
         requestTemplates:
           application/json:
             Fn::Sub: >
@@ -201,7 +201,7 @@ paths:
         type: "aws"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostMitigationsFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostMitigationsFunction.Arn}:live/invocations
         requestTemplates:
           application/json:
             Fn::Sub: >


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Clean up CIMIT stub template permissions

### Why did it change

We now only call the CIMIT stub via API gateway. So we can remove all the invoke permissions for the core accounts.

I did think that we shouldn't need to define the invoke permissions for the internal API gatway on the lambdas, but removing it also removes API gateways permissions. This is confusing, as core-back internal API, for example, doesn't define permissions like this and it works fine. There seems to be some issue with importing an OpenAPI spec and those perms being create (found people reporting similar issues online). I'm just leaving them in for now.
