### PR TITLE
LIME-1592 core-stub updated to access jwksEndpoint for automated key …

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuer.java
@@ -5,6 +5,8 @@ import java.net.URI;
 public record CredentialIssuer(
         String id,
         String name,
+        URI jwksEndpoint,
+        boolean useKeyRotation,
         URI authorizeUrl,
         URI tokenUrl,
         URI credentialUrl,

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/config/credentialissuer/CredentialIssuerMapper.java
@@ -8,6 +8,8 @@ public class CredentialIssuerMapper {
     public CredentialIssuer map(Map<String, Object> map) {
         String id = (String) map.get("id");
         String name = (String) map.get("name");
+        URI jwksEndpoint = URI.create((String) map.get("jwksEndpoint"));
+        boolean useKeyRotation = Boolean.parseBoolean(map.get("useKeyRotation").toString());
         URI authorizeUrl = URI.create((String) map.get("authorizeUrl"));
         URI tokenUrl = URI.create((String) map.get("tokenUrl"));
         URI credentialUrl = URI.create((String) map.get("credentialUrl"));
@@ -21,6 +23,8 @@ public class CredentialIssuerMapper {
         return new CredentialIssuer(
                 id,
                 name,
+                jwksEndpoint,
+                useKeyRotation,
                 authorizeUrl,
                 tokenUrl,
                 credentialUrl,

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -29,6 +29,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
@@ -290,7 +291,7 @@ public class CoreStubHandler {
 
     private <T> void sendAuthorizationRequest(
             Request request, Response response, CredentialIssuer credentialIssuer, T sharedClaims)
-            throws ParseException, JOSEException, JsonProcessingException {
+            throws ParseException, JOSEException {
         State state = createNewState(credentialIssuer);
         request.session().attribute("state", state);
         EvidenceRequestClaims evidenceRequest = request.session().attribute("evidence_request");
@@ -340,7 +341,7 @@ public class CoreStubHandler {
 
     private AuthorizationRequest createBackendAuthorizationRequest(
             CredentialIssuer credentialIssuer, JWTClaimsSet claimsSet)
-            throws JOSEException, java.text.ParseException {
+            throws JOSEException, java.text.ParseException, MalformedURLException {
         AuthorizationRequest authRequest =
                 handlerHelper.createBackEndAuthorizationJAR(credentialIssuer, claimsSet);
         LOGGER.info("🚀 Created AuthorizationRequest for state {}", claimsSet.getClaim("state"));


### PR DESCRIPTION
…rotation

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

core-stub updated to access CRI jwksEndpoint for automated key rotation initiative. The core stub will now select the CRI active public encryption key from the endpoint, encrypt the core stub request to the CRI using the key and include the hashed key id in the JWE header. 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1592](https://govukverify.atlassian.net/browse/LIME-1592)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1592]: https://govukverify.atlassian.net/browse/LIME-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ