### PR TITLE
LIME-1460 Allow setting address country via edit user page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ build
 node_modules
 
 lib
+
+# ipv-config temp copy
+di-ipv-core-stub/config
+
+# stub temp build files
+*/bin
+*/lambdas

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/CanonicalAddress.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/CanonicalAddress.java
@@ -12,6 +12,7 @@ public record CanonicalAddress(
         String streetName,
         String addressLocality,
         String postalCode,
+        String addressCountry,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate validFrom,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
                 LocalDate validUntil) {}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Identity.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/Identity.java
@@ -23,4 +23,29 @@ public record Identity(
                 questions,
                 nino);
     }
+
+    public Identity withAddressCountry(String addressCountry) {
+        List<UKAddress> addresses = this.addresses();
+        UKAddress address = addresses.get(0);
+
+        return new Identity(
+                rowNumber,
+                accountNumber,
+                ctdbDatabase,
+                List.of(
+                        new UKAddress(
+                                address.buildingNumber(),
+                                address.buildingName(),
+                                address.street(),
+                                address.county(),
+                                address.townCity(),
+                                address.postCode(),
+                                address.validFrom(),
+                                address.validUntil(),
+                                addressCountry)),
+                findDateOfBirth,
+                name,
+                questions,
+                nino);
+    }
 }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/IdentityMapper.java
@@ -60,7 +60,8 @@ public class IdentityMapper {
                         map.get("postTown"),
                         map.get("postcode"),
                         addressValidFrom,
-                        null);
+                        null,
+                        map.get("addressCountry"));
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDate date = LocalDate.parse(map.get("dob"), formatter);
@@ -112,6 +113,7 @@ public class IdentityMapper {
                                             address.street(),
                                             address.townCity(),
                                             address.postCode(),
+                                            address.addressCountry(),
                                             // default / arbitrary value assigned for now as
                                             // the validFrom date is not available in test data
                                             validFrom,
@@ -139,7 +141,7 @@ public class IdentityMapper {
 
     public PostcodeSharedClaims mapToAddressSharedClaims(String postcode) {
         CanonicalAddress canonicalAddress =
-                new CanonicalAddress(null, null, null, null, postcode, null, null);
+                new CanonicalAddress(null, null, null, null, postcode, null, null, null);
 
         return new PostcodeSharedClaims(
                 List.of(
@@ -178,7 +180,8 @@ public class IdentityMapper {
                         formData.value("townCity"),
                         formData.value("postCode"),
                         primaryAddressValidFrom,
-                        primaryAddressValidUntil);
+                        primaryAddressValidUntil,
+                        formData.value("addressCountry"));
         addresses.add(primaryAddress);
 
         LocalDate secondaryAddressValidFrom =
@@ -204,7 +207,8 @@ public class IdentityMapper {
                         formData.value("SecondaryUKAddress.townCity"),
                         formData.value("SecondaryUKAddress.postCode"),
                         secondaryAddressValidFrom,
-                        secondaryAddressValidUntil);
+                        secondaryAddressValidUntil,
+                        formData.value("SecondaryUKAddress.addressCountry"));
         if (!Stream.of(
                         secondaryAddress.street(),
                         secondaryAddress.buildingName(),
@@ -217,7 +221,8 @@ public class IdentityMapper {
                                 : null,
                         secondaryAddress.validUntil() != null
                                 ? secondaryAddress.validUntil().toString()
-                                : null)
+                                : null,
+                        secondaryAddress.addressCountry())
                 .allMatch(StringUtils::isBlank)) {
             addresses.add(secondaryAddress);
         }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/UKAddress.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/uatuser/UKAddress.java
@@ -10,4 +10,5 @@ public record UKAddress(
         String townCity,
         String postCode,
         LocalDate validFrom,
-        LocalDate validUntil) {}
+        LocalDate validUntil,
+        String addressCountry) {}

--- a/di-ipv-core-stub/src/main/resources/templates/edit-user.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/edit-user.mustache
@@ -274,6 +274,16 @@
 
             </div>
 
+            <div class="govuk-form-group">
+                <label class="govuk-label" id="addressCountry-label" for="addressCountry">
+                    Country
+                </label>
+
+                <input class="govuk-input govuk-input--width-5" id="addressCountry" name="addressCountry"
+                       type="text" aria-required="false" maxlength="10" value="{{addressMap.0.addressCountry}}">
+
+            </div>
+
             {{#isHmrcKbvCri}}
 
                 <div class="govuk-form-group">
@@ -430,10 +440,19 @@
                         </div>
 
                     </div>
+
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" id="SecondaryUKAddress.addressCountry-label" for="SecondaryUKAddress.addressCountry">
+                            Country
+                        </label>
+
+                        <input class="govuk-input govuk-input--width-5" id="SecondaryUKAddress.addressCountry" name="SecondaryUKAddress.addressCountry"
+                               type="text" aria-required="false" maxlength="10" value="{{addressMap.1.addressCountry}}">
+
+                    </div>
                 </div>
             </details>
             <button class="govuk-button button" data-module="govuk-button">Go to {{criName}}</button>
-
         </form>
 
     </main>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Front end and back end routes updated to allow setting of addressCountry field in sharedClaims when editing a user's details.
Primary address country field defaulted to populate with "GB".

### Why did it change

To allow for testing of International Addresses initiative updates.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1460](https://govukverify.atlassian.net/browse/LIME-1460)

Evidence in ticket.


[LIME-1460]: https://govukverify.atlassian.net/browse/LIME-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ