### PR TITLE
Pyic 7808 enhance dcmaw async stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ di-ipv-core-stub/config
 
 # stub temp build files
 */bin
-*/lambdas

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -344,7 +344,7 @@
         "filename": "di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 513
+        "line_number": 692
       }
     ],
     "di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts": [

--- a/di-ipv-dcmaw-async-stub/README.md
+++ b/di-ipv-dcmaw-async-stub/README.md
@@ -41,6 +41,8 @@ HTTP/1.1 201 Created
 #### Additionally a management endpoint is exposed, which can be hit manually (for example via curl).
 The `management/enqueueVc` endpoint will build and sign a VC based on the inputs provided and push a VC message onto the CRI response queue (via the queue stub lambda).
 
+The `management/generateVc` endpoint will build and sign a VC based on the inputs provided and return it directly.
+
 The `management/enqueueError` endpoint will push an error message onto the CRI response queue, for example to simulate an "access-denied" error scenario.
 
 See `openAPI/dcmaw-async-external.yaml` for the shape of the requests and expected responses. The user id provided must be that of an already initialised DCMAW session (via the `async/credential` request). The oauth state value passed in the original `async/credential` request will have been stored against the user id so that it can be provided in the VC queue message.

--- a/di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml
@@ -231,6 +231,67 @@ Resources:
         EntryPoints:
           - src/handlers/managementEnqueueVcHandler.ts
 
+
+  # lambda to stub management DCMAW Async - cleanupDcmawState
+  ManagementCleanupSessionFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "ManagementCleanupSessionFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "managementCleanupSession-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: managementCleanupSessionHandler.handler
+      Runtime: nodejs20.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          DCMAW_ASYNC_PARAM_BASE_PATH: "/stubs/core/dcmaw-async/"
+          DCMAW_ASYNC_STUB_USER_STATE_TABLE_NAME: !Ref DcmawAsyncStubUserStateTable
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt DcmawAsyncLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/dcmaw-async/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref DcmawAsyncStubUserStateTable
+      AutoPublishAlias: live
+      Events:
+        GetDcmawAsyncVc:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /management/cleanupDcmawState
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/managementCleanupSessionHandler.ts
+
 # lambda to stub management DCMAW Async - enqueueError
   ManagementEnqueueErrorFunction:
     Type: AWS::Serverless::Function
@@ -350,7 +411,28 @@ Resources:
   ManagementEnqueueVcFunctionCoreBuildInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Ref GetDcmawAsyncAccessTokenFunction
+      FunctionName: !Ref ManagementEnqueueVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
+  ManagementCleanupSessionFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementCleanupSessionFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
+  ManagementCleanupSessionFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementCleanupSessionFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
+  ManagementCleanupSessionFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementCleanupSessionFunction
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
@@ -373,6 +455,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/ManagementEnqueueVc-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  ManagementCleanupSessionFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/ManagementCleanupSession-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ManagementEnqueueErrorFunctionLogGroup:
@@ -495,6 +584,7 @@ Resources:
     DependsOn:
       - GetDcmawAsyncVcFunction
       - GetDcmawAsyncAccessTokenFunction
+      - ManagementCleanupSessionFunction
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub DCMAW Async API Gateway ${Environment}

--- a/di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/core-dev-deploy/template.yaml
@@ -232,6 +232,67 @@ Resources:
           - src/handlers/managementEnqueueVcHandler.ts
 
 
+  # lambda to stub management DCMAW Async - generateVc
+  ManagementGenerateVcFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "ManagementGenerateVcFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "managementGenerateVc-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: managementGenerateVcHandler.handler
+      Runtime: nodejs20.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          DCMAW_ASYNC_PARAM_BASE_PATH: "/stubs/core/dcmaw-async/"
+          DCMAW_ASYNC_STUB_USER_STATE_TABLE_NAME: !Ref DcmawAsyncStubUserStateTable
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt DcmawAsyncLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/dcmaw-async/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref DcmawAsyncStubUserStateTable
+      AutoPublishAlias: live
+      Events:
+        GetDcmawAsyncVc:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /management/generateVc
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/managementGenerateVcHandler.ts
+
+
   # lambda to stub management DCMAW Async - cleanupDcmawState
   ManagementCleanupSessionFunction:
     Type: AWS::Serverless::Function
@@ -415,6 +476,27 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
+  ManagementGenerateVcFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementGenerateVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
+  ManagementGenerateVcFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementGenerateVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
+  ManagementGenerateVcFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementGenerateVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
   ManagementCleanupSessionFunctionCoreDev01InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -455,6 +537,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/ManagementEnqueueVc-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  ManagementGenerateVcFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/ManagementGenerateVc-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ManagementCleanupSessionFunctionLogGroup:

--- a/di-ipv-dcmaw-async-stub/deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/deploy/template.yaml
@@ -263,6 +263,66 @@ Resources:
         EntryPoints:
           - src/handlers/managementEnqueueVcHandler.ts
 
+  # lambda to stub management DCMAW Async - generateVc
+  ManagementGenerateVcFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "ManagementGenerateVcFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "managementGenerateVc-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: managementGenerateVcHandler.handler
+      Runtime: nodejs20.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          DCMAW_ASYNC_PARAM_BASE_PATH: "/stubs/core/dcmaw-async/"
+          DCMAW_ASYNC_STUB_USER_STATE_TABLE_NAME: !Ref DcmawAsyncStubUserStateTable
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt DcmawAsyncLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/dcmaw-async/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBReadPolicy:
+            TableName: !Ref DcmawAsyncStubUserStateTable
+      AutoPublishAlias: live
+      Events:
+        GetDcmawAsyncVc:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /management/generateVc
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/managementGenerateVcHandler.ts
+
   # lambda to stub management DCMAW Async - cleanupDcmawState
   ManagementCleanupSessionFunction:
     Type: AWS::Serverless::Function
@@ -446,6 +506,27 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: !FindInMap [ CoreAccounts, build, accountId ]
 
+  ManagementGenerateVcFunctionCoreDev01InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementGenerateVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev01, accountId ]
+
+  ManagementGenerateVcFunctionCoreDev02InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementGenerateVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, dev02, accountId ]
+
+  ManagementGenerateVcFunctionCoreBuildInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ManagementGenerateVcFunction
+      Action: "lambda:InvokeFunction"
+      Principal: !FindInMap [ CoreAccounts, build, accountId ]
+
   ManagementCleanupSessionFunctionCoreDev01InvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -487,6 +568,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/ManagementEnqueueVc-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  ManagementGenerateVcFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/ManagementGenerateVc-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ManagementCleanupSessionFunctionLogGroup:

--- a/di-ipv-dcmaw-async-stub/deploy/template.yaml
+++ b/di-ipv-dcmaw-async-stub/deploy/template.yaml
@@ -616,6 +616,7 @@ Resources:
     DependsOn:
       - GetDcmawAsyncVcFunction
       - GetDcmawAsyncAccessTokenFunction
+      - ManagementCleanupSessionFunction
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub DCMAW Async API Gateway ${Environment}

--- a/di-ipv-dcmaw-async-stub/lambdas/src/common/apiResponse.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/common/apiResponse.ts
@@ -12,3 +12,16 @@ export function buildApiResponse(
     },
   };
 }
+
+export function buildApiResponseFromString(
+    body: string,
+    statusCode: number = 200,
+): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    body: body,
+    headers: {
+      "content-type": "text/plain",
+    },
+  };
+}

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -1,11 +1,40 @@
 export interface ManagementEnqueueVcRequest {
   user_id: string;
+  queue_name?: string;
+  delay_seconds?: number;
+}
+
+export function isManagementEnqueueVcRequest(request: any): request is ManagementEnqueueVcRequest {
+  const underTest = request as ManagementEnqueueVcRequest;
+  return underTest.user_id !== undefined;
+}
+
+export interface ManagementEnqueueVcRequestIndividualDetails extends ManagementEnqueueVcRequest {
   test_user: TestUser;
   document_type: DocumentType;
   evidence_type: EvidenceType;
   ci?: string[];
-  delay_seconds?: number;
-  queue_name?: string;
+}
+
+export function isManagementEnqueueVcRequestIndividualDetails(request: any): request is ManagementEnqueueVcRequestIndividualDetails {
+  const underTest = request as ManagementEnqueueVcRequestIndividualDetails;
+  return isManagementEnqueueVcRequest(underTest)
+      && underTest.test_user !== undefined
+      && underTest.document_type !== undefined
+      && underTest.evidence_type !== undefined;
+}
+
+export interface ManagementEnqueueVcRequestEvidenceAndSubject extends ManagementEnqueueVcRequest {
+  credential_subject: object;
+  evidence: object;
+  nbf?: number;
+}
+
+export function isManagementEnqueueVcRequestEvidenceAndSubject(request: any): request is ManagementEnqueueVcRequestEvidenceAndSubject {
+  const underTest = request as ManagementEnqueueVcRequestEvidenceAndSubject;
+  return isManagementEnqueueVcRequest(underTest)
+      && underTest.evidence !== undefined
+      && underTest.credential_subject !== undefined;
 }
 
 export interface ManagementEnqueueErrorRequest {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -43,6 +43,35 @@ export async function buildMockVc(
   };
 }
 
+export async function buildMockVcFromSubjectAndEvidence(
+    userId: string,
+    credentialSubject: object,
+    evidence: object,
+    nbf?: number,
+) {
+  const config = await getConfig();
+  const timestamp = Math.round(new Date().getTime() / 1000);
+  return {
+    jti: crypto.randomUUID(),
+    iss: config.vcIssuer,
+    aud: config.vcAudience,
+    sub: userId,
+    iat: timestamp,
+    nbf: nbf || timestamp,
+    vc: {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://vocab.account.gov.uk/contexts/identity-v1.jsonld",
+      ],
+      type: ["VerifiableCredential", "IdentityCheckCredential"],
+      credentialSubject: credentialSubject,
+      evidence: [
+        evidence
+      ],
+    },
+  };
+}
+
 const testUserClaims = {
   [TestUser.kennethD]: {
     name: [

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
@@ -1,0 +1,12 @@
+import {importPKCS8, SignJWT} from "jose";
+import {JWTPayload} from "jose/dist/types/types";
+
+export async function vcToSignedJwt(vc: JWTPayload, signingKey: string) {
+    const formattedSigningKey = await importPKCS8(
+        `-----BEGIN PRIVATE KEY-----\n${signingKey}\n-----END PRIVATE KEY-----`, // pragma: allowlist secret - the key is coming from config
+        "ES256",
+    );
+    return await new SignJWT(vc)
+        .setProtectedHeader({ alg: "ES256", typ: "JWT" })
+        .sign(formattedSigningKey);
+}

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -71,9 +71,6 @@ export async function handler(
     };
 
     const queueName = queueNameFromRequest ?? config.queueName;
-    console.log(`Posting to queue ${queueName} at ${config.queueStubUrl}`);
-
-    console.log(`stub config: ${JSON.stringify(config)}`);
 
     const postResult = await fetch(config.queueStubUrl, {
       method: "POST",
@@ -84,8 +81,6 @@ export async function handler(
         delaySeconds: delaySeconds ?? 0,
       }),
     });
-
-    console.log(`Result: ${await postResult.text()}`);
 
     if (!postResult.ok) {
       throw new Error(`Failed to enqueue VC: ${await postResult.text()}`);

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementGenerateVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementGenerateVcHandler.ts
@@ -12,7 +12,6 @@ export async function handler(
   event: APIGatewayProxyEventV2,
 ): Promise<APIGatewayProxyResultV2> {
   try {
-    console.log("Generating VC")
     const config = await getConfig();
 
     if (event.body === undefined) {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementGenerateVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementGenerateVcHandler.ts
@@ -1,0 +1,47 @@
+import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
+import {buildApiResponse, buildApiResponseFromString} from "../common/apiResponse";
+import getErrorMessage from "../common/errorReporting";
+import { buildMockVcFromSubjectAndEvidence } from "../domain/mockVc";
+import {
+  isManagementEnqueueVcRequestEvidenceAndSubject,
+} from "../domain/managementEnqueueRequest";
+import getConfig from "../common/config";
+import {vcToSignedJwt} from "../domain/signedJwt";
+
+export async function handler(
+  event: APIGatewayProxyEventV2,
+): Promise<APIGatewayProxyResultV2> {
+  try {
+    console.log("Generating VC")
+    const config = await getConfig();
+
+    if (event.body === undefined) {
+      return buildApiResponse({ errorMessage: "No request body" }, 400);
+    }
+
+    const requestBody = JSON.parse(event.body);
+
+    if (!isManagementEnqueueVcRequestEvidenceAndSubject(requestBody)) {
+      return buildApiResponse({ errorMessage: "Unrecognised request body" }, 400);
+    }
+
+    const vc = await buildMockVcFromSubjectAndEvidence(
+        requestBody.user_id,
+        requestBody.credential_subject,
+        requestBody.evidence,
+        requestBody.nbf,
+      );
+
+    const signedJwt = await vcToSignedJwt(vc, config.vcSigningKey);
+
+    return buildApiResponseFromString(
+        signedJwt,
+        200,
+    );
+  } catch (error) {
+    return buildApiResponse(
+      { errorMessage: "Unexpected error: " + getErrorMessage(error) },
+      500,
+    );
+  }
+}

--- a/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
+++ b/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
@@ -110,6 +110,34 @@ paths:
             responseTemplates:
               application/json: '{"result": "success"}'
 
+  /management/generateVc:
+    post:
+      description: Generates and returns a VC - for setting up test scenarios
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ManagementGenerateVcRequestBody"
+      responses:
+        200:
+          description: "Success response"
+          content:
+            text/plain:
+              schema:
+                type: string
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManagementGenerateVcFunction.Arn}:live/invocations
+        passthroughBehavior: "WHEN_NO_TEMPLATES"
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: '{"result": "success"}'
+
   /management/cleanupDcmawState:
     post:
       description: Cleans up DCMAW session state from stub given a user id.
@@ -245,6 +273,13 @@ components:
         user_id:
           type: string
           description: The id of a user that has an already-initialised session
+        delay_seconds:
+          type: number
+          description: Optional number of seconds to delay delivery of the message (default=0)
+        queue_name:
+          type: string
+          description: Optional queue name to override the stub's default.
+        # Properties for selecting pre-canned VC data
         test_user:
           type: string
           enum: [kennethD]
@@ -260,9 +295,34 @@ components:
         ci:
           type: array
           description: Optional array of CI codes
-        delay_seconds:
+        # Properties for just passing in the full data blocks for the VC
+        credential_subject:
+          type: object
+          description: The credential subject block for the VC
+        evidence:
+          type: object
+          description: The evidence block for the VC
+        nbf:
           type: number
-          description: Optional number of seconds to delay delivery of the message (default=0)
+          description: Optional value for nbf field
+    ManagementGenerateVcRequestBody:
+      description: Request body for generating a VC
+      type: object
+      required:
+        - user_id
+      properties:
+        user_id:
+          type: string
+          description: The id of a user that has an already-initialised session
+        credential_subject:
+          type: object
+          description: The credential subject block for the VC
+        evidence:
+          type: object
+          description: The evidence block for the VC
+        nbf:
+          type: number
+          description: Optional value for nbf field
     ManagementCleanupDCMAWStateRequestBody:
       description: Request body for cleaning up DCMAW state given a user id.
       type: object


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add the ability to specify the subject and evidence blocks when enqueuing a VC and an endpoint to generate and return a VC

### Why did it change

The current system of having an enum in the stub is too limiting.
Some tests need to set up an existing identity - requesting a signed VC from the stub is much quicker than going through a full journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7808](https://govukverify.atlassian.net/browse/PYIC-7808)


[PYIC-7808]: https://govukverify.atlassian.net/browse/PYIC-7808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ