### PR TITLE
SPT-1450: No Dynatrace Secret lookups in dev

### DIFF
--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -2,27 +2,44 @@ AWSTemplateFormatVersion: "2010-09-09"
 
 Transform:
   - AWS::Serverless-2016-10-31
-  - AWS::LanguageExtensions
 Globals:
   Function:
     Environment:
       Variables:
-        AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
-        DT_CONNECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'  #pragma: allowlist secret
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn, DefaultValue: "not-used" ]  #pragma: allowlist secret
-        DT_CONNECTION_BASE_URL: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'   #pragma: allowlist secret
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn, DefaultValue: "not-used" ]  #pragma: allowlist secret
-        DT_CLUSTER_ID: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'   #pragma: allowlist secret
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn, DefaultValue: "not-used" ]  #pragma: allowlist secret
-        DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'  #pragma: allowlist secret
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn, DefaultValue: "not-used" ]  #pragma: allowlist secret
-        DT_TENANT: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'   #pragma: allowlist secret
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn, DefaultValue: "not-used" ]   #pragma: allowlist secret
+        AWS_LAMBDA_EXEC_WRAPPER: !If
+          - IsDevelopment
+          - !Ref "AWS::NoValue"
+          - /opt/dynatrace
+        DT_CONNECTION_AUTH_TOKEN: !If
+          - IsDevelopment
+          - !Ref "AWS::NoValue"
+          - !Sub
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'  #pragma: allowlist secret
+            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+        DT_CONNECTION_BASE_URL: !If
+          - IsDevelopment
+          - !Ref "AWS::NoValue"
+          - !Sub
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'   #pragma: allowlist secret
+            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+        DT_CLUSTER_ID: !If
+          - IsDevelopment
+          - !Ref "AWS::NoValue"
+          - !Sub
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'   #pragma: allowlist secret
+            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+        DT_LOG_COLLECTION_AUTH_TOKEN: !If
+          - IsDevelopment
+          - !Ref "AWS::NoValue"
+          - !Sub
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'  #pragma: allowlist secret
+            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+        DT_TENANT: !If
+          - IsDevelopment
+          - !Ref "AWS::NoValue"
+          - !Sub
+            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'   #pragma: allowlist secret
+            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]   #pragma: allowlist secret
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
     Timeout: 30
     PermissionsBoundary: !If


### PR DESCRIPTION
## Proposed changes

### What changed

- Add condition to not do Dynatrace secret lookup in dev environments.

### Why did it change

Deployments are failing in Trust and Reuse dev environment due to failing lookups.

### Issue tracking

- [SPT-1450](https://govukverify.atlassian.net/browse/SPT-1450)


[SPT-1450]: https://govukverify.atlassian.net/browse/SPT-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ