### PR TITLE
LIME-1736 Remove basic auth from jwks endpoint

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/BasicAuthHandler.java
@@ -12,6 +12,7 @@ public class BasicAuthHandler {
     private static final int NUMBER_OF_AUTHENTICATION_FIELDS = 2;
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String AUTHORIZATION_TYPE = "Basic";
+    private static final String JWKS_PATH = "/.well-known/jwks.json";
 
     public BasicAuthHandler() {
         CoreStubConfig.getUserAuth();
@@ -19,6 +20,11 @@ public class BasicAuthHandler {
 
     public Filter authFilter =
             (Request request, Response response) -> {
+                if (request.pathInfo().equals(JWKS_PATH)) {
+                    // basic auth not required on the jwks endpoint
+                    return;
+                }
+
                 if (!request.headers().contains(AUTHORIZATION_HEADER) || !authenticated(request)) {
                     response.header("WWW-Authenticate", AUTHORIZATION_TYPE);
                     Spark.halt(401, "Not Authenticated");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

### What changed

Removed basic auth from jwks endpoint

### Why did it change

To access the Core stub’s public JWKS endpoint, basic HTTP auth for the /.well-known/jwks.json route must first be disabled.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1736](https://govukverify.atlassian.net/browse/LIME-1736)
- [LIME-1660](https://govukverify.atlassian.net/browse/LIME-1660)


[LIME-1736]: https://govukverify.atlassian.net/browse/LIME-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1660]: https://govukverify.atlassian.net/browse/LIME-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ