### PR TITLE
PYIC-6951: Enforce having to submit CRI stub data or an Oauth error on the stubs

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -626,6 +626,18 @@
     window.GOVUKFrontend.initAll();
 </script>
 <script>
+  document.querySelector('form').addEventListener('submit', function(e) {
+    const jsonPayload = document.getElementById('jsonPayload').value.trim();
+    const oauthError = document.getElementById('requested_oauth_error').value;
+    const oauthErrorEndpoint = document.querySelector('input[name="requested_oauth_error_endpoint"]:checked');
+
+    if (!jsonPayload && (oauthError === 'none' && !oauthErrorEndpoint)) {
+        e.preventDefault();
+        alert("Please enter CRI stub data or select Oauth error")
+    }
+  });
+</script>
+<script>
     var dropdownData = {{{cri_stub_data}}}
     var filtered = dropdownData.filter(x => x.criType === "{{cri-name}}")
     $(document).ready(function() {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Currently a user can submit nothing on the stub and continue. 
This javascript checks 3 form fields that are required as a minimum to continue, this will apply to all stubs but is specifically for stubs which dont have GPG45 scores to fail backend validation.
Subsequent PR to add missing CRI types to validator: https://github.com/govuk-one-login/ipv-stubs/pull/1142

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6951](https://govukverify.atlassian.net/browse/PYIC-6951)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-6951]: https://govukverify.atlassian.net/browse/PYIC-6951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ