### PR TITLE
BAU: Strip free text inputs to orch stub

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -119,9 +119,9 @@ public class IpvHandler {
     private String getAuthorizeRedirect(Context ctx, String errorType) throws Exception {
 
         var environment = ctx.queryParam(ENVIRONMENT_PARAM);
-        var userIdTextValue = ctx.queryParam(USER_ID_PARAM);
-        var signInJourneyIdText = ctx.queryParam(JOURNEY_ID_PARAM);
-        var userEmailAddress = ctx.queryParam(EMAIL_ADDRESS_PARAM);
+        var userIdTextValue = stripIfNotNull(ctx.queryParam(USER_ID_PARAM));
+        var signInJourneyIdText = stripIfNotNull(ctx.queryParam(JOURNEY_ID_PARAM));
+        var userEmailAddress = stripIfNotNull(ctx.queryParam(EMAIL_ADDRESS_PARAM));
         var userId = getUserIdValue(userIdTextValue);
         var isMfaReset = Objects.equals(ctx.queryParam(MFA_RESET_PARAM), CHECKBOX_CHECKED_VALUE);
 
@@ -205,6 +205,10 @@ public class IpvHandler {
                         .build();
 
         return authRequest.toURI().toString();
+    }
+
+    private String stripIfNotNull(String value) {
+        return value == null ? null : value.strip();
     }
 
     private URI getIpvEndpoint(String environment) throws URISyntaxException {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Strip free text inputs to orch stub

### Why did it change

The most of the freetext inputs to orch-stub weren't being stripped. This is most notably a problem if you copy a userId from Splunk and paste it in - it comes with a whitespace.

The result is that the user ID in the EVCS signed JWT access token doesn't match the user ID that gets sent by core to EVCS (which probably does strip it somewhere). And you get an access denied error from EVCS.
