### PR TITLE
PYIC-7631: Remove basic auth from jwks endpoint

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/BasicAuthHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/BasicAuthHandler.java
@@ -10,8 +10,14 @@ import java.util.Base64;
 public class BasicAuthHandler {
     private static final int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
     private static final String AUTHORIZATION_TYPE = "Basic";
+    private static final String JWKS_PATH = "/.well-known/jwks.json";
 
     public void authFilter(Context ctx) {
+        if (ctx.path().equals(JWKS_PATH)) {
+            // We don't need basic auth on the jwks endpoint
+            return;
+        }
+
         var authHeader = ctx.header(Header.AUTHORIZATION);
         if (authHeader == null || !authenticated(authHeader)) {
             ctx.header(Header.WWW_AUTHENTICATE, AUTHORIZATION_TYPE);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove basic auth from jwks endpoint

### Why did it change

We don't need it and it makes the config for core more tricky.

There's no `beforeExcept` filter, so this seemed easier than configuring the basic auth handler on each endpoint directly.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7631](https://govukverify.atlassian.net/browse/PYIC-7631)


[PYIC-7631]: https://govukverify.atlassian.net/browse/PYIC-7631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ