### PR TITLE
OJ-3245: Fix to include evidence_requested for none raw text input

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -346,7 +346,7 @@ public class CoreStubHandler {
         try {
             evidenceRequestClaims =
                     (evidenceRequestClaimsText == null || evidenceRequestClaimsText.isEmpty())
-                            ? null
+                            ? sessionEvidenceRequest
                             : objectMapper.readValue(
                                     evidenceRequestClaimsText, EvidenceRequestClaims.class);
             LOGGER.info(
@@ -684,6 +684,11 @@ public class CoreStubHandler {
                         verificationScore == null ? null : Integer.parseInt(verificationScore),
                         identityFraudScore == null ? null : Integer.parseInt(identityFraudScore));
         LOGGER.info("✅  Saving evidence request to session to {}", evidenceRequest);
-        request.session().attribute("evidence_request", evidenceRequest);
+        if (evidenceRequest.getScoringPolicy() != null
+                || evidenceRequest.getStrengthScore() != null
+                || evidenceRequest.getVerificationScore() != null
+                || evidenceRequest.getIdentityFraudScore() != null) {
+            request.session().attribute("evidence_request", evidenceRequest);
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Uses the sessionEvidenceRequest if raw input is null. 
Only add evidence_requested to session if a value is not null.

### Why did it change

To fix recent changes from https://github.com/govuk-one-login/ipv-stubs/pull/1510 

evidence_requested was no longer being included unless sent in the raw input field. This breaks the existing routes for `HMRC Check -Evidence Requested` and `KBV - Evidence Requested`.

### Issue tracking
- [OJ-3245](https://govukverify.atlassian.net/browse/OJ-3245)


[OJ-3245]: https://govukverify.atlassian.net/browse/OJ-3245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ