### PR TITLE
PYIC-8381: add ttl to stored identity record

### DIFF
--- a/di-ipv-evcs-stub/lambdas/src/common/utils.ts
+++ b/di-ipv-evcs-stub/lambdas/src/common/utils.ts
@@ -1,4 +1,14 @@
+import { getSsmParameter } from "./ssmParameter";
+import { config } from "./config";
+
 export function getErrorMessage(error: unknown) {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+export async function getTtl(): Promise<number> {
+  const evcsTtlSeconds: number = parseInt(
+    await getSsmParameter(config.evcsParamBasePath + "evcsStubTtl"),
+  );
+  return Math.floor(Date.now() / 1000) + evcsTtlSeconds;
 }

--- a/di-ipv-evcs-stub/lambdas/src/domain/serviceResponse.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/serviceResponse.ts
@@ -16,5 +16,5 @@ export interface GetResponse {
 }
 
 export interface GetStoredIdentity {
-  storedIdentities: Omit<EvcsStoredIdentityItem, "metadata">[];
+  storedIdentities: Omit<EvcsStoredIdentityItem, "metadata" | "ttl">[];
 }

--- a/di-ipv-evcs-stub/lambdas/src/model/storedIdentityItem.ts
+++ b/di-ipv-evcs-stub/lambdas/src/model/storedIdentityItem.ts
@@ -5,4 +5,5 @@ export default interface EvcsStoredIdentityItem {
   levelOfConfidence: string;
   isValid: boolean;
   metadata?: object;
+  ttl: number;
 }

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsManagementService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsManagementService.ts
@@ -8,6 +8,7 @@ import { createPutItem } from "./evcsService";
 import EvcsStoredIdentityItem from "../model/storedIdentityItem";
 import { StatusCodes } from "../domain/enums";
 import { StoredIdentityRecordType } from "../domain/enums/StoredIdentityRecordType";
+import { getTtl } from "../common/utils";
 
 export interface CreateStoredIdentityRequest {
   userId: string;
@@ -63,6 +64,7 @@ export async function processCreateStoredIdentity(
       levelOfConfidence: createSiRequest.si.vot,
       metadata: createSiRequest.si.metadata,
       isValid: true,
+      ttl: await getTtl(),
     };
     const putItem = createPutItem(evcsStoredIdentityItem);
 

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -14,7 +14,7 @@ import { StatusCodes, VCProvenance, VcState } from "../domain/enums";
 import EvcsVcItem from "../model/evcsVcItem";
 
 import { config } from "../common/config";
-import { getSsmParameter } from "../common/ssmParameter";
+import { getTtl } from "../common/utils";
 import { v4 as uuid } from "uuid";
 import {
   EvcsItemForUpdate,
@@ -367,13 +367,6 @@ async function updateUserVC(evcsVcItem: EvcsItemForUpdate) {
   const updateItemInput: UpdateItemInput = createUpdateItemInput(evcsVcItem);
   updateItemInput.ReturnValues = "ALL_NEW";
   return dynamoClient.updateItem(updateItemInput);
-}
-
-async function getTtl(): Promise<number> {
-  const evcsTtlSeconds: number = parseInt(
-    await getSsmParameter(config.evcsParamBasePath + "evcsStubTtl"),
-  );
-  return Math.floor(Date.now() / 1000) + evcsTtlSeconds;
 }
 
 function getSignatureFromJwt(jwt: string): string {

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -84,10 +84,10 @@ export async function processPostIdentityRequest(
 
   try {
     const transactItems: TransactWriteItem[] = [];
+    const ttl = await getTtl();
 
     if ("vcs" in request) {
       const newUserVcs = request.vcs;
-      const ttl = await getTtl();
 
       // Read user's existing VCs
       const getResponse = await processGetUserVCsRequest(userId, [
@@ -163,6 +163,7 @@ export async function processPostIdentityRequest(
         levelOfConfidence: request.si.vot,
         metadata: request.si.metadata,
         isValid: true,
+        ttl,
       };
       transactItems.push({ Put: createPutItem(storedIdentityItem) });
     }

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsManagementService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsManagementService.test.ts
@@ -15,12 +15,26 @@ import {
 } from "../../src/services/evcsManagementService";
 import "aws-sdk-client-mock-jest";
 import { StatusCodes } from "../../src/domain/enums";
+import { getSsmParameter } from "../../src/common/ssmParameter";
 
 const dbMock = mockClient(DynamoDB);
+
+jest.mock("../../src/common/ssmParameter", () => {
+  const module = jest.requireActual("../../src/common/ssmParameter");
+
+  return {
+    __esModule: true,
+    ...module,
+    getSsmParameter: jest.fn(),
+  };
+});
 
 const TEST_USER_ID = "test-user-id";
 const TEST_VC_STRING =
   "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ"; // pragma: allowlist secret
+
+const MOCK_TTL_CONFIG = "3600";
+const MOCK_TTL = Math.floor(Date.now() / 1000) + parseInt(MOCK_TTL_CONFIG);
 
 const GPG45_SI_RECORD: EvcsStoredIdentityItem = {
   storedIdentity: TEST_VC_STRING,
@@ -28,6 +42,7 @@ const GPG45_SI_RECORD: EvcsStoredIdentityItem = {
   recordType: StoredIdentityRecordType.GPG45,
   levelOfConfidence: Vot.P2,
   isValid: true,
+  ttl: MOCK_TTL,
 };
 
 const TEST_CREATE_SI_REQUEST = {
@@ -40,13 +55,14 @@ const TEST_CREATE_SI_REQUEST = {
 
 beforeEach(() => {
   dbMock.reset();
+  jest.mocked(getSsmParameter).mockResolvedValue(MOCK_TTL_CONFIG);
 });
 
 describe("processGetStoredIdentity", () => {
   it("should return stored identities with a 200 response for user", async () => {
     // Arrange
-    const expectedResponse = [GPG45_SI_RECORD];
-    dbMock.on(QueryCommand).resolves(generateQueryResponse(expectedResponse));
+    const expectedResponse = [{ ...GPG45_SI_RECORD, ttl: undefined }];
+    dbMock.on(QueryCommand).resolves(generateQueryResponse([GPG45_SI_RECORD]));
 
     // Act
     const res = await processGetStoredIdentity(TEST_USER_ID);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- add ttl to stored identity record
- updated unit tests

### Why did it change
There is a `ttl` on the sis record schema that I missed [here](https://govukverify.atlassian.net/browse/SPT-1455). We also need to return a boolean `expired` property from the stub SIS `/user-identity` endpoint which I plan to calculate based off the ttl on the save record.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ