### PR TITLE
PYIC-7620: Remove dependencies on old version of AWS Dynamo library

### DIFF
--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -16,9 +16,9 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.amazonaws:aws-lambda-java-events:3.14.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.773",
 			"software.amazon.awssdk:dynamodb-enhanced:2.29.3",
 			"com.fasterxml.jackson.core:jackson-annotations:2.18.0",
+			"com.fasterxml.jackson.core:jackson-databind:2.18.1",
 			"org.apache.logging.log4j:log4j-api:2.23.1",
 			"org.apache.logging.log4j:log4j-core:2.24.1",
 			"org.apache.logging.log4j:log4j-layout-template-json:2.24.1",

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
@@ -1,11 +1,11 @@
 package uk.gov.di.ipv.core.putcontraindicators.service;
 
-import com.amazonaws.util.CollectionUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
+import software.amazon.awssdk.utils.CollectionUtils;
 import uk.gov.di.ipv.core.library.persistence.items.CimitStubItem;
 import uk.gov.di.ipv.core.library.service.CimitStubItemService;
 import uk.gov.di.ipv.core.library.service.ConfigService;

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -16,9 +16,9 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.amazonaws:aws-lambda-java-events:3.14.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.773",
 			"software.amazon.awssdk:dynamodb-enhanced:2.29.3",
 			"com.fasterxml.jackson.core:jackson-annotations:2.18.0",
+			"com.fasterxml.jackson.core:jackson-databind:2.18.1",
 			"org.apache.logging.log4j:log4j-api:2.23.1",
 			"org.apache.logging.log4j:log4j-core:2.24.1",
 			"org.apache.logging.log4j:log4j-layout-template-json:2.24.1",

--- a/di-ipv-cimit-stub/lambdas/stub-management/src/main/java/uk/gov/di/ipv/core/stubmanagement/StubManagementHandler.java
+++ b/di-ipv-cimit-stub/lambdas/stub-management/src/main/java/uk/gov/di/ipv/core/stubmanagement/StubManagementHandler.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.stubmanagement;
 
-import com.amazonaws.HttpMethod;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
@@ -8,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import uk.gov.di.ipv.core.library.model.UserCisRequest;
 import uk.gov.di.ipv.core.library.model.UserMitigationRequest;
 import uk.gov.di.ipv.core.library.service.CimitStubItemService;
@@ -36,7 +36,7 @@ public class StubManagementHandler
     private static final Pattern CIS_MITIGATIONS =
             Pattern.compile("^/user/[-a-zA-Z0-9_:]+/mitigations/[-a-zA-Z0-9_]+$");
     private static final List<String> SUPPORTED_MITIGATION_METHODS =
-            List.of(HttpMethod.POST.toString(), HttpMethod.PUT.toString());
+            List.of(SdkHttpMethod.POST.toString(), SdkHttpMethod.PUT.toString());
 
     private static final String USER_ID_PATH_PARAMS = "userId";
     private static final String CI_PATH_PARAMS = "ci";
@@ -75,9 +75,9 @@ public class StubManagementHandler
                                 objectMapper
                                         .getTypeFactory()
                                         .constructCollectionType(List.class, UserCisRequest.class));
-                if (httpMethod.equals(HttpMethod.POST.toString())) {
+                if (httpMethod.equals(SdkHttpMethod.POST.toString())) {
                     userService.addUserCis(userId, userCisRequests);
-                } else if (httpMethod.equals(HttpMethod.PUT.toString())) {
+                } else if (httpMethod.equals(SdkHttpMethod.PUT.toString())) {
                     userService.updateUserCis(userId, userCisRequests);
                 } else {
                     return buildErrorResponse("Http Method is not supported.", 400);

--- a/di-ipv-cimit-stub/lib/build.gradle
+++ b/di-ipv-cimit-stub/lib/build.gradle
@@ -9,8 +9,7 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-dynamodb:1.12.773",
-			"software.amazon.awssdk:dynamodb-enhanced:2.29.3",
+	implementation "software.amazon.awssdk:dynamodb-enhanced:2.29.3",
 			"software.amazon.lambda:powertools-parameters:1.16.1",
 			"software.amazon.awssdk:kms:2.29.2",
 			"org.apache.logging.log4j:log4j-api:2.23.1",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove dependency on old version of AWS dynamoDb library

### Why did it change

We're already using the new version too, and this version appears to only be used for it's dependencies which we can depend on directly instead.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7620](https://govukverify.atlassian.net/browse/PYIC-7620)


[PYIC-7620]: https://govukverify.atlassian.net/browse/PYIC-7620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ