### PR TITLE
PYIC-8466: update dcmaw-async and f2f stubs to return journey ids in queue responses

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueErrorEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueErrorEvent.java
@@ -18,7 +18,8 @@ public class CriResponseQueueErrorEvent {
     private String error;
     private String error_description;
 
-    public CriResponseQueueErrorEvent(String sub, String state, String error, String error_description) {
+    public CriResponseQueueErrorEvent(
+            String sub, String state, String error, String error_description) {
         this.sub = sub;
         this.state = state;
         this.error = error;

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueErrorEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueErrorEvent.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.stub.cred.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,6 +11,17 @@ import lombok.Setter;
 public class CriResponseQueueErrorEvent {
     private String sub;
     private String state;
+
+    @JsonProperty("govuk_signin_journey_id")
+    private String journeyId = "stub-journey-id";
+
     private String error;
     private String error_description;
+
+    public CriResponseQueueErrorEvent(String sub, String state, String error, String error_description) {
+        this.sub = sub;
+        this.state = state;
+        this.error = error;
+        this.error_description = error_description;
+    }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueEvent.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/CriResponseQueueEvent.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.stub.cred.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,11 +8,19 @@ import java.util.List;
 
 @Getter
 @Setter
-@AllArgsConstructor
 public class CriResponseQueueEvent {
     private String sub;
     private String state;
 
+    @JsonProperty("govuk_signin_journey_id")
+    private String journeyId = "stub-journey-id";
+
     @JsonProperty("https://vocab.account.gov.uk/v1/credentialJWT")
     private List<String> vcJwt;
+
+    public CriResponseQueueEvent(String sub, String state, List<String> vcJwt) {
+        this.sub = sub;
+        this.state = state;
+        this.vcJwt = vcJwt;
+    }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -826,6 +826,7 @@ public class AuthorizeHandler {
             return;
         }
         if (f2fDetails.sendVcToQueue() && !f2fDetails.sendErrorToQueue()) {
+            LOGGER.info("Sending VC to queue");
             F2FEnqueueLambdaRequest enqueueLambdaRequest =
                     new F2FEnqueueLambdaRequest(
                             f2fDetails.queueName(),

--- a/di-ipv-dcmaw-async-stub/README.md
+++ b/di-ipv-dcmaw-async-stub/README.md
@@ -42,6 +42,15 @@ HTTP/1.1 201 Created
 
 ### Additionally a management endpoint is exposed, which can be hit manually (for example via curl).
 The `management/enqueueVc` endpoint will build and sign a VC based on the inputs provided and push a VC message onto the CRI response queue (via the queue stub lambda).
+The message will look something like this:
+```
+{
+  "sub": "<user id>",
+  "state": "<oauth state>",
+  "govuk_signin_journey_id": "<journey id>",
+  "https://vocab.account.gov.uk/v1/credentialJWT": ["<signed jwt>"]
+}
+```
 
 The `management/generateVc` endpoint will build and sign a VC based on the inputs provided and return it directly.
 

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/credentialHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/credentialHandler.ts
@@ -31,7 +31,7 @@ export async function handler(
     }
 
     // We need to store the state value so we can provide it in the async VC response
-    await persistState(requestBody.sub, requestBody.state);
+    await persistState(requestBody.sub, requestBody.state, requestBody.govuk_signin_journey_id);
 
     return buildApiResponse(
       {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/credentialHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/credentialHandler.ts
@@ -31,7 +31,11 @@ export async function handler(
     }
 
     // We need to store the state value so we can provide it in the async VC response
-    await persistState(requestBody.sub, requestBody.state, requestBody.govuk_signin_journey_id);
+    await persistState(
+      requestBody.sub,
+      requestBody.state,
+      requestBody.govuk_signin_journey_id,
+    );
 
     return buildApiResponse(
       {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
@@ -3,7 +3,7 @@ import { buildApiResponse } from "../common/apiResponse";
 import getErrorMessage from "../common/errorReporting";
 import { ManagementEnqueueErrorRequest } from "../domain/managementEnqueueRequest";
 import getConfig from "../common/config";
-import { getState } from "../services/userStateService";
+import { getUserStateItem } from "../services/userStateService";
 
 export async function handler(
   event: APIGatewayProxyEventV2,
@@ -20,11 +20,12 @@ export async function handler(
       return buildApiResponse({ errorMessage: requestBody }, 400);
     }
 
-    const state = await getState(requestBody.user_id);
+    const {state, journeyId} = await getUserStateItem(requestBody.user_id);
 
     const queueMessage = {
       sub: requestBody.user_id,
       state,
+      govuk_signin_journey_id: journeyId,
       error: requestBody.error_code,
       error_description:
         requestBody.error_description ?? "Error sent via DCMAW Async CRI stub",

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueErrorHandler.ts
@@ -20,7 +20,7 @@ export async function handler(
       return buildApiResponse({ errorMessage: requestBody }, 400);
     }
 
-    const {state, journeyId} = await getUserStateItem(requestBody.user_id);
+    const { state, journeyId } = await getUserStateItem(requestBody.user_id);
 
     const queueMessage = {
       sub: requestBody.user_id,

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -10,7 +10,7 @@ import {
   isManagementEnqueueVcRequestEvidenceAndSubject,
   isManagementEnqueueVcRequestIndividualDetails,
 } from "../domain/managementEnqueueRequest";
-import { getState } from "../services/userStateService";
+import { getUserStateItem } from "../services/userStateService";
 import getConfig from "../common/config";
 import { JWTPayload } from "jose/dist/types/types";
 import { vcToSignedJwt } from "../domain/signedJwt";
@@ -33,7 +33,7 @@ export async function handler(
 
     const queueNameFromRequest = requestBody.queue_name;
     const delaySeconds = requestBody.delay_seconds;
-    const state = await getState(requestBody.user_id);
+    const { state, journeyId } = await getUserStateItem(requestBody.user_id);
     let vc: JWTPayload;
 
     if (isManagementEnqueueVcRequestIndividualDetails(requestBody)) {
@@ -78,7 +78,7 @@ export async function handler(
     const queueMessage = {
       sub: vc.sub,
       state,
-      govuk_signin_journey_id: "stub-journey-id",
+      govuk_signin_journey_id: journeyId,
       "https://vocab.account.gov.uk/v1/credentialJWT": [signedJwt],
     };
 

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -78,6 +78,7 @@ export async function handler(
     const queueMessage = {
       sub: vc.sub,
       state,
+      govuk_signin_journey_id: "stub-journey-id",
       "https://vocab.account.gov.uk/v1/credentialJWT": [signedJwt],
     };
 

--- a/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/services/userStateService.ts
@@ -26,16 +26,17 @@ export async function persistState(
   const updateItemInput: UpdateItemInput = {
     TableName: userStateTableName,
     Key: marshall({ userId }),
-    UpdateExpression: "set #state = :state, #ttl = :ttl, #journeyId = :journeyId",
+    UpdateExpression:
+      "set #state = :state, #ttl = :ttl, #journeyId = :journeyId",
     ExpressionAttributeNames: {
       "#state": "state",
       "#ttl": "ttl",
-      "#journeyId": "journeyId"
+      "#journeyId": "journeyId",
     },
     ExpressionAttributeValues: marshall({
       ":state": state,
       ":ttl": Math.floor(Date.now() / 1000) + 3600, // epoch timestamp in seconds
-      ":journeyId": journeyId
+      ":journeyId": journeyId,
     }),
   };
   await dynamoClient.updateItem(updateItemInput);
@@ -52,7 +53,7 @@ export async function getUserStateItem(userId: string) {
   if (userStateItem === null) {
     throw new Error(`No state record found for user id ${userId}`);
   }
-  return {state: userStateItem.state, journeyId: userStateItem.journeyId};
+  return { state: userStateItem.state, journeyId: userStateItem.journeyId };
 }
 
 /** Deletes state record. */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- update dcmaw-async and f2f stubs to return journey ids in queue responses

### Why did it change
- mobile will be returning the journey id in the sqs message and f2f _may_ be doing the same 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8466](https://govukverify.atlassian.net/browse/PYIC-8466)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs



[PYIC-8466]: https://govukverify.atlassian.net/browse/PYIC-8466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ