### PR TITLE
PYIC-7581: Add `/migration/...` endpoint to evcs stub

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -376,35 +376,35 @@
         "filename": "di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts",
         "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 33
       },
       {
         "type": "JSON Web Token",
         "filename": "di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts",
         "hashed_secret": "cb498892d71e652f2c8ab9f595e7b9b3c8df83fb",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts",
         "hashed_secret": "a2fcd7a0ad73d6a95764ce22d253ca83fb4f4958",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 72
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts",
         "hashed_secret": "132479e05bec1139350a743f6e21c4f913c45cbf",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 82
       },
       {
         "type": "JSON Web Token",
         "filename": "di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts",
         "hashed_secret": "94960314d11935b5d2a71e772c8bf9eeaab766ef",
         "is_verified": false,
-        "line_number": 99
+        "line_number": 100
       }
     ],
     "di-ipv-evcs-stub/openAPI/evcs-external.yaml": [
@@ -460,5 +460,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-28T07:53:41Z"
+  "generated_at": "2024-10-23T12:21:06Z"
 }

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -230,6 +230,12 @@ Resources:
             RestApiId: !Ref RestApiGateway
             Path: /vcs/{userId}
             Method: GET
+        GetMigratedUserVCs:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /migration/{userId}
+            Method: GET
     Metadata:
       # Manage esbuild properties
       BuildMethod: esbuild

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -266,6 +266,12 @@ Resources:
             RestApiId: !Ref RestApiGateway
             Path: /vcs/{userId}
             Method: GET
+        GetMigratedUserVCs:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /migration/{userId}
+            Method: GET
     Metadata:
       # Manage esbuild properties
       BuildMethod: esbuild

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
@@ -79,18 +79,20 @@ export async function getHandler(
     try {
       requestedStates = getRequestedStates(event);
 
-      accessTokenVerified = await verifyAccessToken(
-        validateAccessToken(
-          event.headers
-            ? event.headers[
-                Object.keys(event.headers).find(
-                  (header) => header.toLowerCase() === "authorization",
-                ) || ""
-              ]
-            : undefined,
-        ),
-        decodedUserId,
-      );
+      accessTokenVerified = event.path?.startsWith("/migration")
+        ? true
+        : await verifyAccessToken(
+            validateAccessToken(
+              event.headers
+                ? event.headers[
+                    Object.keys(event.headers).find(
+                      (header) => header.toLowerCase() === "authorization",
+                    ) || ""
+                  ]
+                : undefined,
+            ),
+            decodedUserId,
+          );
     } catch (error) {
       console.error(error);
       return buildApiResponse({ message: getErrorMessage(error) }, 400);

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -162,6 +162,63 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
+  /migration/{userId}:
+    get:
+      description: "Returns a list of user verifiable credentials"
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: urn:uuid:d1823066-2137-4380-b0ba-4b61947e08e6
+          description: A valid uuid as user Id.
+        - name: state
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/VCStates"
+            example: CURRENT, PENDING_RETURN or ALL
+          description: A valid comma separated state value or ALL to retrieve VCs in all available states.
+        - name: afterKey
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/VCSignature"
+            example: qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ
+          description: A VC signature to retrieve next set of VCs, its used for pagination.
+      responses:
+        200:
+          description: "The list of Verifiable Credentials"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  vcs:
+                    type: array
+                    description: List of user VCs.
+                  afterKey:
+                    type: string
+                    description: Indicates that the user has more VCs than the ones returned in the response. If full set of VCS is required subsequent calls should be made with this value as a query string parameter, until this value is not returned in the response.
+                    example: qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ
+        400:
+          $ref: '#/components/responses/BadRequest'
+        500:
+          $ref: '#/components/responses/ServerError'
+      x-amazon-apigateway-request-validator: ALL
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsGetUserVCsFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: '{"result": "success"}'
 components:
   responses:
     BadRequest:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add `/migration/...` endpoint to evcs stub

### Why did it change

As part of the plans to reconcile the VCs migrated into EVCS, the EVCS system will be opening a temporary endpoint for us to fetch VCs without an access token. This adds the same to our stub to allow us to test the process in dev and build.

EVCS actual implementation can be found here: https://github.com/govuk-one-login/di-id-reuse-storage/pull/1047

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7581](https://govukverify.atlassian.net/browse/PYIC-7581)


[PYIC-7581]: https://govukverify.atlassian.net/browse/PYIC-7581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ