### PR TITLE
OJ-2882: Add "Middle Name" option to edit-user screen

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FullName.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/FullName.java
@@ -2,10 +2,13 @@ package uk.gov.di.ipv.stub.core.config.uatuser;
 
 import spark.utils.StringUtils;
 
-public record FullName(String firstName, String surname) {
-    public String firstLastName() {
-        return "%s %s"
-                .formatted(nonBlankValueOrBlank(firstName), nonBlankValueOrBlank(surname))
+public record FullName(String firstName, String middleName, String surname) {
+    public String fullName() {
+        return "%s %s %s"
+                .formatted(
+                        nonBlankValueOrBlank(firstName),
+                        nonBlankValueOrBlank(middleName),
+                        nonBlankValueOrBlank(surname))
                 .trim();
     }
 

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -69,7 +69,7 @@ public class IdentityMapper {
 
         FindDateOfBirth dateOfBirth = new FindDateOfBirth(dob, dob);
 
-        FullName name = new FullName(map.get("name"), map.get("surname"));
+        FullName name = new FullName(map.get("name"), "", map.get("surname"));
         String nino = null;
 
         return new Identity(
@@ -86,7 +86,7 @@ public class IdentityMapper {
     public DisplayIdentity mapToDisplayable(Identity identity) {
         return new DisplayIdentity(
                 identity.rowNumber(),
-                identity.name().firstLastName(),
+                identity.name().fullName(),
                 identity.questions().numQuestionsTotal());
     }
 
@@ -127,6 +127,7 @@ public class IdentityMapper {
                         new Name(
                                 List.of(
                                         new NameParts(GIVEN_NAME, identity.name().firstName()),
+                                        new NameParts(GIVEN_NAME, identity.name().middleName()),
                                         new NameParts(FAMILY_NAME, identity.name().surname())))),
                 List.of(new DateOfBirth(agedDOB ? dateOfBirth.getAgedDOB() : dateOfBirth.getDOB())),
                 canonicalAddresses,
@@ -226,7 +227,12 @@ public class IdentityMapper {
         FindDateOfBirth findDateOfBirth =
                 new FindDateOfBirth(
                         instant, LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
-        FullName fullName = new FullName(formData.value("firstName"), formData.value("surname"));
+
+        String enteredMiddleName = formData.value("middleName");
+        String middleName = enteredMiddleName == null ? "" : enteredMiddleName;
+
+        FullName fullName =
+                new FullName(formData.value("firstName"), middleName, formData.value("surname"));
         String nino = formData.value("nationalInsuranceNumber");
         return new Identity(
                 identityOnRecord.rowNumber(),

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -523,7 +523,7 @@ public class CoreStubHandler {
     private Identity createNewIdentity() {
         Identity identity;
         UKAddress ukAddress = new UKAddress(null, null, null, null, null, null, null, null);
-        FullName fullName = new FullName(null, null);
+        FullName fullName = new FullName(null, null, null);
         Instant dob = Instant.ofEpochSecond(0);
         identity =
                 new Identity(

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -398,7 +398,7 @@ public class HandlerHelper {
                     .filter(
                             identity ->
                                     identity.name()
-                                            .firstLastName()
+                                            .fullName()
                                             .toLowerCase()
                                             .contains(searchTerm.toLowerCase()))
                     .collect(Collectors.toList());

--- a/di-ipv-core-stub/src/main/resources/templates/edit-user.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/edit-user.mustache
@@ -71,6 +71,11 @@
             </div>
 
             <div class="govuk-form-group">
+                <label class="govuk-label" for="middleName">Middle name</label>
+                <input class="govuk-input" id="middleName" name="middleName" type="text" value="{{identity.name.middleName}}">
+             </div>
+
+            <div class="govuk-form-group">
                 <label class="govuk-label" for="surname">Last name</label>
                 <input class="govuk-input" id="surname" name="surname" type="text" value="{{identity.name.surname}}">
             </div>


### PR DESCRIPTION
## Proposed changes

### What changed
Added a "Middle Name" option to the edit-user screen

### Why did it change
In a real scenario, a user can provide a middle name however on our core-stub, we do not provide a way to enter a middle name. This means that when we do testing using the core stub, we do not test scenarios that involve a middle name. 

**Screenshot**
![Screenshot 2024-10-14 at 16 09 45](https://github.com/user-attachments/assets/f098aa14-cf25-4b13-a71b-9c8a2598df41)

### Issue tracking
- [OJ-2882](https://govukverify.atlassian.net/browse/OJ-2882)
