### PR TITLE
BAU: Remove canary remnants

### DIFF
--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -8,7 +8,6 @@ Globals:
 Description: >-
   This creates the necessary components to deploy IPV Orch Stub onto ECS
   Fargate within the dev platform VPC and private subnets (provided as parameters)
-
 Parameters:
   Environment:
     Description: The name of the environment to deploy to.
@@ -367,19 +366,14 @@ Resources:
     Type: "AWS::ECS::Service"
     Properties:
       Cluster: !Ref OrchStubCluster
-      DeploymentConfiguration: !If
-        - IsNotDevelopment
-        - !Ref AWS::NoValue
-        - MaximumPercent: 200
-          MinimumHealthyPercent: 50
-          DeploymentCircuitBreaker:
-            Enable: true
-            Rollback: true
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
       DeploymentController:
-        Type: !If
-          - IsNotDevelopment
-          - CODE_DEPLOY
-          - ECS
+        Type: ECS
       DesiredCount: !FindInMap
         - EnvironmentConfiguration
         - !Ref AWS::AccountId
@@ -399,10 +393,7 @@ Resources:
           Subnets:
             - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
             - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
-      TaskDefinition: !If
-        - IsNotDevelopment
-        - !Ref AWS::NoValue
-        - !Ref ECSServiceTaskDefinition
+      TaskDefinition: !Ref ECSServiceTaskDefinition
     DependsOn:
       - LoadBalancerListener
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove canary remnants

### Why did it change

A while ago we removed the canaray deployments from orch-stub as they weren't necessary and were causing issues. Looks like we (I) missed a few bits.

This has recently reared it's head when updating the task definition. The pipeline can't find the task definition because we're removing it...

The PRs that added these bits are here:
https://github.com/govuk-one-login/ipv-stubs/pull/648
https://github.com/govuk-one-login/ipv-stubs/pull/671
