### PR TITLE
LIME-1276 new inputs for sending context and shared claims as raw JSON

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -40,6 +40,7 @@ public class CoreStub {
         Spark.get("/evidence-request", coreStubHandler.evidenceRequest);
         Spark.get("/authorize", coreStubHandler.authorize);
         Spark.get("/user-search", coreStubHandler.userSearch);
+        Spark.post("/user-search", coreStubHandler.sendRawSharedClaim);
         Spark.get("/edit-user", coreStubHandler.editUser);
         Spark.post("/edit-user", coreStubHandler.updateUser);
         Spark.get("/callback", coreStubHandler.doCallback);

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/DrivingPermit.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/DrivingPermit.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.stub.core.config.uatuser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DrivingPermit(
+        String personalNumber,
+        String issueNumber,
+        String issuedBy,
+        String fullAddress,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate expiryDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate issueDate) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -133,9 +133,8 @@ public class IdentityMapper {
                 List.of(new Name(parts)),
                 List.of(new DateOfBirth(agedDOB ? dateOfBirth.getAgedDOB() : dateOfBirth.getDOB())),
                 canonicalAddresses,
-                identity.nino() == null
-                        ? null
-                        : List.of(new SocialSecurityRecord(identity.nino())));
+                identity.nino() == null ? null : List.of(new SocialSecurityRecord(identity.nino())),
+                null);
     }
 
     public PostcodeSharedClaims mapToAddressSharedClaims(String postcode) {

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/SharedClaims.java
@@ -13,4 +13,5 @@ public record SharedClaims(
         @JsonProperty("name") List<Name> name,
         @JsonProperty("birthDate") List<DateOfBirth> birthDate,
         @JsonProperty("address") List<CanonicalAddress> addresses,
-        @JsonProperty("socialSecurityRecord") List<SocialSecurityRecord> socialSecurityRecord) {}
+        @JsonProperty("socialSecurityRecord") List<SocialSecurityRecord> socialSecurityRecord,
+        @JsonProperty("drivingPermit") List<DrivingPermit> drivingPermit) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -263,14 +263,13 @@ public class HandlerHelper {
             T sharedClaims,
             EvidenceRequestClaims evidenceRequest,
             String context)
-            throws JOSEException, java.text.ParseException {
+            throws JOSEException, java.text.ParseException, JsonProcessingException {
         ClientID clientID = new ClientID(CoreStubConfig.CORE_STUB_CLIENT_ID);
 
         JWTClaimsSet claimsSet =
                 createJWTClaimsSets(
                         state, credentialIssuer, clientID, sharedClaims, evidenceRequest, context);
-        // The only difference (frontend/backend) are the ClaimSets are created above
-        // for the
+        // The only difference (frontend/backend) are the ClaimSets are created above for the
         // frontend and clientID is already set in the backend ClaimSet
         LOGGER.info("ClaimsSets generated: {}", claimsSet);
         return createBackEndAuthorizationJAR(credentialIssuer, claimsSet);

--- a/di-ipv-core-stub/src/main/resources/templates/user-search.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/user-search.mustache
@@ -79,13 +79,23 @@
             Experian UAT test users sheet</a></legend>
         <form action="/authorize">
             <input type="hidden" name="cri" value="{{cri}}">
-
             <div class="govuk-form-group">
                 <input class="govuk-input govuk-input--width-3" id="rowNumber" name="rowNumber" type="text"
                        placeholder="3">
                 <button class="govuk-button" data-module="govuk-button">Go to {{criName}}</button>
             </div>
         </form>
+
+                <form action="/user-search" method="post">
+                    <input type="hidden" name="cri" value="{{cri}}">
+                    <div class="govuk-form-group">
+                        <legend class="govuk-fieldset__legend govuk-label">Input context value as a string (e.g. check_details) </legend>
+                            <input class="govuk-input govuk-input--width-20" id="context" name="context" type="text">
+                        <legend class="govuk-fieldset__legend govuk-label" style="padding:5px,0,0,0,">Input shared claims raw JSON</legend>
+                            <input class="govuk-input govuk-input--width-20" id="claimsText" name="claimsText" type="text">
+                        <button class="govuk-button" data-module="govuk-button">Go to {{criName}}</button>
+                    </div>
+                </form>
 
     </main>
 </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Two fields and functionality added to send context and shared_claims as raw JSON. 

### Why did it change

To facilitate quick testing using different context and shared_claims data

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1276](https://govukverify.atlassian.net/browse/LIME-1276)
- Draft confluence page explaining updates [here](https://govukverify.atlassian.net/wiki/spaces/Lime/pages/edit-v2/4610261040?draftShareId=c093c582-b7bd-470e-90b8-fb0b23be65af)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->


### Other considerations

This includes a fix in identity mapping whereby null value middle names were not previously accounted for. 

[LIME-1276]: https://govukverify.atlassian.net/browse/LIME-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ