### PR TITLE
PYIC-8146 Use Java21 lambdas and headless yum commands

### DIFF
--- a/di-ipv-cimit-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-cimit-stub/core-dev-deploy/template.yaml
@@ -73,7 +73,7 @@ Resources:
       FunctionName: !Sub "postMitigations-${Environment}"
       CodeUri: "../lambdas/post-mitigations"
       Handler: uk.gov.di.ipv.core.postmitigations.PostMitigationsHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64
@@ -123,7 +123,7 @@ Resources:
       FunctionName: !Sub "putContraIndicators-${Environment}"
       CodeUri: "../lambdas/put-contra-indicators"
       Handler: uk.gov.di.ipv.core.putcontraindicators.PutContraIndicatorsHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64
@@ -172,7 +172,7 @@ Resources:
       FunctionName: !Sub "getContraIndicatorCredential-${Environment}"
       CodeUri: "../lambdas/get-contra-indicator-credential"
       Handler: uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64
@@ -220,7 +220,7 @@ Resources:
       FunctionName: !Sub "stubManagement-${Environment}"
       CodeUri: "../lambdas/stub-management"
       Handler: uk.gov.di.ipv.core.stubmanagement.StubManagementHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -111,7 +111,7 @@ Resources:
       FunctionName: !Sub "postMitigations-${Environment}"
       CodeUri: "../lambdas/post-mitigations"
       Handler: uk.gov.di.ipv.core.postmitigations.PostMitigationsHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64
@@ -161,7 +161,7 @@ Resources:
       FunctionName: !Sub "putContraIndicators-${Environment}"
       CodeUri: "../lambdas/put-contra-indicators"
       Handler: uk.gov.di.ipv.core.putcontraindicators.PutContraIndicatorsHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64
@@ -210,7 +210,7 @@ Resources:
       FunctionName: !Sub "getContraIndicatorCredential-${Environment}"
       CodeUri: "../lambdas/get-contra-indicator-credential"
       Handler: uk.gov.di.ipv.core.getcontraindicatorcredential.GetContraIndicatorCredentialHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64
@@ -258,7 +258,7 @@ Resources:
       FunctionName: !Sub "stubManagement-${Environment}"
       CodeUri: "../lambdas/stub-management"
       Handler: uk.gov.di.ipv.core.stubmanagement.StubManagementHandler::handleRequest
-      Runtime: java17
+      Runtime: java21
       PackageType: Zip
       Architectures:
         - arm64

--- a/di-ipv-credential-issuer-stub/Dockerfile
+++ b/di-ipv-credential-issuer-stub/Dockerfile
@@ -7,7 +7,7 @@ FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344
 
 ENV PORT 8084
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN yum update && yum install -y shadow-utils curl tar
+RUN yum update -y && yum install -y shadow-utils curl tar
 RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
 COPY --from=build \

--- a/di-ipv-credential-issuer-stub/Dockerfile-arm64
+++ b/di-ipv-credential-issuer-stub/Dockerfile-arm64
@@ -9,7 +9,7 @@ FROM --platform="linux/arm64" amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917
 ARG DT_API_TOKEN
 ENV PORT 8084
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN yum update && yum install -y shadow-utils curl tar wget unzip
+RUN yum update -y && yum install -y shadow-utils curl tar wget unzip
 RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
 COPY --from=build \

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/Dockerfile
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/Dockerfile
@@ -7,7 +7,7 @@ FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344
 
 ENV PORT 8084
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN yum update && yum install -y shadow-utils curl tar
+RUN yum update -y && yum install -y shadow-utils curl tar
 RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
 COPY --from=build \

--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -8,7 +8,7 @@ FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344
 
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN yum update && yum install -y shadow-utils curl tar
+RUN yum update -y && yum install -y shadow-utils curl tar
 RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
 COPY --from=build \

--- a/di-ipv-orchestrator-stub/Dockerfile-arm64
+++ b/di-ipv-orchestrator-stub/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM --platform="linux/arm64" amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917
 ARG DT_API_TOKEN
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN yum update && yum install -y shadow-utils curl tar wget unzip
+RUN yum update -y && yum install -y shadow-utils curl tar wget unzip
 RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
 COPY --from=build \

--- a/di-ipv-orchestrator-stub/core-dev-deploy/Dockerfile
+++ b/di-ipv-orchestrator-stub/core-dev-deploy/Dockerfile
@@ -8,7 +8,7 @@ FROM amazoncorretto:21.0.6-al2@sha256:c0643148d077b3917bf6c085aaa1ac35ff1f202344
 
 ENV PORT 8083
 ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
-RUN yum update && yum install -y shadow-utils curl tar
+RUN yum update -y && yum install -y shadow-utils curl tar
 RUN groupadd --system --gid 1001 appgroup && useradd --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
 COPY --from=build \


### PR DESCRIPTION
## Proposed changes

### What changed

- Update CIMIT stub lambdas to use Java21 in their lambdas
- Update Dockerfiles to use the `-y` switch for yum, making it proceed automatically

### Why did it change

- CIMIT stub lambdas had mismatched Java versions
- Dockerfiles couldn't execute when installing updates

### Issue tracking

- [PYIC-8146](https://govukverify.atlassian.net/browse/PYIC-8146)


[PYIC-8146]: https://govukverify.atlassian.net/browse/PYIC-8146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ