### PR TITLE
PYIC-8399: remove default response templates from open api schema

### DIFF
--- a/di-ipv-ais-stub/openAPI/ais-external.yaml
+++ b/di-ipv-ais-stub/openAPI/ais-external.yaml
@@ -104,7 +104,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManageAccountInterventionsFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"message": "Success!!"}'

--- a/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
+++ b/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
@@ -46,7 +46,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetDcmawAsyncAccessTokenFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -74,7 +74,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetDcmawAsyncVcFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          201:
             statusCode: 201
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -105,7 +105,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManagementEnqueueVcFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          201:
             statusCode: 201
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -133,7 +133,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManagementGenerateVcFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -164,7 +164,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManagementCleanupSessionFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          201:
             statusCode: 201
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -195,7 +195,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManagementEnqueueErrorFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          201:
             statusCode: 201
             responseTemplates:
               application/json: '{"result": "success"}'

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -66,7 +66,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsCreateUserVCsFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          202:
             statusCode: 202
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -102,7 +102,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsUpdateUserVCsFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          204:
             statusCode: 204
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -158,7 +158,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsGetUserVCsFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -206,7 +206,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsPutUserVCsFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          202:
             statusCode: 202
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -264,7 +264,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsGetUserVCsFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -301,7 +301,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsManagementGetStoredIdentityFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'

--- a/di-ipv-ticf-stub/openAPI/ticf-external.yaml
+++ b/di-ipv-ticf-stub/openAPI/ticf-external.yaml
@@ -50,7 +50,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetTicfVCFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
@@ -104,7 +104,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ManageUserEvidenceFunction.Arn}:live/invocations
         passthroughBehavior: "WHEN_NO_TEMPLATES"
         responses:
-          default:
+          200:
             statusCode: 200
             responseTemplates:
               application/json: '{"message": "Success!!"}'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removing the default response from the openAPI spec for the stubs

### Why did it change
The default responses were obscuring other status codes (see this [PR](https://github.com/govuk-one-login/ipv-stubs/pull/1497)) so to be safe, we remove them from the spec as no mapping is required for the responses anyway

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8399](https://govukverify.atlassian.net/browse/PYIC-8399)

[PYIC-8399]: https://govukverify.atlassian.net/browse/PYIC-8399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ