### PR TITLE
Dependabot fixes

### DIFF
--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
@@ -16,7 +16,7 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.fasterxml.jackson.core:jackson-databind:2.18.2",
-			"com.nimbusds:oauth2-oidc-sdk:11.21.2",
+			"com.nimbusds:oauth2-oidc-sdk:11.23.1",
 			"org.apache.logging.log4j:log4j-api:2.24.3",
 			"org.apache.logging.log4j:log4j-core:2.24.3",
 			"org.apache.logging.log4j:log4j-layout-template-json:2.24.3",

--- a/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
@@ -16,7 +16,7 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.fasterxml.jackson.core:jackson-databind:2.18.2",
-			"com.nimbusds:oauth2-oidc-sdk:11.21.2",
+			"com.nimbusds:oauth2-oidc-sdk:11.23.1",
 			"org.apache.logging.log4j:log4j-api:2.24.3",
 			"org.apache.logging.log4j:log4j-core:2.24.3",
 			"org.apache.logging.log4j:log4j-layout-template-json:2.24.3",

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -16,13 +16,13 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.amazonaws:aws-lambda-java-events:3.14.0",
-			"software.amazon.awssdk:dynamodb-enhanced:2.30.5",
+			"software.amazon.awssdk:dynamodb-enhanced:2.30.31",
 			"com.fasterxml.jackson.core:jackson-annotations:2.18.2",
 			"com.fasterxml.jackson.core:jackson-databind:2.18.2",
 			"org.apache.logging.log4j:log4j-api:2.24.3",
 			"org.apache.logging.log4j:log4j-core:2.24.3",
 			"org.apache.logging.log4j:log4j-layout-template-json:2.24.3",
-			"com.nimbusds:oauth2-oidc-sdk:11.21.2",
+			"com.nimbusds:oauth2-oidc-sdk:11.23.1",
 			project(":di-ipv-cimit-stub:lib")
 
 	compileOnly "org.projectlombok:lombok:1.18.36"

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -16,7 +16,7 @@ java {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.3",
 			"com.amazonaws:aws-lambda-java-events:3.14.0",
-			"software.amazon.awssdk:dynamodb-enhanced:2.30.5",
+			"software.amazon.awssdk:dynamodb-enhanced:2.30.31",
 			"com.fasterxml.jackson.core:jackson-annotations:2.18.2",
 			"com.fasterxml.jackson.core:jackson-databind:2.18.2",
 			"org.apache.logging.log4j:log4j-api:2.24.3",

--- a/di-ipv-cimit-stub/lib/build.gradle
+++ b/di-ipv-cimit-stub/lib/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-	implementation "software.amazon.awssdk:dynamodb-enhanced:2.30.5",
+	implementation "software.amazon.awssdk:dynamodb-enhanced:2.30.31",
 			"software.amazon.lambda:powertools-parameters:1.16.1",
 			"software.amazon.awssdk:kms:2.29.23",
 			"org.apache.logging.log4j:log4j-api:2.24.3",

--- a/di-ipv-core-stub/build.gradle
+++ b/di-ipv-core-stub/build.gradle
@@ -17,7 +17,7 @@ java {
 dependencies {
 	implementation "com.sparkjava:spark-core:2.9.4",
 			"com.sparkjava:spark-template-mustache:2.7.1",
-			"com.nimbusds:oauth2-oidc-sdk:11.21.2",
+			"com.nimbusds:oauth2-oidc-sdk:11.23.1",
 			"com.google.code.gson:gson:2.11.0",
 			"org.slf4j:slf4j-simple:2.0.16",
 			"org.yaml:snakeyaml:2.3",

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	implementation "io.javalin:javalin:6.3.0",
 			"io.javalin:javalin-rendering:6.3.0",
 			"com.github.spullara.mustache.java:compiler:0.9.14",
-			"com.nimbusds:oauth2-oidc-sdk:11.21.2",
+			"com.nimbusds:oauth2-oidc-sdk:11.23.1",
 			"com.fasterxml.jackson.core:jackson-core:2.18.2",
 			"com.fasterxml.jackson.core:jackson-databind:2.18.2",
 			"com.fasterxml.jackson.core:jackson-annotations:2.18.2",

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	implementation "io.javalin:javalin:6.3.0",
 			"io.javalin:javalin-rendering:6.3.0",
 			"com.github.spullara.mustache.java:compiler:0.9.14",
-			"com.nimbusds:oauth2-oidc-sdk:11.21.2",
+			"com.nimbusds:oauth2-oidc-sdk:11.23.1",
 			"com.fasterxml.jackson.core:jackson-databind:2.18.2",
 			"org.slf4j:slf4j-simple:2.0.16"
 


### PR DESCRIPTION
## Proposed changes

### What changed
- Updated `software.amazon.awssdk:dynamodb-enhanced` for the `io.netty:netty-handle`  transitive dependency to use version :2.30.31 within the external libraries folder
- Updated `com.nimbusds:oauth2-oidc-sdk` for the `net.minidev:json-smart`  transitive dependency to use version 11.23.1 within the external libraries folder

### Why did it change
To improve the security/vulnerability issues found [here](https://github.com/govuk-one-login/ipv-stubs/security/dependabot) for regressed versions.

### Issue tracking

- [OJ-3051](https://govukverify.atlassian.net/browse/OJ-3051)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3051]: https://govukverify.atlassian.net/browse/OJ-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ