### PR TITLE
PYIC-8180: Add nino to CIMIT stub

### DIFF
--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/CredentialSubject.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/CredentialSubject.java
@@ -8,4 +8,5 @@ import java.util.List;
 public record CredentialSubject(
         List<DrivingPermit> drivingPermit,
         List<Passport> passport,
-        List<ResidencePermit> residencePermit) {}
+        List<ResidencePermit> residencePermit,
+        List<SocialSecurityRecord> socialSecurityRecord) {}

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/SocialSecurityRecord.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/dto/SocialSecurityRecord.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.core.putcontraindicators.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SocialSecurityRecord(String personalNumber) implements Document {
+
+    private static final String SOCIAL_SECURITY_IDENTIFIER_TEMPLATE = "socialSecurity/GB/%s";
+
+    @Override
+    public String toIdentifier() {
+        return String.format(SOCIAL_SECURITY_IDENTIFIER_TEMPLATE, personalNumber);
+    }
+}

--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/src/main/java/uk/gov/di/ipv/core/putcontraindicators/service/ContraIndicatorsService.java
@@ -158,6 +158,9 @@ public class ContraIndicatorsService {
             if (!CollectionUtils.isNullOrEmpty(credentialSubject.residencePermit())) {
                 return credentialSubject.residencePermit().get(0).toIdentifier();
             }
+            if (!CollectionUtils.isNullOrEmpty(credentialSubject.socialSecurityRecord())) {
+                return credentialSubject.socialSecurityRecord().get(0).toIdentifier();
+            }
         }
         return null;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add SocialSecurityRecord class to the CIMIT stub

### Why did it change

So it can return CIs for NINOs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8180](https://govukverify.atlassian.net/browse/PYIC-8180)


[PYIC-8180]: https://govukverify.atlassian.net/browse/PYIC-8180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ