### PR TITLE
BAU: Add gradle setup to cimit workflow

### DIFF
--- a/.github/workflows/cimit-stub.yml
+++ b/.github/workflows/cimit-stub.yml
@@ -28,6 +28,12 @@ jobs:
           java-version: '21'
           distribution: 'corretto'
           cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        with:
+          gradle-version: "8.13"
+
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@v4.3.1
         with:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added gradle setup to cimit workflow as it failing due to incompatibility between gradle 9.x and aws-sam-cli.
This issue is very likely caused by ubuntu-latest release which introduced gradle v9.x as default

### Why did it change

To resolve issues related to cimit workflow

###
Issue: https://github.com/govuk-one-login/ipv-stubs/actions/runs/16908101705/job/47902757467
Latest ubuntu release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250804.2

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated
