### PR TITLE
PYIC-8470: evcs invalidate endpoint and new management endpoint

### DIFF
--- a/di-ipv-evcs-stub/README.md
+++ b/di-ipv-evcs-stub/README.md
@@ -175,7 +175,14 @@ Responses
           $ref: '#/components/responses/ServerError'
 ```
 
-5) The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
+5) The format of the `/identity/invalidate` POST endpoint. This is used to set the `isValid` property on a user's stored identities as false.
+Example request body takes just a userId:
+```
+{ "userId": "userId" }
+```
+
+#### Management Endpoint
+The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
 Example response:
 ```
 [

--- a/di-ipv-evcs-stub/README.md
+++ b/di-ipv-evcs-stub/README.md
@@ -182,7 +182,9 @@ Example request body takes just a userId:
 ```
 
 #### Management Endpoint
-The `/management/stored-identity/{userId}` endpoint is used for testing. It doesn't take a request body and requires only the userId as path parameter.
+The `/management` endpoints are used for testing.
+
+The `/management/stored-identity/{userId}` GET endpoint is used to get an SI record from the table. It doesn't take a request body and requires only the userId as path parameter. It will return a 404 if a user is not found.
 Example response:
 ```
 [
@@ -201,4 +203,15 @@ Example response:
     "isValid": "true"
  }
 ]
+```
+
+The `/management/stored-identity/{userId}` POST endpoint is used to create an SI record for a user. It can be used for testing in order to create an SI record without having to go through an identity proofing journey.
+Example request body:
+```
+{
+    "si": {
+        "jwt": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46dXVpZDo5NjI4OTgxNS0wZTUyLTQ4MDAtOTZkZi0xZmY3ZGU5ODFjZDQiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3NDYwODkxNTEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYnVpbGQuYWNjb3VudC5nb3YudWsiLCJhdWQiOiJodHRwczovL29yY2guc3R1YnMuYWNjb3VudC5nb3YudWsiLCJuYmYiOiIxNzc3NjI1MTUxIiwidm90IjoiUDIiLCJjcmVkZW50aWFscyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5pSjkuZXlKemRXSWlPaUoxY200NmRYVnBaRG81TmpJNE9UZ3hOUzB3WlRVeUxUUTRNREF0T1Raa1ppMHhabVkzWkdVNU9ERmpaRFFpTENKaGRXUWlPaUpvZEhSd2N6b3ZMMmxrWlc1MGFYUjVMbUoxYVd4a0xtRmpZMjkxYm5RdVoyOTJMblZySWl3aWJtSm1Jam94TnpRMk1Ea3lOVGszTENKcGMzTWlPaUpvZEhSd2N6b3ZMMkZrWkhKbGMzTXRZM0pwTG5OMGRXSnpMbUZqWTI5MWJuUXVaMjkyTG5Wcklpd2lkbU1pT25zaWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSXNJa0ZrWkhKbGMzTkRjbVZrWlc1MGFXRnNJbDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltRmtaSEpsYzNNaU9sdDdJbUZrWkhKbGMzTkRiM1Z1ZEhKNUlqb2lSMElpTENKaWRXbHNaR2x1WjA1aGJXVWlPaUlpTENKemRISmxaWFJPWVcxbElqb2lTRUZFVEVWWklGSlBRVVFpTENKd2IzTjBZV3hEYjJSbElqb2lRa0V5SURWQlFTSXNJbUoxYVd4a2FXNW5UblZ0WW1WeUlqb2lPQ0lzSW1Ga1pISmxjM05NYjJOaGJHbDBlU0k2SWtKQlZFZ2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1EQXdMVEF4TFRBeEluMWRmWDBzSW1wMGFTSTZJblZ5YmpwMWRXbGtPbU13TlRWbFlXVmpMVEF5WmpVdE5EUTFOQzA1TnpreUxUWXlZemxqTldRM1l6QXdOeUo5LnhkSHlaVUV3d2k2VENpTTM4VXlOZEgtYkhkQjE0QnhtNm0xVWNuWE5SR1Z4cXFHR0R1cWgwODdsTDNtT0ZNd1BFVWxkTEU2TmVKOUI4dFZkSHJrUnlBIl0sImNsYWltcyI6W3siZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJpY2FvSXNzdWVyQ29kZSI6IkdCUiIsImRvY3VtZW50TnVtYmVyIjoiMzIxNjU0OTg3In0seyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NS0wNy0wOCJ9XX1dfQ.DjY3mL3f1U1ehHILXz0ifAosUBCLH3HdAnqYX9YH4t7JdQjSECU885RJKUKZqE33vMvG0n-Ip1tULP7hkQ0R_A", # pragma: allowlist secret
+        "vot": "P2"
+    }
+}
 ```

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -243,6 +243,72 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
+  # lambda to stub EVCS - evcsInvalidateIdentity
+  EvcsInvalidateStoredIdentityFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "EvcsInvalidateStoredIdentityFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "evcsInvalidateStoredIdentity-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: evcsHandler.invalidateStoredIdentityHandler
+      Runtime: nodejs22.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
+          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          NODE_OPTIONS: --enable-source-maps
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt EvcsLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/evcs/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStubUserVcsStoreTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStoredIdentityStoreTable
+      AutoPublishAlias: live
+      Events:
+        InvalidateStoredIdentity:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /identity/invalidate
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/evcsHandler.ts
+
   # lambda to stub EVCS - evcsGetUserVCs
   EvcsGetUserVCsFunction:
     Type: AWS::Serverless::Function
@@ -398,6 +464,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/evcsPostIdentity-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+  EvcsInvalidateStoredIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/evcsInvalidateStoredIdentity-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
   EvcsGetUserVCsFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -444,6 +444,72 @@ Resources:
         EntryPoints:
           - src/handlers/evcsManagementHandler.ts
 
+  # lambda for management endpoint to store SI record for user
+  EvcsManagementCreateStoredIdentityFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "EvcsManagementCreateStoredIdentityFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "evcsManagementCreateStoredIdentity-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: evcsManagementHandler.createUserStoredIdentityHandler
+      Runtime: nodejs22.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
+          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          NODE_OPTIONS: --enable-source-maps
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt EvcsLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/evcs/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStubUserVcsStoreTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStoredIdentityStoreTable
+      AutoPublishAlias: live
+      Events:
+        GetStoredIdentity:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /management/stored-identity/{userId}
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/evcsManagementHandler.ts
+
   EvcsCreateUserVCsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
@@ -485,6 +551,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/evcsManagementGetStoredIdentity-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+  EvcsManagementCreateStoredIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/evcsManagementCreateStoredIdentity-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   EvcsLambdaSecurityGroup:

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -418,8 +418,6 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
-    # lambda for management endpoint to retrieve stored identity record for user
-
   # lambda for management endpoint to retrieve stored identity record for user
   EvcsManagementGetStoredIdentityFunction:
     Type: AWS::Serverless::Function
@@ -486,6 +484,72 @@ Resources:
         EntryPoints:
           - src/handlers/evcsManagementHandler.ts
 
+  # lambda for management endpoint to create SI record for user
+  EvcsManagementCreateStoredIdentityFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "EvcsManagementCreateStoredIdentityFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "evcsManagementCreateStoredIdentity-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: evcsManagementHandler.createUserStoredIdentityHandler
+      Runtime: nodejs22.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
+          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          NODE_OPTIONS: --enable-source-maps
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt EvcsLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/evcs/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStubUserVcsStoreTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStoredIdentityStoreTable
+      AutoPublishAlias: live
+      Events:
+        GetStoredIdentity:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /management/stored-identity/{userId}
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/evcsManagementHandler.ts
+
   EvcsCreateUserVCsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
@@ -527,6 +591,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/evcsManagementGetStoredIdentity-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+  EvcsManagementCreateStoredIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/evcsManagementCreateStoredIdentity-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   EvcsLambdaSecurityGroup:

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -283,6 +283,72 @@ Resources:
         EntryPoints:
           - src/handlers/evcsHandler.ts
 
+  # lambda to stub EVCS - evcsInvalidateIdentity
+  EvcsInvalidateStoredIdentityFunction:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    # checkov:skip=CKV_AWS_173: doing it later
+    DependsOn:
+      - "EvcsInvalidateStoredIdentityFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "evcsInvalidateStoredIdentity-${Environment}"
+      CodeUri: "../lambdas"
+      Handler: evcsHandler.invalidateStoredIdentityHandler
+      Runtime: nodejs22.x
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          ISSUER: "https://evcs-cri.stubs.account.gov.uk"
+          EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          NODE_OPTIONS: --enable-source-maps
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt EvcsLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/evcs/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStubUserVcsStoreTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref EvcsStoredIdentityStoreTable
+      AutoPublishAlias: live
+      Events:
+        InvalidateStoredIdentity:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /identity/invalidate
+            Method: POST
+    Metadata:
+      # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2022"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/evcsHandler.ts
+
   # lambda to stub EVCS - evcsGetUserVCs
   EvcsGetUserVCsFunction:
     Type: AWS::Serverless::Function
@@ -440,6 +506,13 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/evcsPostIdentity-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+  EvcsInvalidateStoredIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    # checkov:skip=CKV_AWS_158: No need for customer managed keys for short lived logs
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/evcsInvalidateStoredIdentity-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
   EvcsGetUserVCsFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/di-ipv-evcs-stub/lambdas/src/common/apiResponses.ts
+++ b/di-ipv-evcs-stub/lambdas/src/common/apiResponses.ts
@@ -1,8 +1,8 @@
 import { APIGatewayProxyResultV2 } from "aws-lambda";
 
 export function buildApiResponse(
-  body?: object,
   statusCode: number = 200,
+  body?: object,
 ): APIGatewayProxyResultV2 {
   return {
     statusCode,

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/identityEndpointRequests.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/identityEndpointRequests.ts
@@ -1,7 +1,7 @@
 import { VcDetails } from "../sharedTypes";
 import { Vot } from "../enums/vot";
 
-interface StoredIdentityDetails {
+export interface StoredIdentityDetails {
   jwt: string;
   vot: Vot;
   metadata?: object;

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/identityEndpointRequests.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/identityEndpointRequests.ts
@@ -16,3 +16,7 @@ export interface PutRequest {
   vcs: VcDetails[];
   si?: StoredIdentityDetails;
 }
+
+export interface InvalidateIdentityRequest {
+  userId: string;
+}

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/index.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/index.ts
@@ -1,3 +1,3 @@
 export * from "./postRequest";
 export * from "./patchRequest";
-export * from "./postIdentityRequest";
+export * from "./identityEndpointRequests";

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
@@ -33,15 +33,14 @@ export async function postIdentityHandler(
     parsedPostIdentityRequest = parsePostIdentityRequest(event);
   } catch (error) {
     console.error(error);
-    return buildApiResponse(
-      { message: getErrorMessage(error) },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: getErrorMessage(error),
+    });
   }
 
   const res = await processPostIdentityRequest(parsedPostIdentityRequest);
 
-  return buildApiResponse(res.response, res.statusCode);
+  return buildApiResponse(res.statusCode, res.response);
 }
 
 export async function invalidateStoredIdentityHandler(
@@ -54,15 +53,14 @@ export async function invalidateStoredIdentityHandler(
     parsedInvalidateSiRequest = parseInvalidateIdentityRequest(event);
   } catch (error) {
     console.error(error);
-    return buildApiResponse(
-      { message: getErrorMessage(error) },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: getErrorMessage(error),
+    });
   }
 
   const res = await invalidateUserSi(parsedInvalidateSiRequest.userId);
 
-  return buildApiResponse(res.response, res.statusCode);
+  return buildApiResponse(res.statusCode);
 }
 
 export async function createHandler(
@@ -71,10 +69,9 @@ export async function createHandler(
   console.info(`---Create Request received----`);
   const userId = event.pathParameters?.userId;
   if (!userId) {
-    return buildApiResponse(
-      { message: "Missing userId." },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: "Missing userId.",
+    });
   }
 
   let request;
@@ -82,17 +79,16 @@ export async function createHandler(
     request = parsePostRequest(event);
   } catch (error) {
     console.error(error);
-    return buildApiResponse(
-      { message: getErrorMessage(error) },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: getErrorMessage(error),
+    });
   }
   const res = await processPostUserVCsRequest(
     decodeURIComponent(userId),
     request,
   );
 
-  return buildApiResponse(res.response, res.statusCode);
+  return buildApiResponse(res.statusCode, res.response);
 }
 
 export async function updateHandler(
@@ -101,10 +97,9 @@ export async function updateHandler(
   console.info(`---Update request received----`);
   const userId = event.pathParameters?.userId;
   if (!userId) {
-    return buildApiResponse(
-      { message: "Missing userId." },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: "Missing userId.",
+    });
   }
 
   let request;
@@ -112,17 +107,16 @@ export async function updateHandler(
     request = parsePatchRequest(event);
   } catch (error) {
     console.error(error);
-    return buildApiResponse(
-      { message: getErrorMessage(error) },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: getErrorMessage(error),
+    });
   }
   const res = await processPatchUserVCsRequest(
     decodeURIComponent(userId),
     request,
   );
 
-  return buildApiResponse(res.response, res.statusCode);
+  return buildApiResponse(res.statusCode, res.response);
 }
 
 export async function getHandler(
@@ -131,10 +125,9 @@ export async function getHandler(
   console.info(`---Get request received----`);
   const userId = event.pathParameters?.userId;
   if (!userId) {
-    return buildApiResponse(
-      { message: "Missing userId." },
-      StatusCodes.BadRequest,
-    );
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: "Missing userId.",
+    });
   }
   const decodedUserId = decodeURIComponent(userId);
 
@@ -160,10 +153,9 @@ export async function getHandler(
           );
     } catch (error) {
       console.error(error);
-      return buildApiResponse(
-        { message: getErrorMessage(error) },
-        StatusCodes.BadRequest,
-      );
+      return buildApiResponse(StatusCodes.BadRequest, {
+        message: getErrorMessage(error),
+      });
     }
 
     let res: ServiceResponse = {
@@ -172,13 +164,12 @@ export async function getHandler(
     if (accessTokenVerified)
       res = await processGetUserVCsRequest(decodedUserId, requestedStates);
 
-    return buildApiResponse(res.response, res.statusCode);
+    return buildApiResponse(res.statusCode, res.response);
   } catch (error) {
     console.error(error);
-    return buildApiResponse(
-      { message: getErrorMessage(error) },
-      StatusCodes.InternalServerError,
-    );
+    return buildApiResponse(StatusCodes.InternalServerError, {
+      message: getErrorMessage(error),
+    });
   }
 }
 

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsManagementHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsManagementHandler.ts
@@ -11,12 +11,9 @@ export async function getUserStoredIdentityHandler(
     const userId = event.pathParameters?.userId;
 
     if (!userId) {
-      return buildApiResponse(
-        {
-          message: "Missing userId",
-        },
-        StatusCodes.BadRequest,
-      );
+      return buildApiResponse(StatusCodes.BadRequest, {
+        message: "Missing userId",
+      });
     }
 
     const decodedUserId = decodeURIComponent(userId);
@@ -24,18 +21,16 @@ export async function getUserStoredIdentityHandler(
     const res = await processGetStoredIdentity(decodedUserId);
 
     if (res.storedIdentities.length === 0) {
-      return buildApiResponse(
-        { message: "No stored identity found for user" },
-        StatusCodes.NotFound,
-      );
+      return buildApiResponse(StatusCodes.NotFound, {
+        message: "No stored identity found for user",
+      });
     }
 
-    return buildApiResponse(res.storedIdentities, StatusCodes.Success);
+    return buildApiResponse(StatusCodes.Success, res.storedIdentities);
   } catch (error) {
     console.error(error);
-    return buildApiResponse(
-      { message: "Unable to get stored identity for user" },
-      StatusCodes.InternalServerError,
-    );
+    return buildApiResponse(StatusCodes.InternalServerError, {
+      message: "Unable to get stored identity for user",
+    });
   }
 }

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsManagementHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsManagementHandler.ts
@@ -1,7 +1,12 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResultV2 } from "aws-lambda";
 import { buildApiResponse } from "../common/apiResponses";
 import { StatusCodes } from "../domain/enums";
-import { processGetStoredIdentity } from "../services/evcsManagementService";
+import {
+  CreateStoredIdentityRequest,
+  processCreateStoredIdentity,
+  processGetStoredIdentity,
+} from "../services/evcsManagementService";
+import { getErrorMessage } from "../common/utils";
 
 export async function getUserStoredIdentityHandler(
   event: APIGatewayProxyEvent,
@@ -33,4 +38,54 @@ export async function getUserStoredIdentityHandler(
       message: "Unable to get stored identity for user",
     });
   }
+}
+
+export async function createUserStoredIdentityHandler(
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResultV2> {
+  console.info("---Create user stored identity request received---");
+
+  let parsedRequest;
+  try {
+    parsedRequest = parseCreateSiRequest(event);
+  } catch (error) {
+    console.error(error);
+    return buildApiResponse(StatusCodes.BadRequest, {
+      message: getErrorMessage(error),
+    });
+  }
+
+  const res = await processCreateStoredIdentity(parsedRequest);
+
+  return buildApiResponse(res.statusCode, res.response);
+}
+
+function parseCreateSiRequest(
+  event: APIGatewayProxyEvent,
+): CreateStoredIdentityRequest {
+  const userId = event.pathParameters?.userId;
+
+  if (!userId) {
+    throw new Error("Missing user id");
+  }
+
+  const decodedUserId = decodeURIComponent(userId);
+
+  if (!event.body) {
+    throw new Error("Missing request body");
+  }
+
+  const parsedBody = JSON.parse(event.body);
+  if (!parsedBody.si.jwt) {
+    throw new Error("Missing si.jwt");
+  }
+
+  if (!parsedBody.si.vot) {
+    throw new Error("Missing si.vot");
+  }
+
+  return {
+    userId: decodedUserId,
+    si: parsedBody.si,
+  };
 }

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -203,7 +203,6 @@ export async function invalidateUserSi(userId: string) {
     if (storedIdentities.length === 0) {
       console.info("No stored identity found for user");
       return {
-        response: { result: "Success" },
         statusCode: StatusCodes.NoContent,
       };
     }
@@ -232,7 +231,6 @@ export async function invalidateUserSi(userId: string) {
     });
 
     return {
-      response: { result: "Success" },
       statusCode: StatusCodes.NoContent,
     };
   } catch (error) {
@@ -241,7 +239,6 @@ export async function invalidateUserSi(userId: string) {
       error,
     );
     return {
-      response: { result: "Failed" },
       statusCode: StatusCodes.InternalServerError,
     };
   }

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -203,7 +203,7 @@ export async function invalidateUserSi(userId: string) {
     if (storedIdentities.length === 0) {
       console.info("No stored identity found for user");
       return {
-        statusCode: StatusCodes.NoContent,
+        statusCode: StatusCodes.NotFound,
       };
     }
 

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -320,7 +320,7 @@ export async function processPatchUserVCsRequest(
   }
 }
 
-function createPutItem(evcsItem: EvcsVcItem | EvcsStoredIdentityItem) {
+export function createPutItem(evcsItem: EvcsVcItem | EvcsStoredIdentityItem) {
   return {
     TableName: isEvcsVcItem(evcsItem)
       ? config.evcsStubUserVCsTableName
@@ -404,7 +404,7 @@ function getUpdatedState(
   return currentVcState;
 }
 
-function getRecordTypeFromVot(vot: Vot): StoredIdentityRecordType {
+export function getRecordTypeFromVot(vot: Vot): StoredIdentityRecordType {
   if (GPG45_VOTS.includes(vot)) {
     return StoredIdentityRecordType.GPG45;
   }

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -370,7 +370,6 @@ describe("evcs handlers", () => {
       // Arrange
       jest.mocked(invalidateUserSi).mockResolvedValue({
         statusCode: 204,
-        response: { result: "Success" },
       });
 
       // Act
@@ -406,7 +405,6 @@ describe("evcs handlers", () => {
       // Arrange
       jest.mocked(invalidateUserSi).mockResolvedValue({
         statusCode: 500,
-        response: { result: "Failed" },
       });
 
       // Act

--- a/di-ipv-evcs-stub/lambdas/test/evcsManagementHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsManagementHandler.test.ts
@@ -113,7 +113,7 @@ describe("evcs management handlers", () => {
   });
 
   describe("createUserStoredIdentityHandler", () => {
-    it("should return 204 given valid request", async () => {
+    it("should return 202 given valid request", async () => {
       // Arrange
       const testRequest = {
         pathParameters: {

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -342,7 +342,7 @@ describe("invalidateUserSi", () => {
     dbMock.reset();
   });
 
-  it("should return 200 for user with existing stored identities", async () => {
+  it("should return 204 for user with existing stored identities", async () => {
     // Arrange
     dbMock.on(QueryCommand).resolves({
       Items: [
@@ -364,7 +364,7 @@ describe("invalidateUserSi", () => {
     });
   });
 
-  it("should return 200 for user with no existing stored identity", async () => {
+  it("should return 404 for user with no existing stored identity", async () => {
     // Arrange
     dbMock.on(QueryCommand).resolves({ Items: [] });
 
@@ -372,7 +372,7 @@ describe("invalidateUserSi", () => {
     const res = await invalidateUserSi(TEST_USER_ID);
 
     // Assert
-    expect(res.statusCode).toBe(StatusCodes.NoContent);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
     expect(dbMock).not.toHaveReceivedCommand(TransactWriteItemsCommand);
   });
 

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -7,13 +7,17 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import { getSsmParameter } from "../../src/common/ssmParameter";
-import { processPostIdentityRequest } from "../../src/services/evcsService";
+import {
+  invalidateUserSi,
+  processPostIdentityRequest,
+} from "../../src/services/evcsService";
 import { PostIdentityRequest, PutRequest } from "../../src/domain/requests";
 import { StatusCodes, VCProvenance, VcState } from "../../src/domain/enums";
 import "aws-sdk-client-mock-jest";
 import { config } from "../../src/common/config";
 import { Vot } from "../../src/domain/enums/vot";
 import { StoredIdentityRecordType } from "../../src/domain/enums/StoredIdentityRecordType";
+import EvcsStoredIdentityItem from "../../src/model/storedIdentityItem";
 
 jest.useFakeTimers().setSystemTime(new Date("2025-01-01"));
 
@@ -42,6 +46,23 @@ const TEST_VC2 = `eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDo5N
 const TEST_VC3_SIGNATURE =
   "ggN9Y1utkbVunE5brcR3KmXntj5jK_jzccXlLnUO_2DMENTDuBUDlh4dkt7K-upx_n0Ygu125TzduNad41QzoA"; // pragma: allowlist secret
 const TEST_VC3 = `eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDo5NjI4OTgxNS0wZTUyLTQ4MDAtOTZkZi0xZmY3ZGU5ODFjZDQiLCJhdWQiOiJodHRwczovL2lkZW50aXR5LmJ1aWxkLmFjY291bnQuZ292LnVrIiwibmJmIjoxNzQ2MDkyNjAzLCJpc3MiOiJodHRwczovL2ZyYXVkLWNyaS5zdHVicy5hY2NvdW50Lmdvdi51ayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InZhbHVlIjoiS2VubmV0aCIsInR5cGUiOiJHaXZlbk5hbWUifSx7InZhbHVlIjoiRGVjZXJxdWVpcmEiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NS0wNy0wOCJ9XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvc3RhbENvZGUiOiJCQTIgNUFBIiwiYnVpbGRpbmdOdW1iZXIiOiI4IiwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInZhbGlkRnJvbSI6IjIwMDAtMDEtMDEifV19LCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJpZGVudGl0eUZyYXVkU2NvcmUiOjIsInR4biI6IjM0OTg4OTVhLTk0Y2MtNDlkZS04MDc0LTQ5OWU1MjczZDI2YyJ9XX0sImp0aSI6InVybjp1dWlkOjg5ZDY5MTAwLTRiOTctNDYxZi1hOTlkLTNlZDZjMzNkNGVhNCJ9.${TEST_VC3_SIGNATURE}`; // pragma: allowlist secret
+
+const TEST_SI_JWT =
+  "eyJraWQiOiJ0ZXN0LXNpZ25pbmcta2V5IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJodHRwczovL3JldXNlLWlkZW50aXR5LmJ1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiNmJkMjM1ZGMyYTBhNTliODkyMGU0NTJjNzE1MzY0ZWQiLCJuYmYiOjE3NTA2NzQ3NTUsImNyZWRlbnRpYWxzIjpbInl0NUgtN0EyWXhqeTd0eDlUaXRnQ1NTeW80dV9RUHlTam84Q2FrdXlyY01EMjhLMThKSnFyWG5uemc1TXFmZkZxZTB5clRKRlBNa201V3hRdmlNa01BIiwiVDFHdFA3X01ueUZHYmJhSUl3NER3NmJYcEZwakRaeU5jSlU0V1BiME9tTzBYRmZPV0V4NXNiZEkwTlBGeFpNT1JsQjFUYlRibmMxVHhNMVhybjBfRXciXSwiaXNzIjoiaHR0cHM6Ly9pZGVudGl0eS5sb2NhbC5hY2NvdW50Lmdvdi51ayIsImNsYWltcyI6eyJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL3YxL2NvcmVJZGVudGl0eSI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IkFsaWNlIn0seyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJKYW5lIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiRG9lIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTcwLTAxLTAxIn1dfX0sInZvdCI6IlBDTDI1MCIsImlhdCI6MTc1MDY3NDc1NX0.9OqD33fjZLozlbDHZtbAqtrnMNXHyJ-mFZo5F4sVRB-qzjxdK8Iuz9aK_h5iTP6PFHCx7ZwXLbAbtZKjeCEqHg"; // pragma: allowlist secret
+const TEST_SI_TABLE_ITEM_GPG45: EvcsStoredIdentityItem = {
+  userId: TEST_USER_ID,
+  recordType: StoredIdentityRecordType.GPG45,
+  isValid: true,
+  levelOfConfidence: Vot.P2,
+  storedIdentity: TEST_SI_JWT,
+};
+const TEST_SI_TABLE_ITEM_HMRC: EvcsStoredIdentityItem = {
+  userId: TEST_USER_ID,
+  recordType: StoredIdentityRecordType.HMRC,
+  isValid: true,
+  levelOfConfidence: Vot.PCL200,
+  storedIdentity: TEST_SI_JWT,
+};
 
 const TEST_METADATA = {
   reason: "test-created",
@@ -88,7 +109,7 @@ describe("processPostIdentityRequest", () => {
 
   it("should return 200 response with new vc if successful transaction", async () => {
     // Arrange
-    dbMock.on(QueryCommand).resolves(createQueryResponse([]));
+    dbMock.on(QueryCommand).resolves(createEvcsUserVcsQueryResponse([]));
 
     const putRequest: PutRequest = {
       userId: TEST_USER_ID,
@@ -130,7 +151,7 @@ describe("processPostIdentityRequest", () => {
   it("should return 200 response with updated vc if successful transaction", async () => {
     // Arrange
     dbMock.on(QueryCommand).resolves(
-      createQueryResponse([
+      createEvcsUserVcsQueryResponse([
         {
           vc: TEST_VC1,
           state: VcState.HISTORIC,
@@ -183,7 +204,7 @@ describe("processPostIdentityRequest", () => {
 
   it("should return 200 response if SI not provided", async () => {
     // Arrange
-    dbMock.on(QueryCommand).resolves(createQueryResponse([]));
+    dbMock.on(QueryCommand).resolves(createEvcsUserVcsQueryResponse([]));
 
     const putRequest: PutRequest = {
       userId: TEST_USER_ID,
@@ -216,7 +237,7 @@ describe("processPostIdentityRequest", () => {
   it("should return 200 response, update existing VCs and add new ones if successful transaction", async () => {
     // Arrange
     dbMock.on(QueryCommand).resolves(
-      createQueryResponse([
+      createEvcsUserVcsQueryResponse([
         { vc: TEST_VC1, state: VcState.CURRENT },
         { vc: TEST_VC2, state: VcState.PENDING_RETURN },
       ]),
@@ -292,7 +313,7 @@ describe("processPostIdentityRequest", () => {
 
   it("should return 500 status code if it fails to complete the transaction", async () => {
     // Arrange
-    dbMock.on(QueryCommand).resolves(createQueryResponse([]));
+    dbMock.on(QueryCommand).resolves(createEvcsUserVcsQueryResponse([]));
     dbMock
       .on(TransactWriteItemsCommand)
       .rejects(new Error("Failed to complete transaction"));
@@ -316,11 +337,67 @@ describe("processPostIdentityRequest", () => {
   });
 });
 
+describe("invalidateUserSi", () => {
+  beforeEach(() => {
+    dbMock.reset();
+  });
+
+  it("should return 200 for user with existing stored identities", async () => {
+    // Arrange
+    dbMock.on(QueryCommand).resolves({
+      Items: [
+        marshall(TEST_SI_TABLE_ITEM_GPG45),
+        marshall(TEST_SI_TABLE_ITEM_HMRC),
+      ],
+    });
+
+    // Act
+    const res = await invalidateUserSi(TEST_USER_ID);
+
+    // Assert
+    expect(res.statusCode).toBe(StatusCodes.NoContent);
+    expect(dbMock).toHaveReceivedCommandWith(TransactWriteItemsCommand, {
+      TransactItems: [
+        createUpdateSiIsValidUpdateItem(StoredIdentityRecordType.GPG45),
+        createUpdateSiIsValidUpdateItem(StoredIdentityRecordType.HMRC),
+      ],
+    });
+  });
+
+  it("should return 200 for user with no existing stored identity", async () => {
+    // Arrange
+    dbMock.on(QueryCommand).resolves({ Items: [] });
+
+    // Act
+    const res = await invalidateUserSi(TEST_USER_ID);
+
+    // Assert
+    expect(res.statusCode).toBe(StatusCodes.NoContent);
+    expect(dbMock).not.toHaveReceivedCommand(TransactWriteItemsCommand);
+  });
+
+  it("should return 500 if it fails to update the user's stored identity", async () => {
+    // Arrange
+    dbMock
+      .on(QueryCommand)
+      .resolves({ Items: [marshall(TEST_SI_TABLE_ITEM_GPG45)] });
+    dbMock
+      .on(TransactWriteItemsCommand)
+      .rejects(new Error("Failed to update SI item"));
+
+    // Act
+    const res = await invalidateUserSi(TEST_USER_ID);
+
+    // Assert
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+  });
+});
+
 function getTestTtl() {
   return Math.floor(Date.now() / 1000) + parseInt(MOCK_TTL);
 }
 
-function createQueryResponse(
+function createEvcsUserVcsQueryResponse(
   vcsForReturn: {
     vc: string;
     state: VcState;
@@ -409,6 +486,25 @@ function createUserVcUpdateItem(updateVcDetails: {
         ":metadataValue": {
           M: marshall(TEST_METADATA),
         },
+      },
+    },
+  };
+}
+
+function createUpdateSiIsValidUpdateItem(recordType: StoredIdentityRecordType) {
+  return {
+    Update: {
+      TableName: config.evcsStoredIdentityObjectTableName,
+      Key: marshall({
+        userId: TEST_USER_ID,
+        recordType: recordType,
+      }),
+      UpdateExpression: "set #isValid = :isValid",
+      ExpressionAttributeNames: {
+        "#isValid": "isValid",
+      },
+      ExpressionAttributeValues: {
+        ":isValid": marshall(false),
       },
     },
   };

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -326,6 +326,45 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: '{"result": "success"}'
+    post:
+      description: Saves a stored identity record for a user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                si:
+                  $ref: "#/components/schemas/StoredIdentityDetails"
+      responses:
+        202:
+          description: Stored identity record accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        500:
+          $ref: '#/components/responses/ServerError'
+      x-amazon-apigateway-request-validator: ALL
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsManagementCreateStoredIdentityFunction.Arn}:live/invocations
+        passthroughBehavior: "WHEN_NO_TEMPLATES"
+        responses:
+          202:
+            statusCode: 202
+            responseTemplates:
+              application/json: '{"result": "success"}'
 components:
   responses:
     BadRequest:

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -214,14 +214,7 @@ paths:
               $ref: "#/components/schemas/UserIdRequestBody"
       responses:
         204:
-          description: "Successfully invalidated user SI"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: string
+          description: "Successfully invalidated user stored identity record"
         400:
           $ref: '#/components/responses/BadRequest'
         500:

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -203,6 +203,42 @@ paths:
             responseTemplates:
               application/json: '{"result": "success"}'
 
+  /identity/invalidate:
+    post:
+      description: Set a User's SI document as invalid hence the SI document should no longer be used.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserIdRequestBody"
+      responses:
+        204:
+          description: "Successfully invalidated user SI"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+        400:
+          $ref: '#/components/responses/BadRequest'
+        500:
+          $ref: '#/components/responses/ServerError'
+      x-amazon-apigateway-request-validator: ALL
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: POST
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvcsInvalidateStoredIdentityFunction.Arn}:live/invocations
+        passthroughBehavior: "WHEN_NO_TEMPLATES"
+        responses:
+          204:
+            statusCode: 204
+            responseTemplates:
+              application/json: '{"result": "success"}'
+
   /migration/{userId}:
     get:
       description: "Returns a list of user verifiable credentials"
@@ -362,17 +398,24 @@ components:
         required:
           - signature
           - state
-    PersistStoredIdentity:
-      description: The request body for the /identity POST endpoint to store a user's stored identity record
+    UserIdRequestBody:
+      description: Request body schema containing required userId property.
       type: object
       properties:
         userId:
           type: string
-        si:
-          $ref: "#/components/schemas/StoredIdentityDetails"
       required:
         - userId
-        - si # TODO PYIC-8458: mark this as non-required when updating this endpoint with vcs list
+    PersistStoredIdentity:
+      description: The request body for the /identity POST endpoint to store a user's stored identity record
+      allOf:
+        - $ref: "#/components/schemas/UserIdRequestBody"
+        - type: object
+          properties:
+            si:
+              $ref: "#/components/schemas/StoredIdentityDetails"
+          required:
+            - si # TODO PYIC-8458: mark this as non-required when updating this endpoint with vcs list
     StoredIdentityDetails:
       type: object
       properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- adding `/identity/invalidate` endpoint to evcs stub, used to invalidate a user's stored identity

 | Scenario | screenshot |
|-|-|
| No request body | <img width="758" alt="invalid_request_empty_body" src="https://github.com/user-attachments/assets/cefbf7a9-f171-4ad3-b093-274ddfda4e50" /> |
| No userId property in request body | <img width="991" alt="Screenshot 2025-07-03 at 15 27 01" src="https://github.com/user-attachments/assets/1f6d99ee-f4f9-40e0-8e9e-8403617e0b64" /> |
| successful response | <img width="715" alt="Screenshot 2025-07-03 at 17 32 54" src="https://github.com/user-attachments/assets/f813b7ae-962a-48c4-9544-39981660f74b" /> |
| no SI for user | <img width="760" alt="Screenshot 2025-07-04 at 11 18 41" src="https://github.com/user-attachments/assets/96e0bad6-3e50-44c1-9c0e-19c894ac423d" /> |

Also added a new `/management/stored-identity/<user-id>` POST endpoint to create SIs so we don't have to repeat identity proving steps in tests.
Expected request body:
```
{
 "si": {
    "jwt": "si_jwt",
    "vot": "P2"
  }
}
```

### Why did it change
This new endpoint will be used to invalidate a user's SI record when a user comes back to ipv core to start another identity proving journey and they either fail or abandon this journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8470](https://govukverify.atlassian.net/browse/PYIC-8470)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8470]: https://govukverify.atlassian.net/browse/PYIC-8470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ