### PR TITLE
PYIC-7785: Add option to use enqueue handler to just fetch oauth state

### DIFF
--- a/di-ipv-dcmaw-async-stub/deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/deploy/template.yaml
@@ -243,7 +243,7 @@ Resources:
             ParameterName: stubs/core/dcmaw-async/*
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBCrudPolicy:
+        - DynamoDBReadPolicy:
             TableName: !Ref DcmawAsyncStubUserStateTable
       AutoPublishAlias: live
       Events:
@@ -262,6 +262,66 @@ Resources:
         Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
         EntryPoints:
           - src/handlers/managementEnqueueVcHandler.ts
+
+  # lambda to stub management DCMAW Async - cleanupDcmawState
+  ManagementCleanupSessionFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "ManagementEnqueueVcFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "managementCleanupSession-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: managementCleanupSessionHandler.handler
+      Runtime: nodejs20.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          DCMAW_ASYNC_PARAM_BASE_PATH: "/stubs/core/dcmaw-async/"
+          DCMAW_ASYNC_STUB_USER_STATE_TABLE_NAME: !Ref DcmawAsyncStubUserStateTable
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt DcmawAsyncLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/dcmaw-async/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBWritePolicy:
+            TableName: !Ref DcmawAsyncStubUserStateTable
+      AutoPublishAlias: live
+      Events:
+        GetDcmawAsyncVc:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /management/cleanupDcmawState
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/managementCleanupSessionHandler.ts
 
 # lambda to stub management DCMAW Async - enqueueError
   ManagementEnqueueErrorFunction:

--- a/di-ipv-dcmaw-async-stub/deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/deploy/template.yaml
@@ -271,7 +271,7 @@ Resources:
     # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
     # checkov:skip=CKV_AWS_173: doing it later
     DependsOn:
-      - "ManagementEnqueueVcFunctionLogGroup"
+      - "ManagementCleanupSessionFunctionLogGroup"
     Properties:
       FunctionName: !Sub "managementCleanupSession-${Environment}"
       CodeUri: "../lambdas"
@@ -466,6 +466,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/ManagementEnqueueVc-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  ManagementCleanupSessionFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/ManagementCleanupSession-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ManagementEnqueueErrorFunctionLogGroup:

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -26,4 +26,5 @@ export enum DocumentType {
 export enum EvidenceType {
   success = "success",
   fail = "fail",
+  failWithCi = "failWithCi"
 }

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -26,5 +26,5 @@ export enum DocumentType {
 export enum EvidenceType {
   success = "success",
   fail = "fail",
-  failWithCi = "failWithCi"
+  failWithCi = "failWithCi",
 }

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -50,14 +50,14 @@ const testUserClaims = {
         nameParts: [
           {
             value: "Kenneth",
-            type: "GivenName"
+            type: "GivenName",
           },
           {
             value: "Decerqueira",
-            type: "FamilyName"
-          }
-        ]
-      }
+            type: "FamilyName",
+          },
+        ],
+      },
     ],
     birthDate: [
       {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -45,6 +45,20 @@ export async function buildMockVc(
 
 const testUserClaims = {
   [TestUser.kennethD]: {
+    name: [
+      {
+        nameParts: [
+          {
+            value: "Kenneth",
+            type: "GivenName"
+          },
+          {
+            value: "Decerqueira",
+            type: "FamilyName"
+          }
+        ]
+      }
+    ],
     birthDate: [
       {
         value: "1965-07-08",
@@ -87,6 +101,23 @@ const evidence = {
       type: "IdentityCheck",
       strengthScore: 4,
       validityScore: 0,
+      failedCheckDetails: [
+        {
+          checkMethod: "vcrypt",
+          identityCheckPolicy: "published",
+          activityFrom: null,
+        },
+        {
+          checkMethod: "bvr",
+          biometricVerificationProcessLevel: 3,
+        },
+      ],
+    },
+    [EvidenceType.failWithCi]: {
+      type: "IdentityCheck",
+      strengthScore: 4,
+      validityScore: 0,
+      ci: ["D15"],
       failedCheckDetails: [
         {
           checkMethod: "vcrypt",

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementCleanupSessionHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementCleanupSessionHandler.ts
@@ -1,0 +1,37 @@
+import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
+import { buildApiResponse } from "../common/apiResponse";
+import getErrorMessage from "../common/errorReporting";
+import { deleteState } from "../services/userStateService";
+
+export async function handler(
+  event: APIGatewayProxyEventV2,
+): Promise<APIGatewayProxyResultV2> {
+  try {
+    if (event.body === undefined) {
+      return buildApiResponse({ errorMessage: "No request body" }, 400);
+    }
+
+    const requestBody = JSON.parse(event.body);
+
+    if (!requestBody.user_id) {
+      return buildApiResponse(
+        { errorMessage: "Missing user_id in request body" },
+        400,
+      );
+    }
+
+    await deleteState(requestBody.user_id);
+
+    return buildApiResponse(
+      {
+        result: "success",
+      },
+      200,
+    );
+  } catch (error) {
+    return buildApiResponse(
+      { errorMessage: "Unexpected error: " + getErrorMessage(error) },
+      500,
+    );
+  }
+}

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
@@ -2,8 +2,8 @@ import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
 import { buildApiResponse } from "../common/apiResponse";
 import getErrorMessage from "../common/errorReporting";
 import { ManagementEnqueueErrorRequest } from "../domain/managementEnqueueRequest";
-import { popState } from "../services/userStateService";
 import getConfig from "../common/config";
+import { getState } from "../services/userStateService";
 
 export async function handler(
   event: APIGatewayProxyEventV2,
@@ -20,7 +20,7 @@ export async function handler(
       return buildApiResponse({ errorMessage: requestBody }, 400);
     }
 
-    const state = await popState(requestBody.user_id);
+    const state = await getState(requestBody.user_id);
 
     const queueMessage = {
       sub: requestBody.user_id,

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -18,14 +18,15 @@ export async function handler(
     }
 
     if (!event.body.test_user) {
-      // Only for returning the oauth state
+      // Only for returning the oauth state. Returning the oauthState allows API tests to callback as the mobile app,
+      // which includes it in the callback endpoint as a query parameter.
       const state = await popState(event.body.user_id);
       return buildApiResponse(
-          {
-            result: "success",
-            oauthState: state
-          },
-          201,
+        {
+          result: "success",
+          oauthState: state,
+        },
+        201,
       );
     }
 
@@ -71,7 +72,8 @@ export async function handler(
     return buildApiResponse(
       {
         result: "success",
-        oauthState: state
+        // Returning state allows API tests to callback as the mobile app.
+        oauthState: state,
       },
       201,
     );

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -17,6 +17,18 @@ export async function handler(
       return buildApiResponse({ errorMessage: "No request body" }, 400);
     }
 
+    if (!event.body.test_user) {
+      // Only for returning the oauth state
+      const state = await popState(event.body.user_id);
+      return buildApiResponse(
+          {
+            result: "success",
+            oauthState: state
+          },
+          201,
+      );
+    }
+
     const requestBody = parseRequest(event);
     if (typeof requestBody === "string") {
       return buildApiResponse({ errorMessage: requestBody }, 400);

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -4,7 +4,7 @@ import { buildApiResponse } from "../common/apiResponse";
 import getErrorMessage from "../common/errorReporting";
 import { buildMockVc } from "../domain/mockVc";
 import { ManagementEnqueueVcRequest } from "../domain/managementEnqueueRequest";
-import { popState } from "../services/userStateService";
+import { getState } from "../services/userStateService";
 import getConfig from "../common/config";
 
 export async function handler(
@@ -17,10 +17,12 @@ export async function handler(
       return buildApiResponse({ errorMessage: "No request body" }, 400);
     }
 
-    if (!event.body.test_user) {
-      // Only for returning the oauth state. Returning the oauthState allows API tests to callback as the mobile app,
-      // which includes it in the callback endpoint as a query parameter.
-      const state = await popState(event.body.user_id);
+    const requestBody = JSON.parse(event.body);
+
+    if (!requestBody.test_user) {
+      // We do not want to produce a VC, only to return the oauth state to allows API tests to callback as the mobile
+      // app, which includes it in the callback endpoint as a query parameter.
+      const state = await getState(requestBody.user_id);
       return buildApiResponse(
         {
           result: "success",
@@ -30,17 +32,18 @@ export async function handler(
       );
     }
 
-    const requestBody = parseRequest(event);
-    if (typeof requestBody === "string") {
-      return buildApiResponse({ errorMessage: requestBody }, 400);
+    const parsedBody = parseRequest(event.body);
+
+    if (typeof parsedBody === "string") {
+      return buildApiResponse({ errorMessage: parsedBody }, 400);
     }
 
     const vc = await buildMockVc(
-      requestBody.user_id,
-      requestBody.test_user,
-      requestBody.document_type,
-      requestBody.evidence_type,
-      requestBody.ci,
+      parsedBody.user_id,
+      parsedBody.test_user,
+      parsedBody.document_type,
+      parsedBody.evidence_type,
+      parsedBody.ci,
     );
 
     const signingKey = await importPKCS8(
@@ -51,10 +54,10 @@ export async function handler(
       .setProtectedHeader({ alg: "ES256", typ: "JWT" })
       .sign(signingKey);
 
-    const state = await popState(requestBody.user_id);
+    const state = await getState(parsedBody.user_id);
 
     const queueMessage = {
-      sub: requestBody.user_id,
+      sub: parsedBody.user_id,
       state,
       "https://vocab.account.gov.uk/v1/credentialJWT": [signedJwt],
     };
@@ -63,9 +66,9 @@ export async function handler(
       method: "POST",
       headers: { "x-api-key": config.queueStubApiKey },
       body: JSON.stringify({
-        queueName: requestBody.queue_name ?? config.queueName,
+        queueName: parsedBody.queue_name ?? config.queueName,
         queueEvent: queueMessage,
-        delaySeconds: requestBody.delay_seconds ?? 0,
+        delaySeconds: parsedBody.delay_seconds ?? 0,
       }),
     });
 
@@ -85,14 +88,8 @@ export async function handler(
   }
 }
 
-function parseRequest(
-  event: APIGatewayProxyEventV2,
-): string | ManagementEnqueueVcRequest {
-  if (event.body === undefined) {
-    return "No request body";
-  }
-
-  const requestBody = JSON.parse(event.body);
+function parseRequest(body: string): string | ManagementEnqueueVcRequest {
+  const requestBody = JSON.parse(body);
 
   const mandatoryFields = [
     "user_id",

--- a/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
@@ -37,7 +37,7 @@ export async function persistState(
   await dynamoClient.updateItem(updateItemInput);
 }
 
-/** Gets state value and deletes record. */
+/** Gets state record. */
 export async function getState(userId: string): Promise<string | null> {
   const getItemInput: GetItemInput = {
     TableName: userStateTableName,
@@ -51,7 +51,7 @@ export async function getState(userId: string): Promise<string | null> {
   return userStateItem.state;
 }
 
-/** Gets state value and deletes record. */
+/** Deletes state record. */
 export async function deleteState(userId: string): Promise<void> {
   const getItemInput: GetItemInput = {
     TableName: userStateTableName,

--- a/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
@@ -38,7 +38,7 @@ export async function persistState(
 }
 
 /** Gets state value and deletes record. */
-export async function popState(userId: string): Promise<string | null> {
+export async function getState(userId: string): Promise<string | null> {
   const getItemInput: GetItemInput = {
     TableName: userStateTableName,
     Key: marshall({ userId }),
@@ -48,6 +48,14 @@ export async function popState(userId: string): Promise<string | null> {
   if (userStateItem === null) {
     throw new Error(`No state record found for user id ${userId}`);
   }
-  await dynamoClient.deleteItem(getItemInput);
   return userStateItem.state;
+}
+
+/** Gets state value and deletes record. */
+export async function deleteState(userId: string): Promise<void> {
+  const getItemInput: GetItemInput = {
+    TableName: userStateTableName,
+    Key: marshall({ userId }),
+  };
+  await dynamoClient.deleteItem(getItemInput);
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Add option to use enqueue handler to just fetch oauth state

### Why did it change

- So callbacks in API tests in core-back which don't have VCs can still reference a correct oauth state

### Issue tracking

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)

[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ