### PR TITLE
PYIC-8245: Set AIS_NO_INTERVENTION as default response

### DIFF
--- a/di-ipv-ais-stub/lambdas/src/cases.ts
+++ b/di-ipv-ais-stub/lambdas/src/cases.ts
@@ -1,154 +1,154 @@
 export default {
-    AIS_ACCOUNT_BLOCKED: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_ACCOUNT_BLOCKED",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: true,
-            suspended: false,
-            reproveIdentity: false,
-            resetPassword: false
-        },
-        auditLevel: "standard",
-        history: []
+  AIS_ACCOUNT_BLOCKED: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_ACCOUNT_BLOCKED",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
     },
-    AIS_ACCOUNT_SUSPENDED: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_ACCOUNT_SUSPENDED",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: true,
-            reproveIdentity: false,
-            resetPassword: false
-        },
-        auditLevel: "standard",
-        history: []
+    state: {
+      blocked: true,
+      suspended: false,
+      reproveIdentity: false,
+      resetPassword: false,
     },
-    AIS_ACCOUNT_UNBLOCKED: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_ACCOUNT_UNBLOCKED",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: false,
-            reproveIdentity: false,
-            resetPassword: false
-        },
-        auditLevel: "standard",
-        history: []
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_ACCOUNT_SUSPENDED: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_ACCOUNT_SUSPENDED",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
     },
-    AIS_ACCOUNT_UNSUSPENDED: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_ACCOUNT_UNSUSPENDED",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: false,
-            reproveIdentity: false,
-            resetPassword: false
-        },
-        auditLevel: "standard",
-        history: []
+    state: {
+      blocked: false,
+      suspended: true,
+      reproveIdentity: false,
+      resetPassword: false,
     },
-    AIS_FORCED_USER_IDENTITY_VERIFY: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_FORCED_USER_IDENTITY_VERIFY",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: true,
-            reproveIdentity: true,
-            resetPassword: false
-        },
-        auditLevel: "standard",
-        history: []
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_ACCOUNT_UNBLOCKED: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_ACCOUNT_UNBLOCKED",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
     },
-    AIS_FORCED_USER_PASSWORD_RESET: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_FORCED_USER_PASSWORD_RESET",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: true,
-            reproveIdentity: false,
-            resetPassword: true
-        },
-        auditLevel: "standard",
-        history: []
+    state: {
+      blocked: false,
+      suspended: false,
+      reproveIdentity: false,
+      resetPassword: false,
     },
-    AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: true,
-            reproveIdentity: true,
-            resetPassword: true
-        },
-        auditLevel: "standard",
-        history: []
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_ACCOUNT_UNSUSPENDED: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_ACCOUNT_UNSUSPENDED",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
     },
-    AIS_NO_INTERVENTION: {
-        intervention: {
-            updatedAt: 1696969322935,
-            appliedAt: 1696869005821,
-            sentAt: 1696869003456,
-            description: "AIS_NO_INTERVENTION",
-            reprovedIdentityAt: 1696969322935,
-            resetPasswordAt: 1696875903456,
-            accountDeletedAt: 1696969359935
-        },
-        state: {
-            blocked: false,
-            suspended: false,
-            reproveIdentity: false,
-            resetPassword: false
-        },
-        auditLevel: "standard",
-        history: []
-    }
-}
+    state: {
+      blocked: false,
+      suspended: false,
+      reproveIdentity: false,
+      resetPassword: false,
+    },
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_FORCED_USER_IDENTITY_VERIFY: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_FORCED_USER_IDENTITY_VERIFY",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
+    },
+    state: {
+      blocked: false,
+      suspended: true,
+      reproveIdentity: true,
+      resetPassword: false,
+    },
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_FORCED_USER_PASSWORD_RESET: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_FORCED_USER_PASSWORD_RESET",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
+    },
+    state: {
+      blocked: false,
+      suspended: true,
+      reproveIdentity: false,
+      resetPassword: true,
+    },
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
+    },
+    state: {
+      blocked: false,
+      suspended: true,
+      reproveIdentity: true,
+      resetPassword: true,
+    },
+    auditLevel: "standard",
+    history: [],
+  },
+  AIS_NO_INTERVENTION: {
+    intervention: {
+      updatedAt: 1696969322935,
+      appliedAt: 1696869005821,
+      sentAt: 1696869003456,
+      description: "AIS_NO_INTERVENTION",
+      reprovedIdentityAt: 1696969322935,
+      resetPasswordAt: 1696875903456,
+      accountDeletedAt: 1696969359935,
+    },
+    state: {
+      blocked: false,
+      suspended: false,
+      reproveIdentity: false,
+      resetPassword: false,
+    },
+    auditLevel: "standard",
+    history: [],
+  },
+};

--- a/di-ipv-ais-stub/lambdas/src/handlers/handler.ts
+++ b/di-ipv-ais-stub/lambdas/src/handlers/handler.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
 import { buildApiResponse } from "../utils/response";
 import { getAisResponse } from "../utils/dataLayer";
+import cases from "../cases";
 
 export async function handler(
   event: APIGatewayProxyEventV2,
@@ -22,7 +23,10 @@ export async function handler(
 
     // Non-200 responses do not have bodies
     if (response?.statusCode === 200) {
-      return buildApiResponse(response?.responseBody ?? {}, 200);
+      return buildApiResponse(
+        response?.responseBody ?? cases["AIS_NO_INTERVENTION"],
+        200,
+      );
     }
 
     return buildApiResponse({}, response?.statusCode);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Set AIS_NO_INTERVENTION as default response

### Why did it change

- Successful response as default, so don't need to prime happy paths

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8245](https://govukverify.atlassian.net/browse/PYIC-8245)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [X] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [X] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [X] Tests have been written/updated


[PYIC-8245]: https://govukverify.atlassian.net/browse/PYIC-8245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ