### PR TITLE
PYIC-8363: Update intervention TICF documentation and classes

### DIFF
--- a/di-ipv-ticf-stub/README.md
+++ b/di-ipv-ticf-stub/README.md
@@ -95,6 +95,9 @@ The format of the POST request to the API gateway should look like
         "V03",
         "D03"
     ],
+    "intervention: {
+        "interventionCode": "00"
+    },
     "txn": "uuid"
 }
 ```

--- a/di-ipv-ticf-stub/lambdas/src/domain/ticfEvidenceItem.ts
+++ b/di-ipv-ticf-stub/lambdas/src/domain/ticfEvidenceItem.ts
@@ -1,5 +1,9 @@
 export default interface TicfEvidenceItem {
   type: string;
+  intervention?: {
+    interventionCode: string;
+    interventionReason?: string;
+  };
   ci?: string[];
   txn?: string;
 }

--- a/di-ipv-ticf-stub/lambdas/src/handlers/ticfHandler.ts
+++ b/di-ipv-ticf-stub/lambdas/src/handlers/ticfHandler.ts
@@ -12,9 +12,13 @@ export async function handler(
     const { response, statusCode } = await processGetVCRequest(ticfRequest);
 
     return buildApiResponse(response, statusCode);
-  } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     console.error(error);
-    return buildApiResponse({ errorMessage: error.message }, error.statusCode || 500);
+    return buildApiResponse(
+      { errorMessage: error.message },
+      error.statusCode || 500,
+    );
   }
 }
 

--- a/di-ipv-ticf-stub/lambdas/src/management/handlers/managementHandler.ts
+++ b/di-ipv-ticf-stub/lambdas/src/management/handlers/managementHandler.ts
@@ -24,7 +24,8 @@ export async function handler(
     );
 
     return buildApiResponse({ message: "Success!!" });
-  } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     console.error(error);
     return buildApiResponse(
       { errorMessage: error.message },

--- a/di-ipv-ticf-stub/lambdas/src/services/ticfService.ts
+++ b/di-ipv-ticf-stub/lambdas/src/services/ticfService.ts
@@ -41,9 +41,7 @@ export async function processGetVCRequest(
     nbf: timestamp,
     iat: timestamp,
     vc: {
-      evidence: [
-        ticfEvidenceItem || getDefaultEvidenceItem(),
-      ],
+      evidence: [ticfEvidenceItem || getDefaultEvidenceItem()],
       type: ["VerifiableCredential", "RiskAssessmentCredential"],
     },
   };
@@ -78,11 +76,15 @@ async function getUserEvidenceFromDb(
   return userEvidenceItem ?? undefined;
 }
 
-async function getResponseDelay(userEvidenceItem: UserEvidenceItem | undefined): Promise<number> {
+async function getResponseDelay(
+  userEvidenceItem: UserEvidenceItem | undefined,
+): Promise<number> {
   if (userEvidenceItem?.responseDelay) {
     return userEvidenceItem.responseDelay * 1000;
   }
-  const param = await getSsmParameter(config.ticfParamBasePath + "defaultResponseDelay");
+  const param = await getSsmParameter(
+    config.ticfParamBasePath + "defaultResponseDelay",
+  );
   return parseInt(param);
 }
 

--- a/di-ipv-ticf-stub/lambdas/test/managementHandler.test.ts
+++ b/di-ipv-ticf-stub/lambdas/test/managementHandler.test.ts
@@ -15,6 +15,10 @@ const TEST_REQUEST = {
     type: "RiskAssessment",
     ci: ["V03", "D03"],
     txn: "uuid",
+    intervention: {
+      interventionCode: "01",
+      interventionReason: "007",
+    },
   },
 };
 

--- a/di-ipv-ticf-stub/lambdas/test/ticfHandler.test.ts
+++ b/di-ipv-ticf-stub/lambdas/test/ticfHandler.test.ts
@@ -112,6 +112,10 @@ describe("TICF handler", function () {
         type: "RiskAssessment",
         ci: ["V03", "D03"],
         txn: "uuid",
+        intervention: {
+          interventionCode: "01",
+          interventionReason: "007",
+        },
       },
       statusCode: 200,
       ttl: 3123123,
@@ -134,6 +138,10 @@ describe("TICF handler", function () {
     expect(ticfVc.vc.evidence[0].type).toEqual("RiskAssessment");
     expect(ticfVc.vc.evidence[0].txn).toEqual("uuid");
     expect(ticfVc.vc.evidence[0].ci).toEqual(["V03", "D03"]);
+    expect(ticfVc.vc.evidence[0].intervention).toEqual({
+      interventionCode: "01",
+      interventionReason: "007",
+    });
   });
 
   it("returns a 400 for an empty request", async () => {

--- a/di-ipv-ticf-stub/openAPI/ticf-external.yaml
+++ b/di-ipv-ticf-stub/openAPI/ticf-external.yaml
@@ -152,6 +152,12 @@ components:
               items:
                 type: string
               description: The array of ci codes data
+            intervention:
+              type: object
+              properties:
+                interventionCode:
+                  type: string
+                  description: The code for the intervention
             txn:
               type: string
               description: The txn code (riskEngineAssessmentId) data
@@ -161,4 +167,3 @@ components:
         statusCode:
           type: number
           description: The expected statusCode from TICF when a request is made for this user
-


### PR DESCRIPTION
## Proposed changes

### What changed

- Update intervention TICF documentation and classes

### Why did it change

- So we clearly define the new interface

### Issue tracking

- [PYIC-8363](https://govukverify.atlassian.net/browse/PYIC-8363)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8363]: https://govukverify.atlassian.net/browse/PYIC-8363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ