### PR TITLE
PYIC-8245: Fix GetAccountInterventionsFunction path

### DIFF
--- a/di-ipv-ais-stub/deploy/template.yaml
+++ b/di-ipv-ais-stub/deploy/template.yaml
@@ -138,7 +138,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref RestApiGateway
-            Path: /user/{userId}
+            Path: /ais/{userId}
             Method: GET
     Metadata:
       # Manage esbuild properties


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Fix GetAccountInterventionsFunction endpoint/ path

### Why did it change

- It should be `/ais/{userId}`

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8245](https://govukverify.atlassian.net/browse/PYIC-8245)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8245]: https://govukverify.atlassian.net/browse/PYIC-8245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ