### PR TITLE
OJ-3169: Hash KID included in JWT header for /token endpoint

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/HandlerHelper.java
@@ -181,13 +181,16 @@ public class HandlerHelper {
                 new AuthorizationCodeGrant(
                         authorizationCode, CoreStubConfig.CORE_STUB_REDIRECT_URL);
 
+        String hashedKid = getHashedKeyId(this.ecSigningKey.getKeyID());
+        LOGGER.info("hashed KID is {}", hashedKid);
+
         PrivateKeyJWT privateKeyJWT =
                 new PrivateKeyJWT(
                         new JWTAuthenticationClaimsSet(
                                 clientID, new Audience(credentialIssuer.audience())),
                         JWSAlgorithm.ES256,
                         this.ecSigningKey.toECPrivateKey(),
-                        this.ecSigningKey.getKeyID(),
+                        hashedKid,
                         null);
 
         return new TokenRequest(tokenURI, privateKeyJWT, authzGrant);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Hash KID included in JWT header for /token endpoint

### Why did it change

Because the KIDs on the jwks endpoints are hashed, and the token handler cannot match an unhashed KID to a hashed KID

### Screenshots

Before 
![Screenshot 2025-05-05 at 11 11 05 am](https://github.com/user-attachments/assets/d7e0ff52-8eee-4ff2-b774-a228200c9809)

After
![image](https://github.com/user-attachments/assets/1eb4bb2c-d854-405b-b6a6-894442c9de5f)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3169](https://govukverify.atlassian.net/browse/OJ-3169)


[OJ-3169]: https://govukverify.atlassian.net/browse/OJ-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ