### PR TITLE
PYIC-8194: Add Dev as an option to Orch Stubs

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/HomeHandler.java
@@ -20,8 +20,14 @@ public class HomeHandler {
         String journeyId = UUID.randomUUID().toString();
         String userId = NON_APP_JOURNEY_USER_ID_PREFIX + UUID.randomUUID();
 
+        String defaultEnvironment = ctx.queryParam("defaultEnvironment");
+        if (defaultEnvironment == null || defaultEnvironment.isBlank()) {
+            defaultEnvironment = "DEFAULT";
+        }
+
         moustacheDataModel.put("signInJourneyId", journeyId);
         moustacheDataModel.put("uuid", userId);
+        moustacheDataModel.put("defaultEnvironment", defaultEnvironment);
         moustacheDataModel.put(
                 "credentialSubjects", getData("/data/inheritedJWTCredentialSubjects.json"));
         moustacheDataModel.put("evidences", getData("/data/inheritedJWTEvidences.json"));

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -214,6 +214,7 @@ public class IpvHandler {
     private URI getIpvEndpoint(String environment) throws URISyntaxException {
         String url =
                 switch (environment) {
+                    case ("DEV") -> "https://dev.01.dev.identity.account.gov.uk/";
                     case ("BUILD") -> "https://identity.build.account.gov.uk/";
                     case ("STAGING") -> "https://identity.staging.account.gov.uk/";
                     case ("INTEGRATION") -> "https://identity.integration.account.gov.uk/";
@@ -226,6 +227,7 @@ public class IpvHandler {
     private URI getIpvBackchannelEndpoint(String environment) throws URISyntaxException {
         String url =
                 switch (environment) {
+                    case ("DEV") -> "https://dev.01.dev.identity.account.gov.uk/";
                     case ("BUILD") -> "https://api.identity.build.account.gov.uk/";
                     case ("STAGING") -> "https://api.identity.staging.account.gov.uk/";
                     case ("INTEGRATION") -> "https://api.identity.integration.account.gov.uk/";

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -170,7 +170,7 @@ public class JwtBuilder {
 
     private static RSAKey getEncryptionKey(String targetEnvironment) throws ParseException {
         return switch (targetEnvironment) {
-            case ("BUILD") -> RSAKey.parse(ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_JWK);
+            case ("DEV"), ("BUILD") -> RSAKey.parse(ORCHESTRATOR_BUILD_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("STAGING") -> RSAKey.parse(ORCHESTRATOR_STAGING_JAR_ENCRYPTION_PUBLIC_JWK);
             case ("INTEGRATION") -> RSAKey.parse(
                     ORCHESTRATOR_INTEGRATION_JAR_ENCRYPTION_PUBLIC_JWK);
@@ -180,6 +180,7 @@ public class JwtBuilder {
 
     private static String getIpvCoreAudience(String targetEnvironment) {
         return switch (targetEnvironment) {
+            case ("DEV") -> "https://dev.01.dev.identity.account.gov.uk/";
             case ("BUILD") -> "https://identity.build.account.gov.uk";
             case ("STAGING") -> "https://identity.staging.account.gov.uk";
             case ("INTEGRATION") -> "https://identity.integration.account.gov.uk";

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -80,7 +80,7 @@
             <div class="govuk-form-group">
                 <label class="govuk-label" for="targetEnvironment">Choose a target environment (optional):</label>
                 <select class="govuk-select" name="targetEnvironment" id="targetEnvironment">
-                    <option value="DEFAULT">default</option>
+                    <option value="{{defaultEnvironmentValue}}" selected>default</option>
                     <option value="DEV">dev</option>
                     <option value="BUILD">build</option>
                     <option value="STAGING">staging</option>

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -81,6 +81,7 @@
                 <label class="govuk-label" for="targetEnvironment">Choose a target environment (optional):</label>
                 <select class="govuk-select" name="targetEnvironment" id="targetEnvironment">
                     <option value="DEFAULT">default</option>
+                    <option value="DEV">dev</option>
                     <option value="BUILD">build</option>
                     <option value="STAGING">staging</option>
                     <option value="INTEGRATION">integration</option>


### PR DESCRIPTION
## Proposed changes

### What changed

- Add Dev as an option to Orch Stubs

### Why did it change

- To be able to use the same orch stub for the generic dev account, as there is no obvious way of setting up the orch stub for it to do Selenium tests.

### Issue tracking

- [PYIC-8194](https://govukverify.atlassian.net/browse/PYIC-8194)

[PYIC-8194]: https://govukverify.atlassian.net/browse/PYIC-8194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ