### PR TITLE
BAU: update spotless version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,8 @@ repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
+      - id: remove-tabs
+        exclude: ^([\w\/-]+)?build\.gradle$
       - id: remove-crlf
 
   - repo: https://github.com/mattlqx/pre-commit-search-and-replace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
-      - id: remove-tabs
       - id: remove-crlf
 
   - repo: https://github.com/mattlqx/pre-commit-search-and-replace

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-	id "java"
-	id "com.diffplug.spotless" version "7.0.4"
+    id "java"
+    id "com.diffplug.spotless" version "7.0.4"
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 spotless {
-	java {
-		target "**/src/**/*.java"
-		googleJavaFormat("1.14.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
-	}
+    java {
+        target "**/src/**/*.java"
+        googleJavaFormat("1.14.0").aosp()
+        importOrder "", "javax", "java", "\\#"
+        endWithNewline()
+    }
+    groovyGradle {
+        target '**/*.gradle'
+        greclipse()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
 }
 
 subprojects {
-	task allDeps(type: DependencyReportTask) {}
+    task allDeps(type: DependencyReportTask) {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-	id "java"
-	id "com.diffplug.spotless" version "7.0.3"
+    id "java"
+    id "com.diffplug.spotless" version "7.0.4"
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 spotless {
-	java {
-		target "**/src/**/*.java"
-		googleJavaFormat("1.14.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
-	}
+    java {
+        target "**/src/**/*.java"
+        googleJavaFormat("1.14.0").aosp()
+        importOrder "", "javax", "java", "\\#"
+        endWithNewline()
+    }
+    groovyGradle {
+        target '**/*.gradle'
+        greclipse()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
 }
 
 subprojects {
-	task allDeps(type: DependencyReportTask) {}
+    task allDeps(type: DependencyReportTask) {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-    id "java"
-    id "com.diffplug.spotless" version "7.0.4"
+	id "java"
+	id "com.diffplug.spotless" version "7.0.4"
 }
 
 repositories {
-    mavenCentral()
+	mavenCentral()
 }
 
 spotless {
-    java {
-        target "**/src/**/*.java"
-        googleJavaFormat("1.14.0").aosp()
-        importOrder "", "javax", "java", "\\#"
-        endWithNewline()
-    }
-    groovyGradle {
-        target '**/*.gradle'
-        greclipse()
-        trimTrailingWhitespace()
-        endWithNewline()
-    }
+	java {
+		target "**/src/**/*.java"
+		googleJavaFormat("1.14.0").aosp()
+		importOrder "", "javax", "java", "\\#"
+		endWithNewline()
+	}
+	groovyGradle {
+		target '**/*.gradle'
+		greclipse()
+		trimTrailingWhitespace()
+		endWithNewline()
+	}
 }
 
 subprojects {
-    task allDeps(type: DependencyReportTask) {}
+	task allDeps(type: DependencyReportTask) {}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated spotless to latest version

### Why did it change
The latest version hopefully resolves a [security alert that dependabot](https://github.com/govuk-one-login/ipv-stubs/security/dependabot/76) has raised as our current version of spotless doesn't support the patch for this alert.

