### PR TITLE
PYIC-8381: update SIS isValid logic so that it is invalid when

### DIFF
--- a/di-ipv-sis-stub/lambdas/src/domain/userIdentity.ts
+++ b/di-ipv-sis-stub/lambdas/src/domain/userIdentity.ts
@@ -6,3 +6,8 @@ export interface UserIdentity {
   kidValid: true;
   signatureValid: true;
 }
+
+export interface UserIdentityRequestBody {
+  govukSigninJourneyId: string;
+  vtr: string[];
+}

--- a/di-ipv-sis-stub/lambdas/src/handlers/sisHandler.ts
+++ b/di-ipv-sis-stub/lambdas/src/handlers/sisHandler.ts
@@ -14,6 +14,7 @@ import {
   buildUnauthorisedResponse,
 } from "../domain/errorResponse";
 import { getUserIdFromBearerToken } from "../utils/tokenVerifier";
+import { UserIdentityRequestBody } from "../domain/userIdentity";
 
 const AUTHORISATION_HEADER = "Authorization";
 
@@ -34,9 +35,9 @@ export const postUserIdentityHandler = async (
       return buildApiResponse(400, buildBadRequestResponse("Missing user id"));
     }
 
-    validateUserIdentityRequestBody(event);
+    const validatedRequest = validateUserIdentityRequestBody(event);
 
-    const userIdentity = await getUserIdentity(userId);
+    const userIdentity = await getUserIdentity(userId, validatedRequest.vtr);
 
     if (!userIdentity) {
       return buildApiResponse(404, buildNotFoundResponse());
@@ -61,7 +62,9 @@ export const postUserIdentityHandler = async (
   }
 };
 
-const validateUserIdentityRequestBody = (event: APIGatewayProxyEvent) => {
+const validateUserIdentityRequestBody = (
+  event: APIGatewayProxyEvent,
+): UserIdentityRequestBody => {
   console.info("---Parsing user identity request body---");
 
   if (!event.body) {
@@ -79,4 +82,6 @@ const validateUserIdentityRequestBody = (event: APIGatewayProxyEvent) => {
       "Missing govukSigninJourneyId in request body",
     );
   }
+
+  return requestBody;
 };

--- a/di-ipv-sis-stub/lambdas/src/services/sisService.ts
+++ b/di-ipv-sis-stub/lambdas/src/services/sisService.ts
@@ -8,6 +8,7 @@ const GPG45_RECORD_TYPE = "idrec:gpg45";
 
 export const getUserIdentity = async (
   userId: string,
+  requestedVtrs: string[],
 ): Promise<UserIdentity | null> => {
   console.info("Getting user's SIS record");
 
@@ -33,7 +34,7 @@ export const getUserIdentity = async (
     return {
       content: storedIdentity,
       vot: levelOfConfidence,
-      isValid,
+      isValid: isValid && requestedVtrs.includes(levelOfConfidence),
       // defaulting to false as the ttl is set to the default
       // retention of VCs which is 120 years
       expired: false,

--- a/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
@@ -9,6 +9,8 @@ const TEST_USER_ID = "userId";
 const TEST_SI_JWT =
   "eyJraWQiOiJ0ZXN0LXNpZ25pbmcta2V5IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJodHRwczovL3JldXNlLWlkZW50aXR5LmJ1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiZWFlMDFhYzI5MGE5ODRkMGVhN2MzM2NjNDVlMzZmMTIiLCJuYmYiOjE3NTA2ODIwMTgsImNyZWRlbnRpYWxzIjpbIk43UHhoZmtGa215VFFGS3lBWE15U19INk51Ri13RHpFa3RiX2RWdXJ1bFNSTU1YaG54aGJSMnJ4czlUYy1LUUIwaVhiMV85YUJJOFhDeTJBYkdRdkZRIiwiUzROSlBjaWltYmZ4MDhqczltOThoc3JLTDRiSkh0QlF5S0d0cmRJeklmWW1CUGpyVTlwYXpfdV8xaENySFo4aWp5UW81UlBtUWxNUC1fYzVldXZaSHciLCJBOU9IdUtJOE41aDRDNDU3UTRxdE52a1NGS2ZGZVZNNHNFR3dxUlBjU0hpUXlsemh4UnlxMDBlMURVUUxtU2RpZTlYSWswQ2ZpUVNBX3I3LW1tQ2JBdyIsInk0NHYwcEVBODh6dURoREZEQ0RjUGduOTZwOWJTRm9qeHZQQTFCeEdYTnhEMG5QelFONk1SaG1PWXBTUXg4TW92XzNLWUF4bmZ5aXdSemVBclhKa3FBIl0sImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkubG9jYWwuYWNjb3VudC5nb3YudWsiLCJjbGFpbXMiOnsiaHR0cHM6Ly92b2NhYi5hY2NvdW50Lmdvdi51ay92MS9jb3JlSWRlbnRpdHkiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NjUtMDctMDgifV19LCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL3YxL2FkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwiYnVpbGRpbmdOYW1lIjoiIiwiYnVpbGRpbmdOdW1iZXIiOiI4IiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJzdWJCdWlsZGluZ05hbWUiOiIiLCJ1cHJuIjoxMDAxMjAwMTIwNzcsInZhbGlkRnJvbSI6IjEwMDAtMDEtMDEifV0sImh0dHBzOi8vdm9jYWIuYWNjb3VudC5nb3YudWsvdjEvcGFzc3BvcnQiOlt7ImRvY3VtZW50TnVtYmVyIjoiMzIxNjU0OTg3IiwiZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJpY2FvSXNzdWVyQ29kZSI6IkdCUiJ9XX0sInZvdCI6IlAyIiwiaWF0IjoxNzUwNjgyMDE4fQ.nrbiwaOcvWM92TTAlORzerjjrrCuYD9fcxwEoXbf71J3YZUnwNW0KGUN5jaEvOysG0YWTXSLl_W4sN-Krf7PfQ"; // pragma: allowlist secret
 
+const TEST_VTRS = ["P2"];
+
 const MOCK_USER_IDENTITY = {
   userId: TEST_USER_ID,
   isValid: true,
@@ -28,7 +30,7 @@ describe("getUserIdentity", () => {
     });
 
     // Act
-    const res = await getUserIdentity(TEST_USER_ID);
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
     expect(res).toEqual({
@@ -49,7 +51,7 @@ describe("getUserIdentity", () => {
     });
 
     // Act
-    const res = await getUserIdentity(TEST_USER_ID);
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
     expect(res).toEqual({
@@ -67,9 +69,29 @@ describe("getUserIdentity", () => {
     });
 
     // Act
-    const res = await getUserIdentity(TEST_USER_ID);
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
     expect(res).toBeNull();
+  });
+
+  it("should return not valid if level of confidence on sis record does not match any of the requested VTRs", async () => {
+    // Arrange
+    dbMock.on(QueryCommand).resolves({
+      Items: [marshall({ ...MOCK_USER_IDENTITY, levelOfConfidence: "P1" })],
+    });
+
+    // Act
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
+
+    // Assert
+    expect(res).toEqual({
+      content: MOCK_USER_IDENTITY.storedIdentity,
+      vot: "P1",
+      expired: false,
+      kidValid: true,
+      signatureValid: true,
+      isValid: false,
+    });
   });
 });


### PR DESCRIPTION
- SIS returns isValid = false
- returned levelOfConfidence is not included in the requested VTRs

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
update isValid logic for SIS API

### Why did it change

The requested VTRs passed into the request body should be used to inform whether the SIS stub returns isValid=true

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)

## Checklists
<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ