### PR TITLE
PYIC-6951: Add missing cri types to validator

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/validation/Validator.java
@@ -26,6 +26,9 @@ public class Validator {
     private static final String INVALID_ACTIVITY_VALUES_ERROR_CODE = "1003";
     private static final String INVALID_FRAUD_VALUES_ERROR_CODE = "1004";
     private static final String INVALID_VERIFICATION_VALUES_ERROR_CODE = "1005";
+    private static final String INVALID_EVIDENCE_DRIVING_LICENCE_VALUES_ERROR_CODE = "1006";
+    private static final String INVALID_DOC_CHECK_APP_VALUES_ERROR_CODE = "1007";
+    private static final String INVALID_F2F_VALUES_ERROR_CODE = "1008";
 
     public static final String API_GATEWAY_CALLBACK_SUFFIX =
             "execute-api.eu-west-2.amazonaws.com/credential-issuer/callback";
@@ -65,6 +68,48 @@ public class Validator {
                             new ErrorObject(
                                     INVALID_EVIDENCE_VALUES_ERROR_CODE,
                                     "Invalid numbers provided for evidence strength and validity"));
+                }
+            case EVIDENCE_DRIVING_LICENCE_CRI_TYPE:
+                try {
+                    Integer.parseInt(strengthValue);
+                    Integer.parseInt(validityValue);
+                    Integer.parseInt(activityValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(fraudValue, verificationValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(
+                            false,
+                            new ErrorObject(
+                                    INVALID_EVIDENCE_DRIVING_LICENCE_VALUES_ERROR_CODE,
+                                    "Invalid numbers provided for evidence strength, validity and activity"));
+                }
+            case DOC_CHECK_APP_CRI_TYPE:
+                try {
+                    Integer.parseInt(strengthValue);
+                    Integer.parseInt(validityValue);
+                    Integer.parseInt(activityValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(fraudValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(
+                            false,
+                            new ErrorObject(
+                                    INVALID_DOC_CHECK_APP_VALUES_ERROR_CODE,
+                                    "Invalid numbers provided for evidence strength, validity and activity"));
+                }
+            case F2F_CRI_TYPE:
+                try {
+                    Integer.parseInt(strengthValue);
+                    Integer.parseInt(validityValue);
+                    Integer.parseInt(verificationValue);
+
+                    return areStringsNullOrEmpty(Arrays.asList(activityValue, fraudValue));
+                } catch (NumberFormatException e) {
+                    return new ValidationResult(
+                            false,
+                            new ErrorObject(
+                                    INVALID_F2F_VALUES_ERROR_CODE,
+                                    "Invalid numbers provided for evidence strength, validity and verification"));
                 }
             case ACTIVITY_CRI_TYPE:
                 try {

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/validation/ValidatorTest.java
@@ -156,6 +156,90 @@ class ValidatorTest {
     }
 
     @Test
+    void shouldReturnSuccessfulValidationOnValidDrivingLicenceEvidenceGpg() {
+        ValidationResult result =
+                Validator.verifyGpg45(
+                        CriType.EVIDENCE_DRIVING_LICENCE_CRI_TYPE, "1", "3", "1", null, null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInDrivingLicenceEvidence() {
+        ValidationResult result =
+                Validator.verifyGpg45(
+                        CriType.EVIDENCE_DRIVING_LICENCE_CRI_TYPE,
+                        "abc",
+                        "/&43",
+                        "as1",
+                        null,
+                        null);
+        assertFalse(result.isValid());
+        assertEquals(
+                "Invalid numbers provided for evidence strength, validity and activity",
+                result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnDrivingLicenceEvidence() {
+        ValidationResult result =
+                Validator.verifyGpg45(
+                        CriType.EVIDENCE_DRIVING_LICENCE_CRI_TYPE, "1", "2", "1", "4", null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnSuccessfulValidationOnValidDocCheckAppEvidenceGpg() {
+        ValidationResult result =
+                Validator.verifyGpg45(CriType.DOC_CHECK_APP_CRI_TYPE, "1", "3", "1", null, null);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInDocCheckAppEvidence() {
+        ValidationResult result =
+                Validator.verifyGpg45(
+                        CriType.DOC_CHECK_APP_CRI_TYPE, "abc", "/&43", null, null, null);
+        assertFalse(result.isValid());
+        assertEquals(
+                "Invalid numbers provided for evidence strength, validity and activity",
+                result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnDocCheckAppEvidence() {
+        ValidationResult result =
+                Validator.verifyGpg45(CriType.DOC_CHECK_APP_CRI_TYPE, "1", "2", "1", "4", null);
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnSuccessfulValidationOnValidF2fEvidenceGpg() {
+        ValidationResult result =
+                Validator.verifyGpg45(CriType.F2F_CRI_TYPE, "1", "3", null, null, "1");
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfInvalidNumberParamProvidedInF2fEvidence() {
+        ValidationResult result =
+                Validator.verifyGpg45(CriType.F2F_CRI_TYPE, "abc", "/&43", null, null, null);
+        assertFalse(result.isValid());
+        assertEquals(
+                "Invalid numbers provided for evidence strength, validity and verification",
+                result.getError().getDescription());
+    }
+
+    @Test
+    void shouldReturnFailedValidationIfScoresProvidedForInvalidCriTypeOnF2fEvidence() {
+        ValidationResult result =
+                Validator.verifyGpg45(CriType.F2F_CRI_TYPE, "1", "2", null, "4", "1");
+        assertFalse(result.isValid());
+        assertEquals("Invalid GPG45 score provided", result.getError().getDescription());
+    }
+
+    @Test
     void redirectUrlIsInvalidShouldReturnFalseForValidUrlWithOnlyOneRegistered() {
         assertFalse(Validator.redirectUrlIsInvalid("clientIdValid", "https://valid.example.com"));
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the validator to include all missing CRI types, preventing crashes and ensuring that all types are handled correctly
This change should now direct the missing type CRI's to pyi-no-match on no data submitted rather than crashing on a unrecoverable page

Some CRI types, such as Address and NINO, do not have GPG45 scoring fields, allowing submissions with no data to still progress. We need to explore solutions for these specific scenarios.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6951](https://govukverify.atlassian.net/browse/PYIC-6951)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-6951]: https://govukverify.atlassian.net/browse/PYIC-6951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ