### PR TITLE
PYIC-7785: Add CleanupSession to the external open API definitions.

### DIFF
--- a/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
+++ b/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
@@ -110,6 +110,37 @@ paths:
             responseTemplates:
               application/json: '{"result": "success"}'
 
+  /management/cleanupDcmawState:
+    post:
+      description: Cleans up DCMAW session state from stub given a user id.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ManagementCleanupDCMAWStateRequestBody"
+      responses:
+        200:
+          description: "Success response"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManagementCleanupSessionFunction.Arn}:live/invocations
+        passthroughBehavior: "WHEN_NO_TEMPLATES"
+        responses:
+          default:
+            statusCode: 201
+            responseTemplates:
+              application/json: '{"result": "success"}'
+
   /management/enqueueError:
     post:
       description: Generates and pushes error onto queue
@@ -235,6 +266,15 @@ components:
         delay_seconds:
           type: number
           description: Optional number of seconds to delay delivery of the message (default=0)
+    ManagementCleanupDCMAWStateRequestBody:
+      description: Request body for cleaning up DCMAW state given a user id.
+      type: object
+      required:
+        - user_id
+      properties:
+        user_id:
+          type: string
+          description: The id of a user that has an already-initialised session
     ManagementEnqueueErrorRequestBody:
       description: Request body for enqueueing an error
       type: object


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add CleanupSession to the external open API definitions.

### Why did it change

- So the endpoint can be reached from the API gateway

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)

[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ