### PR TITLE
PYIC-7660: Configure auth client ID

### DIFF
--- a/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/template.yaml
@@ -460,6 +460,8 @@ Resources:
               Value: '{{resolve:ssm:/stubs/orch/env/ORCHESTRATOR_PORT}}'
             - Name: ORCHESTRATOR_SIGNING_JWK
               Value: '{{resolve:ssm:/stubs/orch/env/ORCHESTRATOR_SIGNING_JWK}}'
+            - Name: AUTH_CLIENT_ID
+              Value: '{{resolve:ssm:/stubs/orch/env/AUTH_CLIENT_ID}}'
             - Name: AUTH_SIGNING_JWK
               Value: '{{resolve:ssm:/stubs/orch/env/AUTH_SIGNING_JWK}}'
             - Name: ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_JWK

--- a/di-ipv-orchestrator-stub/deploy/template.yaml
+++ b/di-ipv-orchestrator-stub/deploy/template.yaml
@@ -467,6 +467,8 @@ Resources:
               Value: '{{resolve:ssm:/stubs/orch/env/ORCHESTRATOR_PORT}}'
             - Name: ORCHESTRATOR_SIGNING_JWK
               Value: '{{resolve:ssm:/stubs/orch/env/ORCHESTRATOR_SIGNING_JWK}}'
+            - Name: AUTH_CLIENT_ID
+              Value: '{{resolve:ssm:/stubs/orch/env/AUTH_CLIENT_ID}}'
             - Name: AUTH_SIGNING_JWK
               Value: '{{resolve:ssm:/stubs/orch/env/AUTH_SIGNING_JWK}}'
             - Name: ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_JWK


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Configure auth client ID

### Why did it change

The orch stub is falling back to the hard coded default for the auth stub client ID, as we haven't set the env var that it checks. This sets the env var from the value in config.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7660](https://govukverify.atlassian.net/browse/PYIC-7660)


[PYIC-7660]: https://govukverify.atlassian.net/browse/PYIC-7660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ