### PR TITLE
LIME-1660 Updated kid and cache-control header for wellknownjwks

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/handlers/CoreStubHandler.java
@@ -83,7 +83,7 @@ public class CoreStubHandler {
                         .append(y)
                         .append("\",\n")
                         .append(
-                                "      \"kid\": \"0020c60a8796188b88dab4540a918cf7c8d33c9dbe5642b231aad12f2ebffcf6\",\n")
+                                "      \"kid\": \"74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828\",\n")
                         .append("      \"alg\": \"ES256\"\n")
                         .append("    }\n")
                         .append("  ]\n")
@@ -519,6 +519,7 @@ public class CoreStubHandler {
                     LOGGER.info("Received request for JWKS endpoint: {}", request.url());
                 }
                 response.type("application/json");
+                response.header("Cache-Control", "max-age=300");
                 return jwksResponse;
             };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Amended hashed KeyID for stub public signing key and added cache control to the response header 

### Why did it change

To enable verification using core stub jwks endpoint

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1660](https://govukverify.atlassian.net/browse/LIME-1660)



[LIME-1660]: https://govukverify.atlassian.net/browse/LIME-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ