### PR TITLE
PYIC-8381: output the DynamoDB KMS key and table from evcs stub cloud…

### DIFF
--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -49,23 +49,15 @@ Mappings:
       Name: ReusePublicHostedZoneId
 
 Conditions:
-  IsIPVCore:
-    Fn::Or:
-      - Condition: IsDev01
-      - Condition: IsDev02
-
-  IsDev01: 
+  IsDev01:
     Fn::Equals: [ !Ref "AWS::AccountId", "130355686670"]
-
-  IsDev02:
-    Fn::Equals: [ !Ref "AWS::AccountId", "175872367215"]
 
   IsReuse:
     Fn::Or:
       - Condition: IsReuseDev
       - Condition: IsReuseBuild
 
-  IsReuseDev: 
+  IsReuseDev:
     Fn::Equals: [ !Ref "AWS::AccountId", "110869144943"]
 
   IsReuseBuild:
@@ -73,7 +65,7 @@ Conditions:
 
   IsReuseMain:
     Fn::Equals: [ !Ref "AWS::StackName", "evcs-stub"]
-      
+
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -718,9 +710,9 @@ Resources:
   EvcsStubSSLCert:
     Type: AWS::CertificateManager::Certificate
     Properties:
-      DomainName: !If 
+      DomainName: !If
         - IsReuse
-        - !If 
+        - !If
           - IsReuseDev
           - !If
             - IsReuseMain
@@ -732,9 +724,9 @@ Resources:
           - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
           - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
       DomainValidationOptions:
-        - DomainName: !If 
+        - DomainName: !If
           - IsReuse
-          - !If 
+          - !If
             - IsReuseDev
             - !If
               - IsReuseMain
@@ -755,9 +747,9 @@ Resources:
     Type: AWS::ApiGateway::DomainName
     # checkov:skip=CKV_AWS_120: doing it later
     Properties:
-      DomainName: !If 
+      DomainName: !If
         - IsReuse
-        - !If 
+        - !If
           - IsReuseDev
           - !If
             - IsReuseMain
@@ -778,9 +770,9 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     # checkov:skip=CKV_AWS_120: doing it later
     Properties:
-      DomainName: !If 
+      DomainName: !If
         - IsReuse
-        - !If 
+        - !If
           - IsReuseDev
           - !If
             - IsReuseMain
@@ -801,9 +793,9 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       Type: A
-      Name: !If 
+      Name: !If
         - IsReuse
-        - !If 
+        - !If
           - IsReuseDev
           - !If
             - IsReuseMain
@@ -872,3 +864,15 @@ Outputs:
     Export:
       Name: !Sub "EvcsRestApiGatewayID-${Environment}"
     Value: !Ref RestApiGateway
+
+  EvcsDynamoDBKmsKey:
+    Description: DynamoDB KMS Key
+    Export:
+      Name: !Sub "EvcsDynamoDBKmsKey-${Environment}"
+    Value: !Ref DynamoDBKmsKey
+
+  EvcsStoredIdentityRecordsTable:
+    Description: EVCS Stored Identity Records table
+    Export:
+      Name: !Sub "EvcsStoredIdentityRecordsTable-${Environment}"
+    Value: !Ref EvcsStoredIdentityStoreTable

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -924,3 +924,15 @@ Outputs:
     Export:
       Name: !Sub "EvcsRestApiGatewayID-${Environment}"
     Value: !Ref RestApiGateway
+
+  EvcsDynamoDBKmsKey:
+    Description: DynamoDB KMS Key
+    Export:
+      Name: !Sub "EvcsDynamoDBKmsKey-${Environment}"
+    Value: !Ref DynamoDBKmsKey
+
+  EvcsStoredIdentityRecordsTable:
+    Description: EVCS Stored Identity Records table
+    Export:
+      Name: !Sub "EvcsStoredIdentityRecordsTable-${Environment}"
+    Value: !Ref EvcsStoredIdentityStoreTable


### PR DESCRIPTION
…formation

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- output the dynamoDB kms key and SI record table from evcs-stub cloudformation

### Why did it change

- so we can access these in the sis-stub cloudformation (we'll be pulling from the SI record table defined in the evcs-stub cloudformation)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)



[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ