### PR TITLE
PYIC-7468 DCMAW async stub management endpoint follow up

### DIFF
--- a/di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml
@@ -549,6 +549,9 @@ Resources:
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
       SSESpecification:
         SSEEnabled: true
         SSEType: KMS

--- a/di-ipv-dcmaw-async-stub/deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/deploy/template.yaml
@@ -582,6 +582,9 @@ Resources:
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
       SSESpecification:
         SSEEnabled: true
         SSEType: KMS

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -16,6 +16,7 @@ export async function buildMockVc(
   const config = await getConfig();
   const timestamp = Math.round(new Date().getTime() / 1000);
   return {
+    jti: crypto.randomUUID(),
     iss: config.vcIssuer,
     aud: config.vcAudience,
     sub: userId,

--- a/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
@@ -2,7 +2,6 @@ import {
   DynamoDB,
   GetItemInput,
   UpdateItemInput,
-  DeleteItemInput
 } from "@aws-sdk/client-dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import { getEnvironmentVariable } from "../common/config";

--- a/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
@@ -25,12 +25,14 @@ export async function persistState(
   const updateItemInput: UpdateItemInput = {
     TableName: userStateTableName,
     Key: marshall({ userId }),
-    UpdateExpression: "set #state = :state",
+    UpdateExpression: "set #state = :state, #ttl = :ttl",
     ExpressionAttributeNames: {
       "#state": "state",
+      "#ttl": "ttl",
     },
     ExpressionAttributeValues: marshall({
       ":state": state,
+      ":ttl": Math.floor(Date.now() / 1000) + 3600, // epoch timestamp in seconds
     }),
   };
   await dynamoClient.updateItem(updateItemInput);


### PR DESCRIPTION
## Proposed changes

### What changed

- [Add missing jti claim in VC](https://github.com/govuk-one-login/ipv-stubs/commit/447c9415a430b60a89cf876075c826a308a086aa)
- [Add a TTL to clean up state records after 1 hour in case of orphaned sessions](https://github.com/govuk-one-login/ipv-stubs/commit/627cbae42e7a150adadf6e27f24c4b2348ff1f96)

### Why did it change

A couple of things discovered when testing in build

### Issue tracking
- [PYIC-7468](https://govukverify.atlassian.net/browse/PYIC-7468)



[PYIC-7468]: https://govukverify.atlassian.net/browse/PYIC-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ