### PR TITLE
PYIC-6236: Rename f2fQueue to criResponseQueue

### DIFF
--- a/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
@@ -479,7 +479,7 @@ Resources:
           - Name: F2F_STUB_QUEUE_API_KEY
             Value: !Ref F2fStubQueueApiKey
           - Name: F2F_STUB_QUEUE_NAME
-            Value: !If [IsCoreDev, !Sub "stubQueue_F2FQueue_${Environment}", "stubQueue_F2FQueue_build"]
+            Value: !If [IsCoreDev, !Sub "stubQueue_criResponseQueue_${Environment}", "stubQueue_criResponseQueue_build"]
           Secrets:
             - Name: "VC_SIGNING_KEY"
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/f2f/env/VC_SIGNING_KEY"

--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -521,7 +521,7 @@ Resources:
           - Name: F2F_STUB_QUEUE_API_KEY
             Value: !Ref F2fStubQueueApiKey
           - Name: F2F_STUB_QUEUE_NAME
-            Value: !If [IsCoreDev, !Sub "stubQueue_F2FQueue_${Environment}", "stubQueue_F2FQueue_build"]
+            Value: !If [IsCoreDev, !Sub "stubQueue_criResponseQueue_${Environment}", "stubQueue_criResponseQueue_build"]
           Secrets:
             - Name: "VC_SIGNING_KEY"
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/stubs/credential-issuer/f2f/env/VC_SIGNING_KEY"

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueErrorEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueErrorEvent.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class F2FQueueErrorEvent {
+public class CriResponseQueueErrorEvent {
     private String sub;
     private String state;
     private String error;

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueEvent.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @Setter
 @AllArgsConstructor
-public class F2FQueueEvent {
+public class CriResponseQueueEvent {
     private String sub;
     private String state;
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FEnqueueLambdaRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FEnqueueLambdaRequest.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class F2FEnqueueLambdaRequest {
     private String queueName;
-    private F2FQueueEvent queueEvent;
+    private CriResponseQueueEvent queueEvent;
     private int delaySeconds;
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FErrorEnqueueLambdaRequest.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/F2FErrorEnqueueLambdaRequest.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class F2FErrorEnqueueLambdaRequest {
     private String queueName;
-    private F2FQueueErrorEvent queueEvent;
+    private CriResponseQueueErrorEvent queueEvent;
     private int delaySeconds;
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -841,7 +841,7 @@ public class AuthorizeHandler {
             F2FEnqueueLambdaRequest enqueueLambdaRequest =
                     new F2FEnqueueLambdaRequest(
                             f2fDetails.queueName(),
-                            new F2FQueueEvent(userId, state, List.of(signedVcJwt)),
+                            new CriResponseQueueEvent(userId, state, List.of(signedVcJwt)),
                             requireNonNullElse(
                                     f2fDetails.delaySeconds(), F2F_DEFAULT_DELAY_SECONDS));
 
@@ -868,7 +868,7 @@ public class AuthorizeHandler {
             F2FErrorEnqueueLambdaRequest enqueueLambdaRequest =
                     new F2FErrorEnqueueLambdaRequest(
                             f2fDetails.queueName(),
-                            new F2FQueueErrorEvent(
+                            new CriResponseQueueErrorEvent(
                                     userId, state, "access_denied", "Something went wrong"),
                             requireNonNullElse(
                                     f2fDetails.delaySeconds(), F2F_DEFAULT_DELAY_SECONDS));

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -664,7 +664,7 @@ class AuthorizeHandlerTest {
         }
 
         @Test
-        void apiAuthorizeShouldAllowVcToBeSentToF2fQueue() throws Exception {
+        void apiAuthorizeShouldAllowVcToBeSentToCriResponseQueue() throws Exception {
             when(mockContext.bodyAsClass(ApiAuthRequest.class))
                     .thenReturn(
                             new ApiAuthRequest(
@@ -674,7 +674,8 @@ class AuthorizeHandlerTest {
                                     "{\"activityHistoryScore\":1,\"checkDetails\":[{\"checkMethod\":\"vri\"},{\"biometricVerificationProcessLevel\":3,\"checkMethod\":\"bvr\"}],\"validityScore\":2,\"strengthScore\":3,\"type\":\"IdentityCheck\"}\"",
                                     null,
                                     null,
-                                    new F2fDetails(true, false, "stubQueue_F2FQueue_build", 0),
+                                    new F2fDetails(
+                                            true, false, "stubQueue_criResponseQueue_build", 0),
                                     null));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
             when(mockSignedJwt.serialize()).thenReturn(DCMAW_VC);
@@ -692,7 +693,7 @@ class AuthorizeHandlerTest {
         }
 
         @Test
-        void apiAuthorizeShouldAllowErrorToBeSentToF2fQueue() throws Exception {
+        void apiAuthorizeShouldAllowErrorToBeSentToCriResponseQueue() throws Exception {
             when(mockContext.bodyAsClass(ApiAuthRequest.class))
                     .thenReturn(
                             new ApiAuthRequest(
@@ -702,7 +703,8 @@ class AuthorizeHandlerTest {
                                     "{\"activityHistoryScore\":1,\"checkDetails\":[{\"checkMethod\":\"vri\"},{\"biometricVerificationProcessLevel\":3,\"checkMethod\":\"bvr\"}],\"validityScore\":2,\"strengthScore\":3,\"type\":\"IdentityCheck\"}\"",
                                     null,
                                     null,
-                                    new F2fDetails(false, true, "stubQueue_F2FQueue_build", 0),
+                                    new F2fDetails(
+                                            false, true, "stubQueue_criResponseQueue_build", 0),
                                     null));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
             when(mockSignedJwt.serialize()).thenReturn(DCMAW_VC);

--- a/di-ipv-queue-stub/deploy/template.yaml
+++ b/di-ipv-queue-stub/deploy/template.yaml
@@ -304,10 +304,10 @@ Resources:
       TargetKeyId: !Ref QueuesKmsKey
 
   # Shared dead-letter queue for all stub queues
-  F2FDLQ:
+  CriResponseDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: "stubQueue_F2FDLQ"
+      QueueName: "stubQueue_criResponse_deadLetterQueue"
       KmsMasterKeyId: !Ref QueuesKmsKey
       RedriveAllowPolicy:
         redrivePermission: allowAll

--- a/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
+++ b/di-ipv-queue-stub/enqueue-event/src/services/queueService.ts
@@ -30,7 +30,7 @@ export const getOrCreateSqsQueueUrl = async (
 
             // Create the queue if it does not exist
             const redrivePolicy = {
-                deadLetterTargetArn: `arn:aws:sqs:eu-west-2:${accountId}:stubQueue_F2FDLQ`,
+                deadLetterTargetArn: `arn:aws:sqs:eu-west-2:${accountId}:stubQueue_criResponse_deadLetterQueue`,
                 maxReceiveCount: "1"
             };
             const createQueueResponse = await sqsClient.send(new CreateQueueCommand({


### PR DESCRIPTION
## Proposed changes

### What changed

- Rename f2fQueue to criResponseQueue

### Why did it change

- As this queue will receive traffic from dcmawAsync as well

### Issue tracking

- [PYIC-6236](https://govukverify.atlassian.net/browse/PYIC-6236)

### Notes

This should only refactor and update the default queue put into the input for sending async VC

[PYIC-6236]: https://govukverify.atlassian.net/browse/PYIC-6236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ