### PR TITLE
BAU: Fix when no middle name in JWT

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -119,16 +119,18 @@ public class IdentityMapper {
                                 })
                         .collect(toList());
 
+        List<NameParts> parts = new ArrayList<>();
+        parts.add(new NameParts(GIVEN_NAME, identity.name().firstName()));
+        if (!identity.name().middleName().isBlank()) {
+            parts.add(new NameParts(GIVEN_NAME, identity.name().middleName()));
+        }
+        parts.add(new NameParts(FAMILY_NAME, identity.name().surname()));
+
         return new SharedClaims(
                 List.of(
                         "https://www.w3.org/2018/credentials/v1",
                         "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"),
-                List.of(
-                        new Name(
-                                List.of(
-                                        new NameParts(GIVEN_NAME, identity.name().firstName()),
-                                        new NameParts(GIVEN_NAME, identity.name().middleName()),
-                                        new NameParts(FAMILY_NAME, identity.name().surname())))),
+                List.of(new Name(parts)),
                 List.of(new DateOfBirth(agedDOB ? dateOfBirth.getAgedDOB() : dateOfBirth.getDOB())),
                 canonicalAddresses,
                 identity.nino() == null


### PR DESCRIPTION
## Proposed changes

### What changed
Add middle name to JWT if it's present/not blank.

### Why did it change
The person identity table had a "GivenName" field with no value attached causing errors in Check HMRC.

![Screenshot 2024-10-18 at 10 32 27](https://github.com/user-attachments/assets/c933ba5f-4f26-45f3-b1eb-49d6d8bc2f7b)

