### PR TITLE
bau-fix-middle-name-in-jwt

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -121,7 +121,7 @@ public class IdentityMapper {
 
         List<NameParts> parts = new ArrayList<>();
         parts.add(new NameParts(GIVEN_NAME, identity.name().firstName()));
-        if (!identity.name().middleName().isBlank()) {
+        if (identity.name().middleName() != null && !identity.name().middleName().isBlank()) {
             parts.add(new NameParts(GIVEN_NAME, identity.name().middleName()));
         }
         parts.add(new NameParts(FAMILY_NAME, identity.name().surname()));


### PR DESCRIPTION
## Proposed changes

### What changed
Added null check to middle name

### Why did it change
Was causing an NPE when using users that have no middle name.

