### PR TITLE
SPT-1450: Add dev lookup values

### DIFF
--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -117,6 +117,9 @@ Conditions:
 
 Mappings:
   EnvironmentConfiguration:
+    dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables  #pragma: allowlist secret
+      dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables  #pragma: allowlist secret
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1


### PR DESCRIPTION
## Proposed changes

### What changed

- Add dev lookup values (even though they won't be used) this prevents parse errors when starting a SAM deploy

### Why did it change

Still failing in Reuse dev environment.

### Issue tracking
- [SPT-1450](https://govukverify.atlassian.net/browse/SPT-1450)



[SPT-1450]: https://govukverify.atlassian.net/browse/SPT-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ