### PR TITLE
PYIC-7785: Update async DCMAW stub for API tests

### DIFF
--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -5,6 +5,8 @@ export interface ManagementEnqueueVcRequest {
   evidence_type: EvidenceType;
   ci?: string[];
   delay_seconds?: number;
+  queueName?: string;
+  queueStubApiKey?: string;
 }
 
 export interface ManagementEnqueueErrorRequest {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -5,8 +5,7 @@ export interface ManagementEnqueueVcRequest {
   evidence_type: EvidenceType;
   ci?: string[];
   delay_seconds?: number;
-  queueName?: string;
-  queueStubApiKey?: string;
+  queue_name?: string;
 }
 
 export interface ManagementEnqueueErrorRequest {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -48,9 +48,9 @@ export async function handler(
 
     await fetch(config.queueStubUrl, {
       method: "POST",
-      headers: { "x-api-key": requestBody.queueStubApiKey ?? config.queueStubApiKey },
+      headers: { "x-api-key": config.queueStubApiKey },
       body: JSON.stringify({
-        queueName: requestBody.queueName ?? config.queueName,
+        queueName: requestBody.queueName ?? config.queue_name,
         queueEvent: queueMessage,
         delaySeconds: requestBody.delay_seconds ?? 0,
       }),

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -48,9 +48,9 @@ export async function handler(
 
     await fetch(config.queueStubUrl, {
       method: "POST",
-      headers: { "x-api-key": config.queueStubApiKey },
+      headers: { "x-api-key": requestBody.queueStubApiKey ?? config.queueStubApiKey },
       body: JSON.stringify({
-        queueName: config.queueName,
+        queueName: requestBody.queueName ?? config.queueName,
         queueEvent: queueMessage,
         delaySeconds: requestBody.delay_seconds ?? 0,
       }),
@@ -59,6 +59,7 @@ export async function handler(
     return buildApiResponse(
       {
         result: "success",
+        oauthState: state
       },
       201,
     );

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -50,7 +50,7 @@ export async function handler(
       method: "POST",
       headers: { "x-api-key": config.queueStubApiKey },
       body: JSON.stringify({
-        queueName: requestBody.queue_name ?? config.queue_name,
+        queueName: requestBody.queue_name ?? config.queueName,
         queueEvent: queueMessage,
         delaySeconds: requestBody.delay_seconds ?? 0,
       }),

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -50,7 +50,7 @@ export async function handler(
       method: "POST",
       headers: { "x-api-key": config.queueStubApiKey },
       body: JSON.stringify({
-        queueName: requestBody.queueName ?? config.queue_name,
+        queueName: requestBody.queue_name ?? config.queue_name,
         queueEvent: queueMessage,
         delaySeconds: requestBody.delay_seconds ?? 0,
       }),


### PR DESCRIPTION
## Proposed changes

### What changed

1. Add oauth state to response from enqueue.
2. Enable enqueue in local

### Why did it change

- To allow API tests to work from https://github.com/govuk-one-login/ipv-core-back/pull/2833

### Issue tracking

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)


[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ