### PR TITLE
PYIC-6568 Clean up unused config

### DIFF
--- a/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
@@ -80,14 +80,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/orch/env/IPV_BACKCHANNEL_ENDPOINT" #pragma: allowlist secret
-  IpvBackchannelTokenPath:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/orch/env/IPV_BACKCHANNEL_TOKEN_PATH" #pragma: allowlist secret
-  IpvBackchannelUserIdentityPath:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/orch/env/IPV_BACKCHANNEL_USER_IDENTITY_PATH" #pragma: allowlist secret
   IpvEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -578,10 +570,6 @@ Resources:
               Value: !Ref OrchestratorIntegrationJarEncryptionPublicKey
             - Name: IPV_BACKCHANNEL_ENDPOINT
               Value: !Ref IpvBackchannelEndpoint
-            - Name: IPV_BACKCHANNEL_TOKEN_PATH
-              Value: !Ref IpvBackchannelTokenPath
-            - Name: IPV_BACKCHANNEL_USER_IDENTITY_PATH
-              Value: !Ref IpvBackchannelUserIdentityPath
             - Name: IPV_ENDPOINT
               Value: !Ref IpvEndpoint
             - Name: IPV_CORE_AUDIENCE

--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -95,14 +95,6 @@ Parameters:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
     Default: "/stubs/orch/env/IPV_BACKCHANNEL_ENDPOINT" #pragma: allowlist secret
-  IpvBackchannelTokenPath:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/orch/env/IPV_BACKCHANNEL_TOKEN_PATH" #pragma: allowlist secret
-  IpvBackchannelUserIdentityPath:
-    Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/stubs/orch/env/IPV_BACKCHANNEL_USER_IDENTITY_PATH" #pragma: allowlist secret
   IpvEndpoint:
     Description: "Environment Variables for ECS - Retrieved from SSM Parameter Store"
     Type: AWS::SSM::Parameter::Value<String>
@@ -606,10 +598,6 @@ Resources:
               Value: !Ref OrchestratorIntegrationJarEncryptionPublicKey
             - Name: IPV_BACKCHANNEL_ENDPOINT
               Value: !Ref IpvBackchannelEndpoint
-            - Name: IPV_BACKCHANNEL_TOKEN_PATH
-              Value: !Ref IpvBackchannelTokenPath
-            - Name: IPV_BACKCHANNEL_USER_IDENTITY_PATH
-              Value: !Ref IpvBackchannelUserIdentityPath
             - Name: IPV_ENDPOINT
               Value: !Ref IpvEndpoint
             - Name: IPV_CORE_AUDIENCE


### PR DESCRIPTION
## Proposed changes

### What changed

Remove references to `IPV_BACKCHANNEL_TOKEN_PATH` and `IPV_BACKCHANNEL_USER_IDENTITY_PATH`

### Why did it change

They are unused

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6568](https://govukverify.atlassian.net/browse/PYIC-6568)


[PYIC-6568]: https://govukverify.atlassian.net/browse/PYIC-6568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ