### PR TITLE
PYIC-8427: add new evcs identity endpoint

### DIFF
--- a/di-ipv-evcs-stub/README.md
+++ b/di-ipv-evcs-stub/README.md
@@ -188,7 +188,39 @@ Responses
           $ref: '#/components/responses/ServerError'
 ```
 
-5) The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
+5) The format of the `/identity` POST endpoint
+Example request body
+```
+{
+ "userId": "userId",
+ "si": {
+    "jwt": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46dXVpZDo5NjI4OTgxNS0wZTUyLTQ4MDAtOTZkZi0xZmY3ZGU5ODFjZDQiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3NDYwODkxNTEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYnVpbGQuYWNjb3VudC5nb3YudWsiLCJhdWQiOiJodHRwczovL29yY2guc3R1YnMuYWNjb3VudC5nb3YudWsiLCJuYmYiOiIxNzc3NjI1MTUxIiwidm90IjoiUDIiLCJjcmVkZW50aWFscyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5pSjkuZXlKemRXSWlPaUoxY200NmRYVnBaRG81TmpJNE9UZ3hOUzB3WlRVeUxUUTRNREF0T1Raa1ppMHhabVkzWkdVNU9ERmpaRFFpTENKaGRXUWlPaUpvZEhSd2N6b3ZMMmxrWlc1MGFYUjVMbUoxYVd4a0xtRmpZMjkxYm5RdVoyOTJMblZySWl3aWJtSm1Jam94TnpRMk1Ea3lOVGszTENKcGMzTWlPaUpvZEhSd2N6b3ZMMkZrWkhKbGMzTXRZM0pwTG5OMGRXSnpMbUZqWTI5MWJuUXVaMjkyTG5Wcklpd2lkbU1pT25zaWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSXNJa0ZrWkhKbGMzTkRjbVZrWlc1MGFXRnNJbDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltRmtaSEpsYzNNaU9sdDdJbUZrWkhKbGMzTkRiM1Z1ZEhKNUlqb2lSMElpTENKaWRXbHNaR2x1WjA1aGJXVWlPaUlpTENKemRISmxaWFJPWVcxbElqb2lTRUZFVEVWWklGSlBRVVFpTENKd2IzTjBZV3hEYjJSbElqb2lRa0V5SURWQlFTSXNJbUoxYVd4a2FXNW5UblZ0WW1WeUlqb2lPQ0lzSW1Ga1pISmxjM05NYjJOaGJHbDBlU0k2SWtKQlZFZ2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1EQXdMVEF4TFRBeEluMWRmWDBzSW1wMGFTSTZJblZ5YmpwMWRXbGtPbU13TlRWbFlXVmpMVEF5WmpVdE5EUTFOQzA1TnpreUxUWXlZemxqTldRM1l6QXdOeUo5LnhkSHlaVUV3d2k2VENpTTM4VXlOZEgtYkhkQjE0QnhtNm0xVWNuWE5SR1Z4cXFHR0R1cWgwODdsTDNtT0ZNd1BFVWxkTEU2TmVKOUI4dFZkSHJrUnlBIl0sImNsYWltcyI6W3siZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJpY2FvSXNzdWVyQ29kZSI6IkdCUiIsImRvY3VtZW50TnVtYmVyIjoiMzIxNjU0OTg3In0seyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NS0wNy0wOCJ9XX1dfQ.DjY3mL3f1U1ehHILXz0ifAosUBCLH3HdAnqYX9YH4t7JdQjSECU885RJKUKZqE33vMvG0n-Ip1tULP7hkQ0R_A", # pragma: allowlist secret
+    "vot": "P2"
+ }
+}
+```
+Responses
+```
+        202:
+          description: VCs Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messageId:
+                    type: string
+                    description: The SQS message ID.
+                    example: "bd8359d9-d559-47dd-9467-2a31e88a9e2d"
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        500:
+          $ref: '#/components/responses/ServerError'
+```
+
+6) The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
 Example response:
 ```
 [

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -293,7 +293,7 @@ Resources:
             TableName: !Ref EvcsStoredIdentityStoreTable
       AutoPublishAlias: live
       Events:
-        PutUserVCs:
+        PostIdentity:
           Type: Api
           Properties:
             RestApiId: !Ref RestApiGateway

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -243,6 +243,72 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
+  # lambda to stub EVCS - evcsPostIdentity
+  EvcsPostIdentityFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "EvcsPostIdentityFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "evcsPostIdentity-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: evcsHandler.postIdentityHandler
+      Runtime: nodejs22.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
+          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          NODE_OPTIONS: --enable-source-maps
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt EvcsLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/evcs/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStubUserVcsStoreTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStoredIdentityStoreTable
+      AutoPublishAlias: live
+      Events:
+        PutUserVCs:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /identity
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/evcsHandler.ts
+
   # lambda to stub EVCS - evcsGetUserVCs
   EvcsGetUserVCsFunction:
     Type: AWS::Serverless::Function
@@ -398,6 +464,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/putEvcsUserVCs-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+  EvcsPostIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/evcsPostIdentity-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
   EvcsGetUserVCsFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -283,6 +283,72 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
+  # lambda to stub EVCS - evcsPostIdentity
+  EvcsPostIdentityFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "EvcsPostIdentityFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "evcsPostIdentity-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: evcsHandler.postIdentityHandler
+      Runtime: nodejs22.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
+          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          NODE_OPTIONS: --enable-source-maps
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt EvcsLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/evcs/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStubUserVcsStoreTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStoredIdentityStoreTable
+      AutoPublishAlias: live
+      Events:
+        PutUserVCs:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /identity
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/evcsHandler.ts
+
   # lambda to stub EVCS - evcsGetUserVCs
   EvcsGetUserVCsFunction:
     Type: AWS::Serverless::Function
@@ -440,6 +506,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/putEvcsUserVCs-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+  EvcsPostIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/evcsPostIdentity-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
   EvcsGetUserVCsFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -333,7 +333,7 @@ Resources:
             TableName: !Ref EvcsStoredIdentityStoreTable
       AutoPublishAlias: live
       Events:
-        PutUserVCs:
+        PostIdentity:
           Type: Api
           Properties:
             RestApiId: !Ref RestApiGateway

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/index.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/index.ts
@@ -1,3 +1,3 @@
 export * from "./postRequest";
 export * from "./patchRequest";
-export * from "./putRequest";
+export * from "./postIdentityRequest";

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/postIdentityRequest.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/postIdentityRequest.ts
@@ -7,6 +7,10 @@ interface StoredIdentityDetails {
   metadata?: object;
 }
 
+export type PostIdentityRequest = Omit<PutRequest, "vcs" | "si"> & {
+  si: StoredIdentityDetails;
+};
+
 export interface PutRequest {
   userId: string;
   vcs: VcDetails[];

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -211,6 +211,46 @@ paths:
             responseTemplates:
               application/json: '{"result": "success"}'
 
+  /identity:
+    post:
+      description: "Saves the stored identity record for a given user into EVCS"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PersistStoredIdentity"
+      responses:
+        202:
+          description: Stored identity record accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messageId:
+                    type: string
+                    description: The SQS message ID.
+                    example: "bd8359d9-d559-47dd-9467-2a31e88a9e2d"
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        500:
+          $ref: '#/components/responses/ServerError'
+      x-amazon-apigateway-request-validator: ALL
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsPostIdentityFunction.Arn}:live/invocations
+        passthroughBehavior: "WHEN_NO_TEMPLATES"
+        responses:
+          202:
+            statusCode: 202
+            responseTemplates:
+              application/json: '{"result": "success"}'
+
   /migration/{userId}:
     get:
       description: "Returns a list of user verifiable credentials"
@@ -384,6 +424,17 @@ components:
       required:
         - userId
         - vcs
+    PersistStoredIdentity:
+      description: The request body for the /identity POST endpoint to store a user's stored identity record
+      type: object
+      properties:
+        userId:
+          type: string
+        si:
+          $ref: "#/components/schemas/StoredIdentityDetails"
+      required:
+        - userId
+        - si
     StoredIdentityDetails:
       type: object
       properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- added new EVCS POST `/identity` endpoint as part of phase 1
-  re-use existing logic as the endpoint will be more like the existing PUT `/vcs` endpoint in phase two

### Why did it change
Trust & Reuse team have re-estimated the size of their work to instead now implement a POST `/identity` endpoint. As part of phase 1, we only need to use this endpoint to store the SI record. In phase 2, the endpoint will be updated to store the VCs as well.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8427](https://govukverify.atlassian.net/browse/PYIC-8427)


## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8427]: https://govukverify.atlassian.net/browse/PYIC-8427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ