### PR TITLE
SPT-1450: Config EVCS stub for Trust and Reuse

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/core-team @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team @govuk-one-login/identity-sre
+* @govuk-one-login/core-team @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team @govuk-one-login/identity-sre @govuk-one-login/trust-and-reuse-leads @govuk-one-login/trust-and-reuse-team

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Transform: AWS::Serverless-2016-10-31
+
 Globals:
   Function:
     Timeout: 30
@@ -36,9 +37,34 @@ Parameters:
       The ARN of the Code Signing Config to use, provided by the deployment pipeline
     Default: "none"
 
+Mappings:
+  HostedZoneImportName:
+    "130355686670": # IPV Core dev01
+      Name: Dev01StubsHostedZoneId
+    "175872367215": # IPV Core dev02
+      Name: Dev02StubsHostedZoneId
+    "110869144943": # Reuse stubs dev
+      Name: ReusePublicHostedZoneId
+    "054367266435": # Reuse stubs build
+      Name: ReusePublicHostedZoneId
+
 Conditions:
-  IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670"]
-  IsDev02: !Equals [ !Ref AWS::AccountId, "175872367215"]
+  IsIPVCore:
+    Fn::Or:
+      - Condition: IsDev01
+      - Condition: IsDev02
+
+  IsDev01: 
+    Fn::Equals: [ !Ref "AWS::AccountId", "130355686670"]
+
+  IsDev02:
+    Fn::Equals: [ !Ref "AWS::AccountId", "175872367215"]
+
+  IsReuse:
+    Fn::Or:
+      - Fn::Equals: [ !Ref "AWS::AccountId", "110869144943" ]
+      - Fn::Equals: [ !Ref "AWS::AccountId", "054367266435" ]
+      
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -683,30 +709,38 @@ Resources:
   EvcsStubSSLCert:
     Type: AWS::CertificateManager::Certificate
     Properties:
-      DomainName: !If
-        - IsDev01
-        - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-      DomainValidationOptions:
-        - DomainName: !If
+      DomainName: !If 
+          - IsIPVCore
+          - !If 
             - IsDev01
             - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
             - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-          HostedZoneId: !If
+          - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+      DomainValidationOptions:
+        - DomainName: !If 
+          - IsIPVCore
+          - !If 
             - IsDev01
-            - !ImportValue Dev01StubsHostedZoneId
-            - !If [IsDev02, !ImportValue Dev02StubsHostedZoneId, DevStubsHostedZoneId]
+            - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
+            - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
+          - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+          HostedZoneId:
+            Fn::ImportValue:
+              Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]
       ValidationMethod: DNS
 
-    # api domain entries / mapping
+  # api domain entries / mapping
   EvcsStubRestApiDomain:
     Type: AWS::ApiGateway::DomainName
     # checkov:skip=CKV_AWS_120: doing it later
     Properties:
-      DomainName: !If
-        - IsDev01
-        - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !If [IsDev02, !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk", !Ref AWS::NoValue]
+      DomainName: !If 
+        - IsIPVCore
+        - !If 
+          - IsDev01
+          - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
+          - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
+        - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
       RegionalCertificateArn: !Ref EvcsStubSSLCert
       EndpointConfiguration:
         Types:
@@ -717,10 +751,13 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     # checkov:skip=CKV_AWS_120: doing it later
     Properties:
-      DomainName: !If
-        - IsDev01
-        - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
+      DomainName: !If 
+        - IsIPVCore
+        - !If 
+          - IsDev01
+          - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
+          - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
+        - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
       RestApiId: !Ref RestApiGateway
       Stage: !Ref RestApiGateway.Stage
     DependsOn:
@@ -731,14 +768,16 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       Type: A
-      Name: !If
-        - IsDev01
-        - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
-        - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-      HostedZoneId: !If
-        - IsDev01
-        - !ImportValue Dev01StubsHostedZoneId
-        - !If [IsDev02, !ImportValue Dev02StubsHostedZoneId, DevStubsHostedZoneId]
+      Name: !If 
+        - IsIPVCore
+        - !If 
+          - IsDev01
+          - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
+          - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
+        - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+      HostedZoneId:
+        Fn::ImportValue:
+          Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]
       AliasTarget:
         DNSName: !GetAtt EvcsStubRestApiDomain.RegionalDomainName
         HostedZoneId: !GetAtt EvcsStubRestApiDomain.RegionalHostedZoneId

--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -62,8 +62,17 @@ Conditions:
 
   IsReuse:
     Fn::Or:
-      - Fn::Equals: [ !Ref "AWS::AccountId", "110869144943" ]
-      - Fn::Equals: [ !Ref "AWS::AccountId", "054367266435" ]
+      - Condition: IsReuseDev
+      - Condition: IsReuseBuild
+
+  IsReuseDev: 
+    Fn::Equals: [ !Ref "AWS::AccountId", "110869144943"]
+
+  IsReuseBuild:
+    Fn::Equals: [ !Ref "AWS::AccountId", "054367266435"]
+
+  IsReuseMain:
+    Fn::Equals: [ !Ref "AWS::StackName", "evcs-stub"]
       
   UsePermissionsBoundary:
     Fn::Not:
@@ -710,20 +719,32 @@ Resources:
     Type: AWS::CertificateManager::Certificate
     Properties:
       DomainName: !If 
-          - IsIPVCore
-          - !If 
-            - IsDev01
-            - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
-            - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-          - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+        - IsReuse
+        - !If 
+          - IsReuseDev
+          - !If
+            - IsReuseMain
+            - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+            - !Sub "evcs-${AWS::StackName}.reuse.${Environment}.stubs.account.gov.uk"
+          - !Sub "evcs.reuse.stubs.account.gov.uk"
+        - !If
+          - IsDev01
+          - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
+          - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
       DomainValidationOptions:
         - DomainName: !If 
-          - IsIPVCore
+          - IsReuse
           - !If 
+            - IsReuseDev
+            - !If
+              - IsReuseMain
+              - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+              - !Sub "evcs-${AWS::StackName}.reuse.${Environment}.stubs.account.gov.uk"
+            - !Sub "evcs.reuse.stubs.account.gov.uk"
+          - !If
             - IsDev01
             - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
             - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-          - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
           HostedZoneId:
             Fn::ImportValue:
               Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]
@@ -735,12 +756,18 @@ Resources:
     # checkov:skip=CKV_AWS_120: doing it later
     Properties:
       DomainName: !If 
-        - IsIPVCore
+        - IsReuse
         - !If 
+          - IsReuseDev
+          - !If
+            - IsReuseMain
+            - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+            - !Sub "evcs-${AWS::StackName}.reuse.${Environment}.stubs.account.gov.uk"
+          - !Sub "evcs.reuse.stubs.account.gov.uk"
+        - !If
           - IsDev01
           - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
           - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-        - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
       RegionalCertificateArn: !Ref EvcsStubSSLCert
       EndpointConfiguration:
         Types:
@@ -752,12 +779,18 @@ Resources:
     # checkov:skip=CKV_AWS_120: doing it later
     Properties:
       DomainName: !If 
-        - IsIPVCore
+        - IsReuse
         - !If 
+          - IsReuseDev
+          - !If
+            - IsReuseMain
+            - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+            - !Sub "evcs-${AWS::StackName}.reuse.${Environment}.stubs.account.gov.uk"
+          - !Sub "evcs.reuse.stubs.account.gov.uk"
+        - !If
           - IsDev01
           - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
           - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-        - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
       RestApiId: !Ref RestApiGateway
       Stage: !Ref RestApiGateway.Stage
     DependsOn:
@@ -769,12 +802,18 @@ Resources:
     Properties:
       Type: A
       Name: !If 
-        - IsIPVCore
+        - IsReuse
         - !If 
+          - IsReuseDev
+          - !If
+            - IsReuseMain
+            - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+            - !Sub "evcs-${AWS::StackName}.reuse.${Environment}.stubs.account.gov.uk"
+          - !Sub "evcs.reuse.stubs.account.gov.uk"
+        - !If
           - IsDev01
           - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
           - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
-        - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
       HostedZoneId:
         Fn::ImportValue:
           Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]


### PR DESCRIPTION
## Proposed changes

### What changed

Configured EVCS stub dev to be deployable to the Trust and Reuse team stub `dev` and `build` accounts.

### Why did it change

So that IPV Core and Trust and Reuse are able to share the IPV EVCS stub.

### Issue tracking

- [SPT-1450](https://govukverify.atlassian.net/browse/SPT-1450)

### Testing

The branch was manually deployed to the Trust and Reuse team stubs dev account. The API Key was obtained from API Gateway and curl was used to access the `GET /healthcheck` API. The following is a screenshot showing a successful health check response.  

<img width="1363" height="152" alt="Screenshot 2025-08-04 at 08 51 25" src="https://github.com/user-attachments/assets/d60d928e-2787-4686-a699-d9c713559639" />

[SPT-1450]: https://govukverify.atlassian.net/browse/SPT-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ