### PR TITLE
PYIC-8146 Update Orch, CRI and CIMIT stubs to Java 21

### DIFF
--- a/.github/workflows/cimit-stub.yml
+++ b/.github/workflows/cimit-stub.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'corretto'
           cache: gradle
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@v4.2.1

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: '21'
+          distribution: 'corretto'
           cache: gradle
       - name: Build
         run: ./gradlew clean build

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 spotless {
 	java {
 		target "**/src/**/*.java"
-		googleJavaFormat("1.14.0").aosp()
+		googleJavaFormat("1.25.2").aosp()
 		importOrder "", "javax", "java", "\\#"
 		endWithNewline()
 	}

--- a/di-ipv-cimit-stub/build.gradle
+++ b/di-ipv-cimit-stub/build.gradle
@@ -8,8 +8,8 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 subprojects {

--- a/di-ipv-cimit-stub/gradle/wrapper/gradle-wrapper.properties
+++ b/di-ipv-cimit-stub/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/get-contra-indicator-credential/build.gradle
@@ -9,8 +9,8 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/post-mitigations/build.gradle
@@ -9,8 +9,8 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -9,8 +9,8 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -9,8 +9,8 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/di-ipv-cimit-stub/lib/build.gradle
+++ b/di-ipv-cimit-stub/lib/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.withType(Jar).configureEach { Jar jar ->

--- a/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/PendingMitigationService.java
+++ b/di-ipv-cimit-stub/lib/src/main/java/uk/gov/di/ipv/core/library/service/PendingMitigationService.java
@@ -82,11 +82,13 @@ public class PendingMitigationService {
 
         switch (pendingMitigationItem.getRequestMethod()) {
             case "PUT" -> itemToMitigate.setMitigations(pendingMitigationItem.getMitigationCodes());
-            case "POST" -> itemToMitigate.addMitigations(
-                    pendingMitigationItem.getMitigationCodes());
-            default -> throw new IllegalArgumentException(
-                    String.format(
-                            "Method not supported: %s", pendingMitigationItem.getRequestMethod()));
+            case "POST" ->
+                    itemToMitigate.addMitigations(pendingMitigationItem.getMitigationCodes());
+            default ->
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Method not supported: %s",
+                                    pendingMitigationItem.getRequestMethod()));
         }
 
         cimitService.updateCimitStubItem(itemToMitigate);

--- a/di-ipv-credential-issuer-stub/Dockerfile
+++ b/di-ipv-credential-issuer-stub/Dockerfile
@@ -1,15 +1,15 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e AS build
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew build --no-daemon
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e
 
 ENV PORT 8084
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN yum update && yum install -y shadow-utils curl tar
+RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
 COPY --from=build \
     /home/gradle/src/build/distributions/di-ipv-credential-issuer-stub.tar \
     /app/

--- a/di-ipv-credential-issuer-stub/Dockerfile-arm64
+++ b/di-ipv-credential-issuer-stub/Dockerfile-arm64
@@ -1,17 +1,17 @@
 ARG DT_API_TOKEN
-FROM --platform="linux/arm64" openjdk:17.0.1-jdk-slim@sha256:565d3643a78a657ca03e85c110af9579a07e833d6bcc14f475249c521b5c5d74 AS build
+FROM --platform="linux/arm64" amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e AS build
 ARG DT_API_TOKEN
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew build --no-daemon
 
-FROM --platform="linux/arm64" openjdk:17.0.1-jdk-slim@sha256:565d3643a78a657ca03e85c110af9579a07e833d6bcc14f475249c521b5c5d74
+FROM --platform="linux/arm64" amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e
 ARG DT_API_TOKEN
 ENV PORT 8084
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN yum update && yum install -y shadow-utils curl tar wget unzip
+RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl && apt-get install -y wget && apt-get install -y unzip
 COPY --from=build \
     /home/gradle/src/build/distributions/di-ipv-credential-issuer-stub.tar \
     /app/

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/Dockerfile
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/Dockerfile
@@ -1,15 +1,15 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e AS build
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew build --no-daemon
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e
 
 ENV PORT 8084
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN yum update && yum install -y shadow-utils curl tar
+RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
 COPY --from=build \
     /home/gradle/src/build/distributions/di-ipv-credential-issuer-stub.tar \
     /app/

--- a/di-ipv-credential-issuer-stub/gradle/wrapper/gradle-wrapper.properties
+++ b/di-ipv-credential-issuer-stub/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -255,7 +255,10 @@ public class AuthorizeHandler {
     }
 
     private String generateResponseRedirect(AuthRequest authRequest, JWTClaimsSet claimsSet)
-            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+            throws IOException,
+                    NoSuchAlgorithmException,
+                    InvalidKeySpecException,
+                    JOSEException,
                     ParseException {
         AuthorizationErrorResponse requestedAuthErrorResponse = handleRequestedError(authRequest);
         if (requestedAuthErrorResponse != null) {
@@ -484,8 +487,9 @@ public class AuthorizeHandler {
                 gpg45Score.put(STRENGTH, Integer.parseInt(gpg45Scores.strength()));
                 gpg45Score.put(VALIDITY, Integer.parseInt(gpg45Scores.validity()));
             }
-            case ACTIVITY_CRI_TYPE -> gpg45Score.put(
-                    ACTIVITY_HISTORY, Integer.parseInt(gpg45Scores.activityHistory()));
+            case ACTIVITY_CRI_TYPE ->
+                    gpg45Score.put(
+                            ACTIVITY_HISTORY, Integer.parseInt(gpg45Scores.activityHistory()));
             case FRAUD_CRI_TYPE -> {
                 gpg45Score.put(FRAUD, Integer.parseInt(gpg45Scores.fraud()));
                 if (StringUtils.isNotBlank(gpg45Scores.activityHistory())) {
@@ -493,8 +497,8 @@ public class AuthorizeHandler {
                             ACTIVITY_HISTORY, Integer.parseInt(gpg45Scores.activityHistory()));
                 }
             }
-            case VERIFICATION_CRI_TYPE -> gpg45Score.put(
-                    VERIFICATION, Integer.parseInt(gpg45Scores.verification()));
+            case VERIFICATION_CRI_TYPE ->
+                    gpg45Score.put(VERIFICATION, Integer.parseInt(gpg45Scores.verification()));
             case DOC_CHECK_APP_CRI_TYPE -> {
                 int strengthNum =
                         StringUtils.isNotBlank(gpg45Scores.validity())

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/vc/VerifiableCredentialGenerator.java
@@ -80,8 +80,8 @@ public class VerifiableCredentialGenerator {
 
     private List<String> getVcType() {
         return switch (getCriType()) {
-            case USER_ASSERTED_CRI_TYPE -> List.of(
-                    VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_ASSERTION_CREDENTIAL_TYPE);
+            case USER_ASSERTED_CRI_TYPE ->
+                    List.of(VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_ASSERTION_CREDENTIAL_TYPE);
             case ADDRESS_CRI_TYPE -> List.of(VERIFIABLE_CREDENTIAL_TYPE, ADDRESS_CREDENTIAL_TYPE);
             default -> List.of(VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE);
         };

--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -1,16 +1,16 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e AS build
 COPY . /home/gradle
 WORKDIR /home/gradle
 RUN ./gradlew build --no-daemon --stacktrace
 
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e
 
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN yum update && yum install -y shadow-utils curl tar
+RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
 COPY --from=build \
     /home/gradle/build/distributions/di-ipv-orchestrator-stub.tar \
     /app/

--- a/di-ipv-orchestrator-stub/Dockerfile-arm64
+++ b/di-ipv-orchestrator-stub/Dockerfile-arm64
@@ -1,18 +1,18 @@
 ARG DT_API_TOKEN
-FROM --platform="linux/arm64" openjdk:17.0.1-jdk-slim@sha256:565d3643a78a657ca03e85c110af9579a07e833d6bcc14f475249c521b5c5d74 AS build
+FROM --platform="linux/arm64" amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e AS build
 ARG DT_API_TOKEN
 COPY . /home/gradle
 WORKDIR /home/gradle
 RUN ./gradlew build --no-daemon --stacktrace
 
 
-FROM --platform="linux/arm64" openjdk:17.0.1-jdk-slim@sha256:565d3643a78a657ca03e85c110af9579a07e833d6bcc14f475249c521b5c5d74
+FROM --platform="linux/arm64" amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e
 ARG DT_API_TOKEN
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN yum update && yum install -y shadow-utils curl tar wget unzip
+RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl && apt-get install -y wget && apt-get install -y unzip
 COPY --from=build \
     /home/gradle/build/distributions/di-ipv-orchestrator-stub.tar \
     /app/

--- a/di-ipv-orchestrator-stub/build.gradle
+++ b/di-ipv-orchestrator-stub/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/di-ipv-orchestrator-stub/core-dev-deploy/Dockerfile
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/Dockerfile
@@ -1,16 +1,16 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e AS build
 COPY . /home/gradle
 WORKDIR /home/gradle
 RUN ./gradlew build --no-daemon --stacktrace
 
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344ab8691cc0f5953f9b97f8e
 
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN yum update && yum install -y shadow-utils curl tar
+RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
 COPY --from=build \
     /home/gradle/build/distributions/di-ipv-orchestrator-stub.tar \
     /app/

--- a/di-ipv-orchestrator-stub/gradle/wrapper/gradle-wrapper.properties
+++ b/di-ipv-orchestrator-stub/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -213,13 +213,13 @@ public class IpvHandler {
     private URI getIpvEndpoint(String environment) throws URISyntaxException {
         String url =
                 switch (environment) {
-                        // dev01
+                    // dev01
                     case ("DEV") -> "https://dev.01.dev.identity.account.gov.uk/";
                     case ("DEV_AMRITS") -> "https://dev-amrits.01.dev.identity.account.gov.uk/";
                     case ("DEV_ALIR") -> "https://dev-alir.01.dev.identity.account.gov.uk/";
                     case ("DEV_PATRICKB") -> "https://dev-patrickb.01.dev.identity.account.gov.uk/";
 
-                        // dev02
+                    // dev02
                     case ("PERF") -> "https://dev-perf.02.dev.identity.account.gov.uk/";
                     case ("DEV_DANC") -> "https://dev-danc.02.dev.identity.account.gov.uk/";
                     case ("DEV_JOEE") -> "https://dev-joee.02.dev.identity.account.gov.uk/";
@@ -227,7 +227,7 @@ public class IpvHandler {
                     case ("DEV_DOMINIKT") -> "https://dev-dominikt.02.dev.identity.account.gov.uk/";
                     case ("DEV_THEAB") -> "https://dev-theab.02.dev.identity.account.gov.uk/";
 
-                        // higher
+                    // higher
                     case ("BUILD") -> "https://identity.build.account.gov.uk/";
                     case ("STAGING") -> "https://identity.staging.account.gov.uk/";
                     case ("INTEGRATION") -> "https://identity.integration.account.gov.uk/";
@@ -240,21 +240,23 @@ public class IpvHandler {
     private URI getIpvBackchannelEndpoint(String environment) throws URISyntaxException {
         String url =
                 switch (environment) {
-                        // dev01
+                    // dev01
                     case ("DEV") -> "https://api-dev.01.dev.identity.account.gov.uk/";
                     case ("DEV_AMRITS") -> "https://api-dev-amrits.01.dev.identity.account.gov.uk/";
                     case ("DEV_ALIR") -> "https://api-dev-alir.01.dev.identity.account.gov.uk/";
-                    case ("DEV_PATRICKB") -> "https://api-dev-patrickb.01.dev.identity.account.gov.uk/";
+                    case ("DEV_PATRICKB") ->
+                            "https://api-dev-patrickb.01.dev.identity.account.gov.uk/";
 
-                        // dev02
+                    // dev02
                     case ("PERF") -> "https://api-dev-perf.02.dev.identity.account.gov.uk/";
                     case ("DEV_DANC") -> "https://api-dev-danc.02.dev.identity.account.gov.uk/";
                     case ("DEV_JOEE") -> "https://api-dev-joee.02.dev.identity.account.gov.uk/";
                     case ("DEV_MIKEC") -> "https://api-dev-mikec.02.dev.identity.account.gov.uk/";
-                    case ("DEV_DOMINIKT") -> "https://api-dev-dominikt.02.dev.identity.account.gov.uk/";
+                    case ("DEV_DOMINIKT") ->
+                            "https://api-dev-dominikt.02.dev.identity.account.gov.uk/";
                     case ("DEV_THEAB") -> "https://api-dev-theab.02.dev.identity.account.gov.uk/";
 
-                        // higher
+                    // higher
                     case ("BUILD") -> "https://api.identity.build.account.gov.uk/";
                     case ("STAGING") -> "https://api.identity.staging.account.gov.uk/";
                     case ("INTEGRATION") -> "https://api.identity.integration.account.gov.uk/";

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/InheritedIdentityJwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/InheritedIdentityJwtBuilder.java
@@ -52,8 +52,11 @@ public class InheritedIdentityJwtBuilder {
 
     public static SignedJWT generate(
             String userId, String vot, String credentialSubject, String evidence)
-            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
-                    JsonProcessingException, ParseException {
+            throws NoSuchAlgorithmException,
+                    InvalidKeySpecException,
+                    JOSEException,
+                    JsonProcessingException,
+                    ParseException {
 
         Map<String, Object> vc = new LinkedHashMap<>();
         vc.put(VC_TYPE, new String[] {VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE});

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -175,14 +175,15 @@ public class JwtBuilder {
 
     private static RSAKey getEncryptionKey(String targetEnvironment) throws ParseException {
         return switch (targetEnvironment) {
-            case ("DEV"), ("DEV_AMRITS"), ("DEV_ALIR"), ("DEV_PATRICKB") -> RSAKey.parse(
-                    ORCHESTRATOR_DEV01_JAR_ENCRYPTION_PUBLIC_JWK);
+            case ("DEV"), ("DEV_AMRITS"), ("DEV_ALIR"), ("DEV_PATRICKB") ->
+                    RSAKey.parse(ORCHESTRATOR_DEV01_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("PERF"),
                     ("DEV_DANC"),
                     ("DEV_JOEE"),
                     ("DEV_MIKEC"),
                     ("DEV_DOMINIKT"),
-                    ("DEV_THEAB") -> RSAKey.parse(ORCHESTRATOR_DEV02_JAR_ENCRYPTION_PUBLIC_JWK);
+                    ("DEV_THEAB") ->
+                    RSAKey.parse(ORCHESTRATOR_DEV02_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("BUILD") -> RSAKey.parse(ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("STAGING") -> RSAKey.parse(ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("INTEGRATION") ->
@@ -193,13 +194,13 @@ public class JwtBuilder {
 
     private static String getIpvCoreAudience(String targetEnvironment) {
         return switch (targetEnvironment) {
-                // dev01
+            // dev01
             case ("DEV") -> "https://dev.01.dev.identity.account.gov.uk";
             case ("DEV_AMRITS") -> "https://dev-amrits.01.dev.identity.account.gov.uk";
             case ("DEV_ALIR") -> "https://dev-alir.01.dev.identity.account.gov.uk";
             case ("DEV_PATRICKB") -> "https://dev-patrickb.01.dev.identity.account.gov.uk";
 
-                // dev02
+            // dev02
             case ("PERF") -> "https://dev-perf.02.dev.identity.account.gov.uk";
             case ("DEV_DANC") -> "https://dev-danc.02.dev.identity.account.gov.uk";
             case ("DEV_JOEE") -> "https://dev-joee.02.dev.identity.account.gov.uk";
@@ -207,7 +208,7 @@ public class JwtBuilder {
             case ("DEV_DOMINIKT") -> "https://dev-dominikt.02.dev.identity.account.gov.uk";
             case ("DEV_THEAB") -> "https://dev-theab.02.dev.identity.account.gov.uk";
 
-                // higher
+            // higher
             case ("BUILD") -> "https://identity.build.account.gov.uk";
             case ("STAGING") -> "https://identity.staging.account.gov.uk";
             case ("INTEGRATION") -> "https://identity.integration.account.gov.uk";

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -85,8 +85,11 @@ public class JwtBuilder {
             Scope scope,
             String clientId,
             String evcsAccessToken)
-            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
-                    JsonProcessingException, ParseException {
+            throws NoSuchAlgorithmException,
+                    InvalidKeySpecException,
+                    JOSEException,
+                    JsonProcessingException,
+                    ParseException {
         String audience = getIpvCoreAudience(environment);
         String redirectUri = ORCHESTRATOR_REDIRECT_URL;
 
@@ -182,8 +185,8 @@ public class JwtBuilder {
                     ("DEV_THEAB") -> RSAKey.parse(ORCHESTRATOR_DEV02_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("BUILD") -> RSAKey.parse(ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("STAGING") -> RSAKey.parse(ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_JWK);
-            case ("INTEGRATION") -> RSAKey.parse(
-                    ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_JWK);
+            case ("INTEGRATION") ->
+                    RSAKey.parse(ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_JWK);
             default -> RSAKey.parse(ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_JWK);
         };
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Proposed changes

### What changed

- Update the java target for the Orch, CRI and CIMIT stubs to Java 21
- Update the Gradle version to 8.13
- Update the Spotless language version
- Update Dockerfiles to use amazon-corretto 21
