### PR TITLE
PYIC-7785: Make only user_id required on the DCMAW enqueue VC endpoint

### DIFF
--- a/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
+++ b/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
@@ -241,9 +241,6 @@ components:
       type: object
       required:
         - user_id
-        - test_user
-        - document_type
-        - evidence_type
       properties:
         user_id:
           type: string


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove required attributes from API gateway endpoint definition

### Why did it change

We can now call the endpoint with just a user_id

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)


[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ