### PR TITLE
PYIC-8626: Remove obsolete NINO stub data

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -210,7 +210,7 @@
         "filename": "di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json",
         "hashed_secret": "51da07e5aabf9c96745c4dc5aa30306162fa13db",
         "is_verified": false,
-        "line_number": 429
+        "line_number": 405
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache": [
@@ -368,5 +368,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-10T14:42:56Z"
+  "generated_at": "2025-08-29T16:46:59Z"
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -398,30 +398,6 @@
       }
     },
     {
-      "criType": "National Insurance Number (Stub)",
-      "label": "Passed National Insurance Number - no scope",
-      "payload": {
-        "type": "IdentityCheck",
-        "checkDetails": [
-          {
-            "checkMethod": "data"
-          }
-        ]
-      }
-    },
-    {
-      "criType": "National Insurance Number (Stub)",
-      "label": "Failed National Insurance Number - no scope",
-      "payload": {
-        "type": "IdentityCheck",
-        "failedCheckDetails": [
-          {
-            "checkMethod": "data"
-          }
-        ]
-      }
-    },
-    {
       "criType": "Bank account verification (Stub)",
       "label": "Passed Bank account verification (Stub)",
       "payload": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove record check nino stub data

### Why did it change

The real CRI is removing this functionality

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8626](https://govukverify.atlassian.net/browse/PYIC-8626)



[PYIC-8626]: https://govukverify.atlassian.net/browse/PYIC-8626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ