### PR TITLE
PYIC-8427: remove old put endpoint

### DIFF
--- a/di-ipv-evcs-stub/README.md
+++ b/di-ipv-evcs-stub/README.md
@@ -143,52 +143,7 @@ Responses
 There is an API gateway deployed in the stubs build account here:
 https://evcs.build.stubs.account.gov.uk/vc-update
 
-4) The format of the PUT (/vcs) request
-Example request
-```
-{
- "userId": "userId",
- "vcs": [
-    {
-        "vc": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", # pragma: allowlist secret
-        "state": "CURRENT",
-        "metadata": {
-            reason: "test-created",
-            timestampMs: "1714478033959",
-            txmaEventId: "txma-event-id",
-            testProperty: "testProperty"
-        },
-        "provenance": "ONLINE"
-    }
- ],
- "si": {
-    "jwt": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46dXVpZDo5NjI4OTgxNS0wZTUyLTQ4MDAtOTZkZi0xZmY3ZGU5ODFjZDQiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3NDYwODkxNTEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYnVpbGQuYWNjb3VudC5nb3YudWsiLCJhdWQiOiJodHRwczovL29yY2guc3R1YnMuYWNjb3VudC5nb3YudWsiLCJuYmYiOiIxNzc3NjI1MTUxIiwidm90IjoiUDIiLCJjcmVkZW50aWFscyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5pSjkuZXlKemRXSWlPaUoxY200NmRYVnBaRG81TmpJNE9UZ3hOUzB3WlRVeUxUUTRNREF0T1Raa1ppMHhabVkzWkdVNU9ERmpaRFFpTENKaGRXUWlPaUpvZEhSd2N6b3ZMMmxrWlc1MGFYUjVMbUoxYVd4a0xtRmpZMjkxYm5RdVoyOTJMblZySWl3aWJtSm1Jam94TnpRMk1Ea3lOVGszTENKcGMzTWlPaUpvZEhSd2N6b3ZMMkZrWkhKbGMzTXRZM0pwTG5OMGRXSnpMbUZqWTI5MWJuUXVaMjkyTG5Wcklpd2lkbU1pT25zaWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSXNJa0ZrWkhKbGMzTkRjbVZrWlc1MGFXRnNJbDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltRmtaSEpsYzNNaU9sdDdJbUZrWkhKbGMzTkRiM1Z1ZEhKNUlqb2lSMElpTENKaWRXbHNaR2x1WjA1aGJXVWlPaUlpTENKemRISmxaWFJPWVcxbElqb2lTRUZFVEVWWklGSlBRVVFpTENKd2IzTjBZV3hEYjJSbElqb2lRa0V5SURWQlFTSXNJbUoxYVd4a2FXNW5UblZ0WW1WeUlqb2lPQ0lzSW1Ga1pISmxjM05NYjJOaGJHbDBlU0k2SWtKQlZFZ2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1EQXdMVEF4TFRBeEluMWRmWDBzSW1wMGFTSTZJblZ5YmpwMWRXbGtPbU13TlRWbFlXVmpMVEF5WmpVdE5EUTFOQzA1TnpreUxUWXlZemxqTldRM1l6QXdOeUo5LnhkSHlaVUV3d2k2VENpTTM4VXlOZEgtYkhkQjE0QnhtNm0xVWNuWE5SR1Z4cXFHR0R1cWgwODdsTDNtT0ZNd1BFVWxkTEU2TmVKOUI4dFZkSHJrUnlBIl0sImNsYWltcyI6W3siZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJpY2FvSXNzdWVyQ29kZSI6IkdCUiIsImRvY3VtZW50TnVtYmVyIjoiMzIxNjU0OTg3In0seyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NS0wNy0wOCJ9XX1dfQ.DjY3mL3f1U1ehHILXz0ifAosUBCLH3HdAnqYX9YH4t7JdQjSECU885RJKUKZqE33vMvG0n-Ip1tULP7hkQ0R_A", # pragma: allowlist secret
-    "vot": "P2"
- }
-}
-```
-Responses
-```
-        202:
-          description: VCs Accepted
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  messageId:
-                    type: string
-                    description: The SQS message ID.
-                    example: "bd8359d9-d559-47dd-9467-2a31e88a9e2d"
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/Forbidden'
-        500:
-          $ref: '#/components/responses/ServerError'
-```
-
-5) The format of the `/identity` POST endpoint
+4) The format of the `/identity` POST endpoint
 Example request body
 ```
 {
@@ -220,7 +175,7 @@ Responses
           $ref: '#/components/responses/ServerError'
 ```
 
-6) The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
+5) The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
 Example response:
 ```
 [

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -177,72 +177,6 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
-  # lambda to stub EVCS - evcsPutUserVCs
-  EvcsPutUserVCsFunction:
-    Type: AWS::Serverless::Function
-    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
-    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
-    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
-    # checkov:skip=CKV_AWS_173: doing it later
-    DependsOn:
-      - "EvcsPutUserVCsFunctionLogGroup"
-    Properties:
-      FunctionName: !Sub "evcsPutUserVCs-${Environment}"
-      CodeUri: "../lambdas"
-      Handler: evcsHandler.putHandler
-      Runtime: nodejs22.x
-      PackageType: Zip
-      Architectures:
-        - arm64
-      MemorySize: 2048
-      Tracing: Active
-      CodeSigningConfigArn: !If
-        - UseCodeSigning
-        - !Ref CodeSigningConfigArn
-        - !Ref AWS::NoValue
-      Environment:
-        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
-        Variables:
-          ENVIRONMENT: !Sub "${Environment}"
-          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
-          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
-          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
-          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
-          NODE_OPTIONS: --enable-source-maps
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
-        SecurityGroupIds:
-          - !GetAtt EvcsLambdaSecurityGroup.GroupId
-      Policies:
-        - VPCAccessPolicy: { }
-        - SSMParameterReadPolicy:
-            ParameterName: stubs/core/evcs/*
-        - KMSDecryptPolicy:
-            KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBCrudPolicy:
-            TableName: !Ref EvcsStubUserVcsStoreTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref EvcsStoredIdentityStoreTable
-      AutoPublishAlias: live
-      Events:
-        CreateUserVCs:
-          Type: Api
-          Properties:
-            RestApiId: !Ref RestApiGateway
-            Path: /vcs
-            Method: PUT
-    Metadata:
-      # Manage esbuild properties
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Target: "es2022"
-        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
-        EntryPoints:
-          - src/handlers/evcsHandler.ts
-
   # lambda to stub EVCS - evcsPostIdentity
   EvcsPostIdentityFunction:
     Type: AWS::Serverless::Function
@@ -457,13 +391,6 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/updateEvcsUserVCs-${Environment}"
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
-  EvcsPutUserVCsFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
-    Properties:
-      RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/putEvcsUserVCs-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
   EvcsPostIdentityFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -217,72 +217,6 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
-  # lambda to stub EVCS - evcsPutUserVCs
-  EvcsPutUserVCsFunction:
-    Type: AWS::Serverless::Function
-    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
-    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
-    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
-    # checkov:skip=CKV_AWS_173: doing it later
-    DependsOn:
-      - "EvcsPutUserVCsFunctionLogGroup"
-    Properties:
-      FunctionName: !Sub "evcsPutUserVCs-${Environment}"
-      CodeUri: "../lambdas"
-      Handler: evcsHandler.putHandler
-      Runtime: nodejs22.x
-      PackageType: Zip
-      Architectures:
-        - arm64
-      MemorySize: 2048
-      Tracing: Active
-      CodeSigningConfigArn: !If
-        - UseCodeSigning
-        - !Ref CodeSigningConfigArn
-        - !Ref AWS::NoValue
-      Environment:
-        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
-        Variables:
-          ENVIRONMENT: !Sub "${Environment}"
-          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
-          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
-          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
-          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
-          NODE_OPTIONS: --enable-source-maps
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
-        SecurityGroupIds:
-          - !GetAtt EvcsLambdaSecurityGroup.GroupId
-      Policies:
-        - VPCAccessPolicy: { }
-        - SSMParameterReadPolicy:
-            ParameterName: stubs/core/evcs/*
-        - KMSDecryptPolicy:
-            KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBCrudPolicy:
-            TableName: !Ref EvcsStubUserVcsStoreTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref EvcsStoredIdentityStoreTable
-      AutoPublishAlias: live
-      Events:
-        PutUserVCs:
-          Type: Api
-          Properties:
-            RestApiId: !Ref RestApiGateway
-            Path: /vcs
-            Method: PUT
-    Metadata:
-      # Manage esbuild properties
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Target: "es2022"
-        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
-        EntryPoints:
-          - src/handlers/evcsHandler.ts
-
   # lambda to stub EVCS - evcsPostIdentity
   EvcsPostIdentityFunction:
     Type: AWS::Serverless::Function
@@ -499,13 +433,6 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/updateEvcsUserVCs-${Environment}"
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
-  EvcsPutUserVCsFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
-    Properties:
-      RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/putEvcsUserVCs-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
   EvcsPostIdentityFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -327,7 +327,9 @@ describe("evcs handlers", () => {
         }),
         case: "si.jwt is missing",
       },
-      // These tests should be uncommented in phase 2 when the /identity object accepts a vcs list
+      // TODO PYIC-8458: These tests should be uncommented in phase 2 when the
+      //  /identity endpoint accepts a vcs list as the request parsing should
+      // handle these criteria
       // {
       //   request: buildPutRequest({ vcs: undefined }),
       //   case: "vcs is missing",

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -8,7 +8,6 @@ import {
   createHandler,
   getHandler,
   postIdentityHandler,
-  putHandler,
   updateHandler,
 } from "../src/handlers/evcsHandler";
 import {
@@ -20,7 +19,7 @@ import {
 import { VcState, VCProvenance } from "../src/domain/enums";
 import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/api-gateway-proxy";
-import { PostIdentityRequest, PutRequest } from "../src/domain/requests";
+import { PostIdentityRequest } from "../src/domain/requests";
 import { Vot } from "../src/domain/enums/vot";
 
 jest.mock("../src/services/evcsService", () => ({
@@ -123,27 +122,6 @@ const buildPostIdentityRequest = (
   };
 };
 
-const buildPutRequest = (putRequest?: RecursivePartial<PutRequest>) => {
-  return {
-    userId: TEST_USER_ID,
-    vcs: [
-      {
-        vc: TEST_VC_STRING,
-        state: VcState.CURRENT,
-        metadata: TEST_METADATA,
-        provenance: VCProvenance.ONLINE,
-      },
-      ...(putRequest?.vcs ? putRequest.vcs : []),
-    ],
-    si: {
-      jwt: TEST_VC_STRING,
-      vot: Vot.P2,
-      metadata: TEST_METADATA,
-    },
-    ...(putRequest ? putRequest : {}),
-  };
-};
-
 const TEST_PATH_PARAM = {
   userId: TEST_USER_ID,
 } as APIGatewayProxyEventPathParameters;
@@ -166,11 +144,6 @@ const TEST_GET_EVENT = {
   pathParameters: TEST_PATH_PARAM,
   headers: TEST_HEADERS,
 } as APIGatewayProxyEvent;
-
-const createPutEvent = (requestBody: RecursivePartial<PutRequest>) =>
-  ({
-    body: JSON.stringify(requestBody),
-  }) as APIGatewayProxyEvent;
 
 const createPostIdentityEvent = (
   requestBody: RecursivePartial<PostIdentityRequest>,
@@ -296,114 +269,6 @@ describe("evcs handlers", () => {
     });
   });
 
-  describe("put handler", () => {
-    it("should return a 202 for a valid request", async () => {
-      // arrange
-      jest.mocked(processPostIdentityRequest).mockResolvedValue({
-        statusCode: 202,
-        response: {},
-      });
-      const testRequest = buildPutRequest();
-
-      // act
-      const response = (await putHandler(
-        createPutEvent(testRequest),
-      )) as APIGatewayProxyStructuredResultV2;
-
-      // assert
-      expect(response.statusCode).toBe(202);
-      expect(processPostIdentityRequest).toHaveBeenCalledWith(testRequest);
-    });
-
-    it("should return a 202 for a request with no si", async () => {
-      // arrange
-      jest.mocked(processPostIdentityRequest).mockResolvedValue({
-        statusCode: 202,
-        response: {},
-      });
-      const testRequest = buildPutRequest({ si: undefined });
-
-      // act
-      const response = (await putHandler(
-        createPutEvent(testRequest),
-      )) as APIGatewayProxyStructuredResultV2;
-
-      // assert
-      expect(response.statusCode).toBe(202);
-      expect(processPostIdentityRequest).toHaveBeenCalledWith(testRequest);
-    });
-
-    it("should return a 500 if saving to EVCS fails", async () => {
-      // arrange
-      jest.mocked(processPostIdentityRequest).mockResolvedValue({
-        statusCode: 500,
-        response: {},
-      });
-      const testRequest = buildPutRequest();
-
-      // act
-      const response = (await putHandler(
-        createPutEvent(testRequest),
-      )) as APIGatewayProxyStructuredResultV2;
-
-      // assert
-      expect(response.statusCode).toBe(500);
-      expect(processPostIdentityRequest).toHaveBeenCalledWith(testRequest);
-    });
-
-    it.each([
-      {
-        request: buildPutRequest({ userId: undefined }),
-        case: "userId is missing",
-      },
-      {
-        request: buildPutRequest({ vcs: undefined }),
-        case: "vcs is missing",
-      },
-      {
-        request: buildPutRequest({ vcs: [] }),
-        case: "vcs is empty",
-      },
-      {
-        request: buildPutRequest({
-          si: { vot: undefined, jwt: TEST_VC_STRING },
-        }),
-        case: "si.vot is missing",
-      },
-      {
-        request: buildPutRequest({
-          vcs: [
-            { vc: "some.vc.sig", state: VcState.CURRENT },
-            { vc: "some.vc.sig", state: VcState.HISTORIC },
-          ],
-        }),
-        case: "duplicate vcs with different states",
-      },
-      {
-        request: buildPutRequest({
-          vcs: [
-            { vc: "some.vc.sig", state: VcState.CURRENT },
-            { vc: "some.vc.sig", state: VcState.CURRENT },
-          ],
-        }),
-        case: "duplicate vcs with the same states",
-      },
-      {
-        request: buildPutRequest({ si: { jwt: undefined, vot: Vot.P2 } }),
-        case: "si.jwt is missing",
-      },
-    ])("should return a 400 if $case", async ({ request }) => {
-      // act
-      const response = (await putHandler(
-        createPutEvent(request),
-      )) as APIGatewayProxyStructuredResultV2;
-
-      // assert
-      expect(response.statusCode).toBe(400);
-      expect(processPostIdentityRequest).not.toHaveBeenCalled();
-    });
-  });
-
   describe("post identity handler", () => {
     it("should return 202 for a valid request", async () => {
       // arrange
@@ -462,6 +327,24 @@ describe("evcs handlers", () => {
         }),
         case: "si.jwt is missing",
       },
+      // These tests should be uncommented in phase 2 when the /identity object accepts a vcs list
+      // {
+      //   request: buildPutRequest({ vcs: undefined }),
+      //   case: "vcs is missing",
+      // },
+      // {
+      //   request: buildPutRequest({ vcs: [] }),
+      //   case: "vcs is empty",
+      // },
+      // {
+      //   request: buildPutRequest({
+      //     vcs: [
+      //       { vc: "some.vc.sig", state: VcState.CURRENT },
+      //       { vc: "some.vc.sig", state: VcState.HISTORIC },
+      //     ],
+      //   }),
+      //   case: "duplicate vcs with different states",
+      // },
     ])("should return a 400 if $case", async ({ request }) => {
       // act
       const response = (await postIdentityHandler(

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -372,7 +372,7 @@ components:
           $ref: "#/components/schemas/StoredIdentityDetails"
       required:
         - userId
-        - si
+        - si # TODO PYIC-8458: mark this as non-required when updating this endpoint with vcs list
     StoredIdentityDetails:
       type: object
       properties:

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -362,20 +362,6 @@ components:
         required:
           - signature
           - state
-    PersistVCsWithStoredIdentity:
-      description: The request body passed to the /vcs PUT endpoint which allows VCS to be saved with or without a corresponding Stored Identity object.
-      type: object
-      properties:
-        userId:
-          type: string
-          description: The user ID associated with the VCs
-        vcs:
-          $ref: "#/components/schemas/PersistVCsArray"
-        si:
-          $ref: "#/components/schemas/StoredIdentityDetails"
-      required:
-        - userId
-        - vcs
     PersistStoredIdentity:
       description: The request body for the /identity POST endpoint to store a user's stored identity record
       type: object

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -163,54 +163,6 @@ paths:
             responseTemplates:
               application/json: '{"result": "success"}'
 
-  /vcs:
-    put:
-      summary: Creates & Updates (Replaces) a batch of unique VCs and optionally a Stored Identity (SI) Object into EVCS.
-      description: |-
-        Save a batch of VCs and optionally a Stored Identity Object into EVCS.
-        A Stored Identity Object is the signed JWT that IPV Core creates and updates that is stored in the `content` field of an EVCS row.
-
-
-        **Note:**
-        - All VC updates are updated in *a single transactional operation*, hence:
-        - If any VCs are duplicated but with different `state` values → reject all with HTTP400.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PersistVCsWithStoredIdentity"
-      responses:
-        202:
-          description: VCs Accepted
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  messageId:
-                    type: string
-                    description: The SQS message ID.
-                    example: "bd8359d9-d559-47dd-9467-2a31e88a9e2d"
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/Forbidden'
-        500:
-          $ref: '#/components/responses/ServerError'
-      x-amazon-apigateway-request-validator: ALL
-      x-amazon-apigateway-integration:
-        type: "aws_proxy"
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsPutUserVCsFunction.Arn}:live/invocations
-        passthroughBehavior: "WHEN_NO_TEMPLATES"
-        responses:
-          202:
-            statusCode: 202
-            responseTemplates:
-              application/json: '{"result": "success"}'
-
   /identity:
     post:
       description: "Saves the stored identity record for a given user into EVCS"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- removes PUT `/vcs` endpoint
- removes specific logic + tests related to PUT endpoint

**Note:** This [ipv-stubs PR](https://github.com/govuk-one-login/ipv-stubs/pull/1534) and [core-back PR](https://github.com/govuk-one-login/ipv-core-back/pull/3247) needs to be merged in first before merging this one

### Why did it change
Trust & Reuse have decided to use an POST `/identity` endpoint instead of a PUT `/vcs` endpoint so removing related code

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8427](https://govukverify.atlassian.net/browse/PYIC-8427)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8427]: https://govukverify.atlassian.net/browse/PYIC-8427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ