### PR TITLE
PYIC-7917: add available_authoritative_source fraudCheck type for M1C profile

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -233,7 +233,7 @@
         "filename": "di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json",
         "hashed_secret": "51da07e5aabf9c96745c4dc5aa30306162fa13db",
         "is_verified": false,
-        "line_number": 416
+        "line_number": 429
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache": [
@@ -437,5 +437,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-04T10:25:30Z"
+  "generated_at": "2025-02-03T21:07:42Z"
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -47,6 +47,19 @@
       }
     },
     {
+      "criType": "Fraud Check (Stub)",
+      "label": "Failed fraud check (Unavailable) (M1C)",
+      "payload": {
+        "type": "IdentityCheck",
+        "failedCheckDetails": [
+          {
+            "checkMethod": "data",
+            "fraudCheck": "available_authoritative_source"
+          }
+        ]
+      }
+    },
+    {
       "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Passed verification (M1A) with checkDetails",
       "payload": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

-  add available_authoritative_source fraudCheck type stub data

### What changed

- Added stub data for available_authoritative_source M1C profile

<!-- Describe the changes in detail - the "what"-->


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7917](https://govukverify.atlassian.net/browse/PYIC-7917)


[PYIC-7917]: https://govukverify.atlassian.net/browse/PYIC-7917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ