### PR TITLE
LIME-1652 Add ./well-known/jwks route to Core-stub

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/CoreStub.java
@@ -45,6 +45,7 @@ public class CoreStub {
         Spark.post("/edit-user", coreStubHandler.updateUser);
         Spark.get("/callback", coreStubHandler.doCallback);
         Spark.get("/answers", coreStubHandler.answers);
+        Spark.get("/.well-known/jwks.json", coreStubHandler.wellKnownJwksStub);
         setupBackendRoutes(coreStubHandler);
         Spark.exception(Exception.class, exceptionHandler());
     }

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -55,11 +55,40 @@ public class CoreStubHandler {
     private HandlerHelper handlerHelper;
     private Map<String, String> questionsMap = new HashMap<>();
     private ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    private String jwksResponse;
 
     public CoreStubHandler(HandlerHelper handlerHelper) {
         this.handlerHelper = handlerHelper;
 
         setQuestions();
+        constructWellKnownJwksSet();
+    }
+
+    private void constructWellKnownJwksSet() {
+        // Public signing key - not a secret
+        String y = "8F8LnQ7wG9hxsT4ax0Aty7iMGIyiY_YGp3_qIZzKo1A"; // pragma: allowlist-secret
+        String x = "k39uKacSukQBrMZrHDTBUZslivpXKDNZTg6inCHwrLc"; // pragma: allowlist-secret
+        StringBuilder sb =
+                new StringBuilder()
+                        .append("{\n")
+                        .append("  \"keys\": [\n")
+                        .append("    {\n")
+                        .append("      \"kty\": \"EC\",\n")
+                        .append("      \"use\": \"sig\",\n")
+                        .append("      \"crv\": \"P-256\",\n")
+                        .append("      \"x\": ")
+                        .append(x)
+                        .append(",\n")
+                        .append("      \"y\": ")
+                        .append(y)
+                        .append(",\n")
+                        .append(
+                                "      \"kid\": \"0020c60a8796188b88dab4540a918cf7c8d33c9dbe5642b231aad12f2ebffcf6\",\n")
+                        .append("      \"alg\": \"ES256\"\n")
+                        .append("    }\n")
+                        .append("  ]\n")
+                        .append("}");
+        jwksResponse = sb.toString();
     }
 
     private void setQuestions() {
@@ -454,6 +483,15 @@ public class CoreStubHandler {
         }
         return null;
     }
+
+    public Route wellKnownJwksStub =
+            (Request request, Response response) -> {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("Received request for JWKS endpoint: {}", request.url());
+                }
+                response.type("application/json");
+                return jwksResponse;
+            };
 
     public Route backendGenerateInitialClaimsSetPostCode =
             (Request request, Response response) -> {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add a new /.well-known/jwks.json endpoint to host Core stub's public signing key

### What changed

Added handler to respond with JWKSet string on request

### Why did it change

Part of OAuth initiative to prepare Core Stub for future work that allows CRIs to verify requests from core

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1652](https://govukverify.atlassian.net/browse/LIME-1652)






[LIME-1652]: https://govukverify.atlassian.net/browse/LIME-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ