### PR TITLE
feat: hash kid when creating signed jwt

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -429,11 +429,12 @@ public class HandlerHelper {
 
         JWTSigner jwtSigner = new JWTSigner();
 
+        String hashedKid = getHashedKeyId(jwtSigner.getKeyId());
+        LOGGER.info("Hashed KID: {}", hashedKid);
+
         SignedJWT signedJWT =
                 new SignedJWT(
-                        new JWSHeader.Builder(jwsSigningAlgorithm)
-                                .keyID(jwtSigner.getKeyId())
-                                .build(),
+                        new JWSHeader.Builder(jwsSigningAlgorithm).keyID(hashedKid).build(),
                         new JWTClaimsSet.Builder()
                                 .subject(getSubject())
                                 .audience(credentialIssuer.audience().toString())


### PR DESCRIPTION
## Proposed changes

### What changed
kid within the jwt will be hashed

### Why did it change
as part of core introducing a public jwks endpoint, common-lambdas now checks to see if the hashed kid is inside the contents of the public jwks json. 

This works for the request to session function but the request to the token endpoint did not use the hashed kid. 
