### PR TITLE
Revert "BAU: Bump docker/login-action from 3.4.0 to 3.5.0"

### DIFF
--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -47,7 +47,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -47,7 +47,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -47,7 +47,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/core-passport-stub.yml
+++ b/.github/workflows/core-passport-stub.yml
@@ -46,7 +46,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-address-stub.yml
+++ b/.github/workflows/cri-address-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-bav-stub.yml
+++ b/.github/workflows/cri-bav-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-claimed-identity-stub.yml
+++ b/.github/workflows/cri-claimed-identity-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-dcmaw-stub.yml
+++ b/.github/workflows/cri-dcmaw-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-driving-licence-stub.yml
+++ b/.github/workflows/cri-driving-licence-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-dwp-kbv-stub.yml
+++ b/.github/workflows/cri-dwp-kbv-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-experian-kbv-stub.yml
+++ b/.github/workflows/cri-experian-kbv-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-f2f-stub.yml
+++ b/.github/workflows/cri-f2f-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-fraud-stub.yml
+++ b/.github/workflows/cri-fraud-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-hmrc-kbv-stub.yml
+++ b/.github/workflows/cri-hmrc-kbv-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-nino-stub.yml
+++ b/.github/workflows/cri-nino-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/cri-passport-stub.yml
+++ b/.github/workflows/cri-passport-stub.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367

--- a/.github/workflows/deploy-orch-stub.yml
+++ b/.github/workflows/deploy-orch-stub.yml
@@ -34,7 +34,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367


### PR DESCRIPTION
Reverts govuk-one-login/ipv-stubs#1606