### PR TITLE
PYIC-8302: update stored identity table sort key

### DIFF
--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -384,17 +384,17 @@ Resources:
     Type: AWS::DynamoDB::Table
     # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
     Properties:
-      TableName: !Sub "evcs-stored-identity-store-${Environment}"
+      TableName: !Sub "evcs-stored-identity-store-${Environment}-temp"
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
         - AttributeName: "userId"
           AttributeType: "S"
-        - AttributeName: "jwtSignature"
+        - AttributeName: "recordType"
           AttributeType: "S"
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
-        - AttributeName: "jwtSignature"
+        - AttributeName: "recordType"
           KeyType: "RANGE"
       SSESpecification:
         SSEEnabled: true

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -420,17 +420,17 @@ Resources:
     Type: AWS::DynamoDB::Table
     # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
     Properties:
-      TableName: !Sub "evcs-stored-identity-store-${Environment}"
+      TableName: !Sub "evcs-stored-identity-store-${Environment}-temp"
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
         - AttributeName: "userId"
           AttributeType: "S"
-        - AttributeName: "jwtSignature"
+        - AttributeName: "recordType"
           AttributeType: "S"
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
-        - AttributeName: "jwtSignature"
+        - AttributeName: "recordType"
           KeyType: "RANGE"
       SSESpecification:
         SSEEnabled: true

--- a/di-ipv-evcs-stub/lambdas/src/domain/enums/StoredIdentityRecordType.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/enums/StoredIdentityRecordType.ts
@@ -1,0 +1,4 @@
+export enum StoredIdentityRecordType {
+  GPG45 = "idrec:gpg45",
+  HMRC = "idrec:Inherited:hmrc",
+}

--- a/di-ipv-evcs-stub/lambdas/src/domain/enums/vot.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/enums/vot.ts
@@ -1,0 +1,11 @@
+export enum Vot {
+  P1 = "P1",
+  P2 = "P2",
+  P3 = "P3",
+  P4 = "P4",
+  PCL200 = "PCL200",
+  PCL250 = "PCL250",
+}
+
+export const GPG45_VOTS = [Vot.P1, Vot.P2, Vot.P3, Vot.P4];
+export const HMRC_VOTS = [Vot.PCL200, Vot.PCL250];

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/putRequest.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/putRequest.ts
@@ -1,8 +1,9 @@
 import { VcDetails } from "../sharedTypes";
+import { Vot } from "../enums/vot";
 
 interface StoredIdentityDetails {
   jwt: string;
-  vot: string;
+  vot: Vot;
   metadata?: object;
 }
 

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
@@ -186,9 +186,7 @@ function parsePutRequest(event: APIGatewayProxyEvent): PutRequest {
     }
   });
 
-  const uniqueVcs = new Set(
-    parsedPutRequest.vcs.map((vc: VcDetails) => vc.vc),
-  );
+  const uniqueVcs = new Set(parsedPutRequest.vcs.map((vc: VcDetails) => vc.vc));
   if (uniqueVcs.size !== parsedPutRequest.vcs.length) {
     throw new Error("Invalid vcs: cannot have duplicate VCs in request");
   }

--- a/di-ipv-evcs-stub/lambdas/src/model/storedIdentityItem.ts
+++ b/di-ipv-evcs-stub/lambdas/src/model/storedIdentityItem.ts
@@ -1,6 +1,6 @@
 export default interface EvcsStoredIdentityItem {
   userId: string;
-  jwtSignature: string;
+  recordType: string;
   storedIdentity: string;
   levelOfConfidence: string;
   isValid: boolean;

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -162,7 +162,7 @@ export async function processPutUserVCsRequest(
     if (putRequest.si) {
       const storedIdentityItem: EvcsStoredIdentityItem = {
         userId: putRequest.userId,
-        recordType: getRecordTypeFromString(putRequest.si.vot),
+        recordType: getRecordTypeFromVot(putRequest.si.vot),
         storedIdentity: putRequest.si.jwt,
         levelOfConfidence: putRequest.si.vot,
         metadata: putRequest.si.metadata,
@@ -348,7 +348,7 @@ function getUpdatedState(
   return currentVcState;
 }
 
-function getRecordTypeFromString(vot: Vot): StoredIdentityRecordType {
+function getRecordTypeFromVot(vot: Vot): StoredIdentityRecordType {
   if (GPG45_VOTS.includes(vot)) {
     return StoredIdentityRecordType.GPG45;
   }

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -20,7 +20,7 @@ import { VcState, VCProvenance } from "../src/domain/enums";
 import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/api-gateway-proxy";
 import { PutRequest } from "../src/domain/requests";
-import {Vot} from "../src/domain/enums/vot";
+import { Vot } from "../src/domain/enums/vot";
 
 jest.mock("../src/services/evcsService", () => ({
   processGetUserVCsRequest: jest.fn(),

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -20,6 +20,7 @@ import { VcState, VCProvenance } from "../src/domain/enums";
 import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/api-gateway-proxy";
 import { PutRequest } from "../src/domain/requests";
+import {Vot} from "../src/domain/enums/vot";
 
 jest.mock("../src/services/evcsService", () => ({
   processGetUserVCsRequest: jest.fn(),
@@ -121,7 +122,7 @@ const buildPutRequest = (putRequest?: RecursivePartial<PutRequest>) => {
     ],
     si: {
       jwt: TEST_VC_STRING,
-      vot: "P2",
+      vot: Vot.P2,
       metadata: TEST_METADATA,
     },
     ...(putRequest ? putRequest : {}),
@@ -366,7 +367,7 @@ describe("evcs handlers", () => {
         case: "duplicate vcs with the same states",
       },
       {
-        request: buildPutRequest({ si: { jwt: undefined, vot: "P2" } }),
+        request: buildPutRequest({ si: { jwt: undefined, vot: Vot.P2 } }),
         case: "si.jwt is missing",
       },
     ])("should return a 400 if $case", async ({ request }) => {

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -350,20 +350,20 @@ describe("evcs handlers", () => {
       {
         request: buildPutRequest({
           vcs: [
-            {vc: "some.vc.sig", state: VcState.CURRENT},
-            {vc: "some.vc.sig", state: VcState.HISTORIC}
-          ]
+            { vc: "some.vc.sig", state: VcState.CURRENT },
+            { vc: "some.vc.sig", state: VcState.HISTORIC },
+          ],
         }),
-        case: "duplicate vcs with different states"
+        case: "duplicate vcs with different states",
       },
       {
         request: buildPutRequest({
           vcs: [
-            {vc: "some.vc.sig", state: VcState.CURRENT},
-            {vc: "some.vc.sig", state: VcState.CURRENT}
-          ]
+            { vc: "some.vc.sig", state: VcState.CURRENT },
+            { vc: "some.vc.sig", state: VcState.CURRENT },
+          ],
         }),
-        case: "duplicate vcs with the same states"
+        case: "duplicate vcs with the same states",
       },
       {
         request: buildPutRequest({ si: { jwt: undefined, vot: "P2" } }),

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -144,7 +144,7 @@ describe("processPutUserVCsRequest", () => {
           provenance: VCProvenance.EXTERNAL,
         }),
         createStoredIdentityPutItem({
-          recordType: TEST_VC2_SIGNATURE,
+          recordType: StoredIdentityRecordType.GPG45,
           storedIdentity: TEST_VC2,
           levelOfConfidence: Vot.P2,
           metadata: TEST_METADATA,

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -12,6 +12,8 @@ import { PutRequest } from "../../src/domain/requests";
 import { StatusCodes, VCProvenance, VcState } from "../../src/domain/enums";
 import "aws-sdk-client-mock-jest";
 import { config } from "../../src/common/config";
+import { Vot } from "../../src/domain/enums/vot";
+import { StoredIdentityRecordType } from "../../src/domain/enums/StoredIdentityRecordType";
 
 jest.useFakeTimers().setSystemTime(new Date("2025-01-01"));
 
@@ -70,7 +72,7 @@ describe("processPutUserVCsRequest", () => {
       ],
       si: {
         jwt: TEST_VC2,
-        vot: "P2",
+        vot: Vot.P2,
       },
     };
 
@@ -89,7 +91,7 @@ describe("processPutUserVCsRequest", () => {
           state: VcState.CURRENT,
         }),
         createStoredIdentityPutItem({
-          jwtSignature: TEST_VC2_SIGNATURE,
+          recordType: StoredIdentityRecordType.GPG45,
           storedIdentity: TEST_VC2,
           levelOfConfidence: "P2",
         }),
@@ -120,7 +122,7 @@ describe("processPutUserVCsRequest", () => {
       ],
       si: {
         jwt: TEST_VC2,
-        vot: "P2",
+        vot: Vot.P2,
         metadata: TEST_METADATA,
       },
     };
@@ -142,9 +144,9 @@ describe("processPutUserVCsRequest", () => {
           provenance: VCProvenance.EXTERNAL,
         }),
         createStoredIdentityPutItem({
-          jwtSignature: TEST_VC2_SIGNATURE,
+          recordType: TEST_VC2_SIGNATURE,
           storedIdentity: TEST_VC2,
-          levelOfConfidence: "P2",
+          levelOfConfidence: Vot.P2,
           metadata: TEST_METADATA,
         }),
       ],
@@ -202,7 +204,7 @@ describe("processPutUserVCsRequest", () => {
       ],
       si: {
         jwt: TEST_VC2,
-        vot: "P2",
+        vot: Vot.P2,
       },
     };
 
@@ -230,7 +232,7 @@ describe("processPutUserVCsRequest", () => {
           provenance: VCProvenance.ONLINE,
         }),
         createStoredIdentityPutItem({
-          jwtSignature: TEST_VC2_SIGNATURE,
+          recordType: StoredIdentityRecordType.GPG45,
           storedIdentity: TEST_VC2,
           levelOfConfidence: "P2",
         }),
@@ -335,7 +337,7 @@ function createStubUserVcPutItem(putVcDetails: {
 }
 
 function createStoredIdentityPutItem(putSiDetails: {
-  jwtSignature: string;
+  recordType: string;
   storedIdentity: string;
   levelOfConfidence: string;
   metadata?: object;
@@ -346,7 +348,7 @@ function createStoredIdentityPutItem(putSiDetails: {
       Item: marshall(
         {
           userId: TEST_USER_ID,
-          jwtSignature: putSiDetails.jwtSignature,
+          recordType: putSiDetails.recordType,
           storedIdentity: putSiDetails.storedIdentity,
           levelOfConfidence: putSiDetails.levelOfConfidence,
           isValid: true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the StoredIdentity table to use `recordType` as sort key instead of the jwt's signature

### Why did it change
So that a user can only have a single GPG45 and/or HMRC stored identity record type stored in EVCS stub

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8302](https://govukverify.atlassian.net/browse/PYIC-8302)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8302]: https://govukverify.atlassian.net/browse/PYIC-8302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ