### PR TITLE
SPT-1450: Add actions to deploy EVCS stubs to reuse accounts

### DIFF
--- a/.github/actions/deploy-evcs-stub/action.yaml
+++ b/.github/actions/deploy-evcs-stub/action.yaml
@@ -1,0 +1,28 @@
+name: deploy-evcs-stub
+description: Deploy the EVCS stub to a given environment
+inputs:
+  role-to-assume:
+    required: true
+    description: The AWS role to assume for the deploymnet
+  artifact-bucket-name:
+    required: true
+    description: The S3 bucket to upload the artefact to
+  signing-profile-name:
+    required: true
+    description: The signing profile used to sign code on upload
+runs:
+  using: composite
+  steps:
+    - name: Set up AWS creds
+      uses: aws-actions/configure-aws-credentials@v4.2.1
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: eu-west-2
+
+    - name: Deploy SAM app
+      uses: govuk-one-login/devplatform-upload-action@v3.9
+      with:
+        artifact-bucket-name: ${{ inputs.artifact-bucket-name }}
+        signing-profile-name: ${{ inputs.signing-profile-name }}
+        working-directory: ./di-ipv-evcs-stub/deploy
+        template-file: .aws-sam/build/template.yaml

--- a/.github/workflows/evcs-stub.yml
+++ b/.github/workflows/evcs-stub.yml
@@ -23,12 +23,6 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v4.2.1
-        with:
-          role-to-assume: ${{ secrets.EVCS_STUB_BUILD_GH_ROLE }}
-          aws-region: eu-west-2
-
       - name: Set up SAM cli
         uses: aws-actions/setup-sam@v2
 
@@ -57,10 +51,23 @@ jobs:
         working-directory: ./di-ipv-evcs-stub/deploy
         run: sam build
 
-      - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.9
+      - name: Deploy to IPV Stubs accounts
+        uses: ./.github/actions/deploy-evcs-stub
         with:
+          role-to-assume: ${{ secrets.EVCS_STUB_BUILD_GH_ROLE }}
           artifact-bucket-name: ${{ secrets.EVCS_STUB_BUILD_S3_BUCKET }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-          working-directory: ./di-ipv-evcs-stub/deploy
-          template-file: .aws-sam/build/template.yaml
+
+      - name: Deploy to Reuse Stubs dev account
+        uses: ./.github/actions/deploy-evcs-stub
+        with:
+          role-to-assume: ${{ secrets.REUSE_EVCS_STUB_DEV_GH_ROLE }}
+          artifact-bucket-name: ${{ secrets.REUSE_EVCS_STUB_DEV_S3_BUCKET }}
+          signing-profile-name: ${{ secrets.REUSE_DEV_SIGNING_PROFILE_NAME }}
+
+      - name: Deploy to Reuse Stubs build account
+        uses: ./.github/actions/deploy-evcs-stub
+        with:
+          role-to-assume: ${{ secrets.REUSE_EVCS_STUB_BUILD_GH_ROLE }}
+          artifact-bucket-name: ${{ secrets.REUSE_EVCS_STUB_BUILD_S3_BUCKET }}
+          signing-profile-name: ${{ secrets.REUSE_BUILD_SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
## Proposed changes

### What changed

- Extract common, account specific, EVCS stub deployment steps into an action
- Call new action to deploy to IPV stubs, Reuse stubs dev and Reuse stubs build accounts.

### Why did it change

Trust and Reuse wish to deploy their own instance of the EVCS stub to aid testing (rather than re-invent the wheel).

The modifications in the PR ensures that future modifications to the EVCS stub will get deployed to the Trust and Reuse instances as well as the IPV stubs accounts.

### Issue tracking

- [SPT-1450](https://govukverify.atlassian.net/browse/SPT-1450)

## Checklists

## Checklists

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs


[SPT-1450]: https://govukverify.atlassian.net/browse/SPT-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ