### PR TITLE
PYIC-7808: Add queue override to enqueue error end point

### DIFF
--- a/di-ipv-dcmaw-async-stub/README.md
+++ b/di-ipv-dcmaw-async-stub/README.md
@@ -1,4 +1,6 @@
-### DCMAW Async CRI Stub
+# DCMAW Async CRI Stub
+
+## Overview
 This will set up an API gateway in front of a lambda and return access tokens and interim DCMAW cri VCs.
 The async/token POST request to the API gateway should look like
 ```
@@ -38,7 +40,7 @@ HTTP/1.1 201 Created
 }
 ```
 
-#### Additionally a management endpoint is exposed, which can be hit manually (for example via curl).
+### Additionally a management endpoint is exposed, which can be hit manually (for example via curl).
 The `management/enqueueVc` endpoint will build and sign a VC based on the inputs provided and push a VC message onto the CRI response queue (via the queue stub lambda).
 
 The `management/generateVc` endpoint will build and sign a VC based on the inputs provided and return it directly.
@@ -47,9 +49,18 @@ The `management/enqueueError` endpoint will push an error message onto the CRI r
 
 See `openAPI/dcmaw-async-external.yaml` for the shape of the requests and expected responses. The user id provided must be that of an already initialised DCMAW session (via the `async/credential` request). The oauth state value passed in the original `async/credential` request will have been stored against the user id so that it can be provided in the VC queue message.
 
-#### Currently, following SSM parameters are used to control VC structure.
+### Currently, following SSM parameters are used to control VC structure.
 To save hits to SSM we have a single config value in the form of a JSON string
 ```
 /stubs/core/dcmawAsync/config
 ```
 The interface `SsmConfig` can be found in `/lambdas/src/common/config.ts`
+
+## Developing the stub
+
+If you want to run a dev version of the stub and have your dev core-back talk to it:
+- Deploy your dev stub `dev-deploy deploy -u <user> -s dcmaw-async-stub`
+- In config find the `/core/credentialIssuers/dcmawAsync/activeConnection` value in the relevant dev01 or dev02 file
+- Update the value to `dev`
+  - You shouldn't have to, but you may also need to manually replace the `${dev-name}`s
+- Update your config `dev-deploy params -u <user> -dev0X`

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -39,6 +39,7 @@ export function isManagementEnqueueVcRequestEvidenceAndSubject(request: any): re
 
 export interface ManagementEnqueueErrorRequest {
   user_id: string;
+  queue_name?: string;
   error_code: string;
   error_description?: string;
   delay_seconds?: number;

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
@@ -30,15 +30,22 @@ export async function handler(
         requestBody.error_description ?? "Error sent via DCMAW Async CRI stub",
     };
 
-    await fetch(config.queueStubUrl, {
+    const queueName = requestBody.queue_name ?? config.queueName;
+    const delaySeconds = requestBody.delay_seconds ?? 0;
+
+    const postResult = await fetch(config.queueStubUrl, {
       method: "POST",
       headers: { "x-api-key": config.queueStubApiKey },
       body: JSON.stringify({
-        queueName: config.queueName,
+        queueName: queueName,
         queueEvent: queueMessage,
-        delaySeconds: requestBody.delay_seconds ?? 0,
+        delaySeconds: delaySeconds,
       }),
     });
+
+    if (!postResult.ok) {
+      throw new Error(`Failed to enqueue VC: ${await postResult.text()}`);
+    }
 
     return buildApiResponse(
       {

--- a/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
+++ b/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
@@ -351,3 +351,6 @@ components:
         delay_seconds:
           type: number
           description: Optional number of seconds to delay delivery of the message (default=0)
+        queue_name:
+          type: string
+          description: Optional queue name to override the stub's default.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add ability to specify the queue to add the error to

### Why did it change

To work in dev environments and to match the enqueueVc endpoint

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7808](https://govukverify.atlassian.net/browse/PYIC-7808)


[PYIC-7808]: https://govukverify.atlassian.net/browse/PYIC-7808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ