### PR TITLE
PYIC-4589: Remove env from orch stub parameter locations

### DIFF
--- a/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
@@ -139,7 +139,6 @@ Conditions:
       - !Equals [ !Ref Environment, "build"]
       - !Equals [ !Ref Environment, "production"]
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670"]
-  IsDev02: !Equals [ !Ref AWS::AccountId, "175872367215"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
 
   UsePermissionsBoundary:
@@ -195,16 +194,16 @@ Resources:
       DomainName: !If
         - IsDev01
         - !Sub "orch-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !If [IsDev02, !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk", !Ref AWS::NoValue]
+        - !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk"
       DomainValidationOptions:
         - DomainName: !If
             - IsDev01
             - !Sub "orch-${Environment}.01.core.dev.stubs.account.gov.uk"
-            - !If [IsDev02, !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk", !Ref AWS::NoValue]
+            - !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk"
           HostedZoneId: !If
             - IsDev01
             - !ImportValue Dev01StubsHostedZoneId
-            - !If [IsDev02, !ImportValue Dev02StubsHostedZoneId, !ImportValue DevStubHostedZoneId]
+            - !ImportValue Dev02StubsHostedZoneId
       ValidationMethod: DNS
 
   # api domain entries / mapping
@@ -214,7 +213,7 @@ Resources:
       DomainName: !If
         - IsDev01
         - !Sub "orch-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !If [IsDev02, !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk", !Ref AWS::NoValue]
+        - !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk"
       DomainNameConfigurations:
         - CertificateArn: !Ref OrchStubSSLCert
           EndpointType: REGIONAL
@@ -226,7 +225,7 @@ Resources:
       DomainName: !If
         - IsDev01
         - !Sub "orch-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !If [IsDev02, !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk", !Ref AWS::NoValue]
+        - !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk"
       ApiId: !Ref ApiGwHttpEndpoint
       Stage: "$default"
     DependsOn:
@@ -241,11 +240,11 @@ Resources:
       Name: !If
         - IsDev01
         - !Sub "orch-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !If [IsDev02, !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk", !Ref AWS::NoValue]
+        - !Sub "orch-${Environment}.02.core.dev.stubs.account.gov.uk"
       HostedZoneId: !If
         - IsDev01
         - !ImportValue Dev01StubsHostedZoneId
-        - !If [IsDev02, !ImportValue Dev02StubsHostedZoneId, !ImportValue DevStubHostedZoneId]
+        - !ImportValue Dev02StubsHostedZoneId
       AliasTarget:
         DNSName: !GetAtt OrchStubApiDomain.RegionalDomainName
         HostedZoneId: !GetAtt OrchStubApiDomain.RegionalHostedZoneId

--- a/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
@@ -27,111 +27,111 @@ Parameters:
   OrchestratorClientId:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_CLIENT_ID" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_CLIENT_ID" #pragma: allowlist secret
   OrchestratorRedirectUrl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_REDIRECT_URL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_REDIRECT_URL" #pragma: allowlist secret
   OrchestratorClientJwtTtl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_CLIENT_JWT_TTL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_CLIENT_JWT_TTL" #pragma: allowlist secret
   OrchestratorPort:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_PORT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_PORT" #pragma: allowlist secret
   OrchestratorClientSigningKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_CLIENT_SIGNING_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_CLIENT_SIGNING_KEY" #pragma: allowlist secret
   OrchestratorJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorDefaultJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorBuildJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorStagingJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorIntegrationJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorBasicAuthEnable:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
   OrchestratorBasicAuthUsername:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
   OrchestratorBasicAuthPassword:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
   IpvBackchannelEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_BACKCHANNEL_ENDPOINT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_BACKCHANNEL_ENDPOINT" #pragma: allowlist secret
   IpvBackchannelTokenPath:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_BACKCHANNEL_TOKEN_PATH" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_BACKCHANNEL_TOKEN_PATH" #pragma: allowlist secret
   IpvBackchannelUserIdentityPath:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_BACKCHANNEL_USER_IDENTITY_PATH" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_BACKCHANNEL_USER_IDENTITY_PATH" #pragma: allowlist secret
   IpvEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_ENDPOINT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_ENDPOINT" #pragma: allowlist secret
   IpvCoreAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_CORE_AUDIENCE" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_CORE_AUDIENCE" #pragma: allowlist secret
   JavaOpts:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/JAVA_OPTS" #pragma: allowlist secret
+    Default: "/stubs/orch/env/JAVA_OPTS" #pragma: allowlist secret
   JbpConfigOpenJdkJre:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+    Default: "/stubs/orch/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
   InheritedIdentityJwtSigningKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_SIGNING_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_SIGNING_KEY" #pragma: allowlist secret
   InheritedIdentityJwtTtl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_TTL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_TTL" #pragma: allowlist secret
   InheritedIdentityJwtIssuer:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_ISSUER" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_ISSUER" #pragma: allowlist secret
   InheritedIdentityJwtVtm:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_VTM" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_VTM" #pragma: allowlist secret
   EvcsAccessTokenEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_ENDPOINT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/EVCS_ACCESS_TOKEN_ENDPOINT" #pragma: allowlist secret
   EvcsAccessTokenTtl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_TTL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/EVCS_ACCESS_TOKEN_TTL" #pragma: allowlist secret
   EvcsAccessTokenSigningKeyJwk:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK" #pragma: allowlist secret
+    Default: "/stubs/orch/env/EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not

--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -46,107 +46,107 @@ Parameters:
   OrchestratorClientId:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_CLIENT_ID" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_CLIENT_ID" #pragma: allowlist secret
   OrchestratorRedirectUrl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_REDIRECT_URL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_REDIRECT_URL" #pragma: allowlist secret
   OrchestratorClientJwtTtl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_CLIENT_JWT_TTL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_CLIENT_JWT_TTL" #pragma: allowlist secret
   OrchestratorPort:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_PORT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_PORT" #pragma: allowlist secret
   OrchestratorClientSigningKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_CLIENT_SIGNING_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_CLIENT_SIGNING_KEY" #pragma: allowlist secret
   OrchestratorDefaultJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorBuildJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorStagingJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorIntegrationJarEncryptionPublicKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_KEY" #pragma: allowlist secret
   OrchestratorBasicAuthEnable:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BASIC_AUTH_ENABLE" #pragma: allowlist secret
   OrchestratorBasicAuthUsername:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BASIC_AUTH_USERNAME" #pragma: allowlist secret
   OrchestratorBasicAuthPassword:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
+    Default: "/stubs/orch/env/ORCHESTRATOR_BASIC_AUTH_PASSWORD" #pragma: allowlist secret
   IpvBackchannelEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_BACKCHANNEL_ENDPOINT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_BACKCHANNEL_ENDPOINT" #pragma: allowlist secret
   IpvBackchannelTokenPath:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_BACKCHANNEL_TOKEN_PATH" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_BACKCHANNEL_TOKEN_PATH" #pragma: allowlist secret
   IpvBackchannelUserIdentityPath:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_BACKCHANNEL_USER_IDENTITY_PATH" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_BACKCHANNEL_USER_IDENTITY_PATH" #pragma: allowlist secret
   IpvEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_ENDPOINT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_ENDPOINT" #pragma: allowlist secret
   IpvCoreAudience:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/IPV_CORE_AUDIENCE" #pragma: allowlist secret
+    Default: "/stubs/orch/env/IPV_CORE_AUDIENCE" #pragma: allowlist secret
   JavaOpts:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/JAVA_OPTS" #pragma: allowlist secret
+    Default: "/stubs/orch/env/JAVA_OPTS" #pragma: allowlist secret
   JbpConfigOpenJdkJre:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
+    Default: "/stubs/orch/env/JBP_CONFIG_OPEN_JDK_JRE" #pragma: allowlist secret
   InheritedIdentityJwtSigningKey:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_SIGNING_KEY" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_SIGNING_KEY" #pragma: allowlist secret
   InheritedIdentityJwtTtl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_TTL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_TTL" #pragma: allowlist secret
   InheritedIdentityJwtIssuer:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_ISSUER" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_ISSUER" #pragma: allowlist secret
   InheritedIdentityJwtVtm:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/INHERITED_IDENTITY_JWT_VTM" #pragma: allowlist secret
+    Default: "/stubs/orch/env/INHERITED_IDENTITY_JWT_VTM" #pragma: allowlist secret
   EvcsAccessTokenEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_ENDPOINT" #pragma: allowlist secret
+    Default: "/stubs/orch/env/EVCS_ACCESS_TOKEN_ENDPOINT" #pragma: allowlist secret
   EvcsAccessTokenTtl:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_TTL" #pragma: allowlist secret
+    Default: "/stubs/orch/env/EVCS_ACCESS_TOKEN_TTL" #pragma: allowlist secret
   EvcsAccessTokenSigningKeyJwk:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/build/orch/env/EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK" #pragma: allowlist secret
+    Default: "/stubs/orch/env/EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK" #pragma: allowlist secret
 
 Conditions:
   IsDevelopment: !Not
@@ -737,7 +737,7 @@ Resources:
                 Action:
                   - "secretsmanager:GetSecretValue" #pragma: allowlist secret
                 Resource:
-                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/stubs/build/orch/*"
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/stubs/orch/*"
         - PolicyName: GetDynatraceSecret
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove env from orch stub parameter locations

### Why did it change

The orch-stub CloudFormation template pulls values for env vars from the parameter store. The path to the values includes an environment slug. This slug is always set to "build" which is confusing.

When defining a parameter in CloudFormation using the `AWS::SSM::Parameter::Value` type the default value has to be a literal string. You can't use the !Sub function to parameterise it for different envs for example.

The values for the parameter store parameters are defined in the stubs-common-infra repo and are defined per env (build and prod). We also define them in the dev config files in core-common-infra so we can deploy the orch stub to the dev account.  So we do already have some separation of config per env.

Setting config values as env vars in the ECS cluster means we don't need to worry about caching, and retrieving the values at runtime should be practically instantaneous. This is important for when we run the perf tests, as the orch-stub can be a bottle neck. I don't really want to change this and add another variable when analysing the perf tests.

As such, this PR just removes the use of the env slug. This should help to remove confusion about where the values are coming from.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4589](https://govukverify.atlassian.net/browse/PYIC-4589)


[PYIC-4589]: https://govukverify.atlassian.net/browse/PYIC-4589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ