### PR TITLE
OJ-2811: Generate international user context claim for Address CRI

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -277,12 +277,14 @@ public class CoreStubHandler {
             request.session().removeAttribute("evidence_request");
         }
 
+        var context = request.queryParams("context");
+
         AuthorizationRequest authRequest;
 
         try {
             authRequest =
                     handlerHelper.createAuthorizationJAR(
-                            state, credentialIssuer, sharedClaims, evidenceRequest);
+                            state, credentialIssuer, sharedClaims, evidenceRequest, context);
         } catch (JOSEException joseException) {
             LOGGER.error("JOSEException occurred," + joseException.getMessage());
             throw joseException;

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -95,6 +95,7 @@ public class HandlerHelper {
     public static final String UNKNOWN_ENV_VAR = "unknown";
     public static final String API_KEY_HEADER = "x-api-key";
     public static final String EVIDENCE_REQUESTED = "evidence_requested";
+    public static final String CONTEXT = "context";
 
     private final ECKey ecSigningKey;
     private final ObjectMapper objectMapper;
@@ -259,13 +260,14 @@ public class HandlerHelper {
             State state,
             CredentialIssuer credentialIssuer,
             T sharedClaims,
-            EvidenceRequestClaims evidenceRequest)
+            EvidenceRequestClaims evidenceRequest,
+            String context)
             throws JOSEException, java.text.ParseException {
         ClientID clientID = new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID);
 
         JWTClaimsSet claimsSet =
                 createJWTClaimsSets(
-                        state, credentialIssuer, clientID, sharedClaims, evidenceRequest);
+                        state, credentialIssuer, clientID, sharedClaims, evidenceRequest, context);
         // The only difference (frontend/backend) are the ClaimSets are created above for the
         // frontend and clientID is already set in the backend ClaimSet
         LOGGER.info("ClaimsSets generated: {}", claimsSet);
@@ -307,9 +309,21 @@ public class HandlerHelper {
             CredentialIssuer credentialIssuer,
             ClientID clientID,
             Object sharedClaims,
+            EvidenceRequestClaims evidenceRequest,
+            String context) {
+        return createJWTClaimsSetBuilder(
+                        state, credentialIssuer, clientID, sharedClaims, evidenceRequest, context)
+                .build();
+    }
+
+    public JWTClaimsSet createJWTClaimsSets(
+            State state,
+            CredentialIssuer credentialIssuer,
+            ClientID clientID,
+            Object sharedClaims,
             EvidenceRequestClaims evidenceRequest) {
         return createJWTClaimsSetBuilder(
-                        state, credentialIssuer, clientID, sharedClaims, evidenceRequest)
+                        state, credentialIssuer, clientID, sharedClaims, evidenceRequest, null)
                 .build();
     }
 
@@ -318,7 +332,8 @@ public class HandlerHelper {
             CredentialIssuer credentialIssuer,
             ClientID clientID,
             Object sharedClaims) {
-        return createJWTClaimsSetBuilder(state, credentialIssuer, clientID, sharedClaims, null)
+        return createJWTClaimsSetBuilder(
+                        state, credentialIssuer, clientID, sharedClaims, null, null)
                 .build();
     }
 
@@ -327,7 +342,8 @@ public class HandlerHelper {
             CredentialIssuer credentialIssuer,
             ClientID clientID,
             T sharedClaims,
-            EvidenceRequestClaims evidenceRequest) {
+            EvidenceRequestClaims evidenceRequest,
+            String context) {
 
         Instant now = Instant.now();
 
@@ -354,6 +370,9 @@ public class HandlerHelper {
         }
         if (Objects.nonNull(evidenceRequest)) {
             claimsSetBuilder.claim(EVIDENCE_REQUESTED, convertToMap(evidenceRequest));
+        }
+        if (!StringUtils.isEmpty(context)) {
+            claimsSetBuilder.claim(CONTEXT, context);
         }
         return claimsSetBuilder;
     }

--- a/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
@@ -70,12 +70,20 @@
                        value="{{name}}{{#isKbvCri}} - Evidence Requested{{/isKbvCri}}">
                 </a>
             {{/isKbvCri}}
-			{{#isAddressCri}}
-                <a href="{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}" >
-                <input class="govuk-button" data-module="govuk-button" type="button"
-                       value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}">
-                </a>
-			{{/isAddressCri}}
+            {{#isAddressCri}}
+                <div class="govuk-button-group">
+                    <a href="/credential-issuer?cri={{id}}&context=international_user" >
+                    <input class="govuk-button" data-module="govuk-button" type="button"
+                        value="{{name}}{{#isAddressCri}} - International Address{{/isAddressCri}}">
+                    </a>
+                </div>
+                <div class="govuk-button-group">
+                    <a href="{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}" >
+                    <input class="govuk-button" data-module="govuk-button" type="button"
+                        value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}">
+                    </a>
+                </div>
+            {{/isAddressCri}}
             <div class="govuk-button-group">
                 <a href="/credential-issuer?cri={{id}}">
                 <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>


### PR DESCRIPTION
## Proposed changes

### What changed

Added new buttons with label `Address CRI <env> - International Address` with query param `context=international_user` 
Refactored createJWTClaimsSet to add the context to the Auth JAR if present.

### Why did it change

Core stub needs to be updated to generate and pass the claim context: international_user , so that we can correctly simulate and test journeys for users with non-UK addresses.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2811](https://govukverify.atlassian.net/browse/OJ-2811)



[OJ-2811]: https://govukverify.atlassian.net/browse/OJ-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ