### PR TITLE
PYIC-8245: Fix get account interventions default cause

### DIFF
--- a/di-ipv-ais-stub/lambdas/src/handlers/handler.ts
+++ b/di-ipv-ais-stub/lambdas/src/handlers/handler.ts
@@ -18,13 +18,20 @@ export async function handler(
     // Get response from DynamoDB
     const response = await getAisResponse(decodeURIComponent(userId));
 
+    if (!response) {
+      return buildApiResponse(
+          cases["AIS_NO_INTERVENTION"],
+          200,
+      );
+    }
+
     // Artificially delay the response
     await delayResponse(response?.responseDelay);
 
     // Non-200 responses do not have bodies
     if (response?.statusCode === 200) {
       return buildApiResponse(
-        response?.responseBody ?? cases["AIS_NO_INTERVENTION"],
+        response?.responseBody ?? {},
         200,
       );
     }

--- a/di-ipv-ais-stub/lambdas/test/handler.test.ts
+++ b/di-ipv-ais-stub/lambdas/test/handler.test.ts
@@ -4,6 +4,7 @@ import {
 } from "aws-lambda";
 import { PutItemCommandInput } from "@aws-sdk/client-dynamodb";
 import { UserManagementRequest, Response } from "../src/utils/types";
+import cases from "../src/cases";
 
 const TEST_USER_ID = "test-user-id";
 const TEST_USER_PATH_PARAM = {
@@ -257,7 +258,7 @@ describe("Management handler primes AIS endpoint responses", () => {
       // arrange
       const managementRequest = getManagementRequest({
         statusCode: expectedStatusCode,
-        intervention,
+        intervention: intervention as keyof typeof cases,
         responseDelay: 0,
       });
 
@@ -270,6 +271,33 @@ describe("Management handler primes AIS endpoint responses", () => {
       expect(JSON.parse(result.body)).toStrictEqual(expectedResponseBody);
     },
   );
+
+  it("Return no interventions as default", async () => {
+    // act
+    const result = await handler(TEST_AIS_REQUEST_EVENT);
+
+    // assert
+    expect(result.statusCode).toStrictEqual(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      intervention: {
+        updatedAt: 1696969322935,
+        appliedAt: 1696869005821,
+        sentAt: 1696869003456,
+        description: "AIS_NO_INTERVENTION",
+        reprovedIdentityAt: 1696969322935,
+        resetPasswordAt: 1696875903456,
+        accountDeletedAt: 1696969359935,
+      },
+      state: {
+        blocked: false,
+        suspended: false,
+        reproveIdentity: false,
+        resetPassword: false,
+      },
+      auditLevel: "standard",
+      history: []
+    })
+  })
 });
 
 function getManagementRequest(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Fix get account interventions default cause

### Why did it change

- So we don't need to stub happy path cases

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8245](https://govukverify.atlassian.net/browse/PYIC-8245)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8245]: https://govukverify.atlassian.net/browse/PYIC-8245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ