### PR TITLE
PYIC-8381: update sis isValid and vot logic

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -76,3 +76,35 @@ jobs:
       - name: Test
         working-directory: ./di-ipv-dcmaw-async-stub/lambdas
         run: npm run test
+  build-sis-stub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install
+        working-directory: ./di-ipv-sis-stub/lambdas
+        run: npm ci
+      - name: Build
+        working-directory: ./di-ipv-sis-stub/lambdas
+        run: npm run build
+      - name: Test
+        working-directory: ./di-ipv-sis-stub/lambdas
+        run: npm run test
+  build-ais-stub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install
+        working-directory: ./di-ipv-ais-stub/lambdas
+        run: npm ci
+      - name: Build
+        working-directory: ./di-ipv-ais-stub/lambdas
+        run: npm run build
+      - name: Test
+        working-directory: ./di-ipv-ais-stub/lambdas
+        run: npm run test

--- a/di-ipv-sis-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-sis-stub/core-dev-deploy/template.yaml
@@ -203,9 +203,7 @@ Resources:
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/sis-external.yaml"
-      ApiKeySourceType: HEADER #pragma: allowlist secret
       Auth:
-        ApiKeyRequired: true #pragma: allowlist secret
         UsagePlan:
           CreateUsagePlan: PER_API
           UsagePlanName: "SIS Usage Plan"

--- a/di-ipv-sis-stub/deploy/template.yaml
+++ b/di-ipv-sis-stub/deploy/template.yaml
@@ -249,9 +249,7 @@ Resources:
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/sis-external.yaml"
-      ApiKeySourceType: HEADER #pragma: allowlist secret
       Auth:
-        ApiKeyRequired: true #pragma: allowlist secret
         UsagePlan:
           CreateUsagePlan: PER_API
           UsagePlanName: "SIS Usage Plan"

--- a/di-ipv-sis-stub/lambdas/src/domain/userIdentity.ts
+++ b/di-ipv-sis-stub/lambdas/src/domain/userIdentity.ts
@@ -6,3 +6,8 @@ export interface UserIdentity {
   kidValid: true;
   signatureValid: true;
 }
+
+export interface UserIdentityRequestBody {
+  govukSigninJourneyId: string;
+  vtr: string[];
+}

--- a/di-ipv-sis-stub/lambdas/src/handlers/sisHandler.ts
+++ b/di-ipv-sis-stub/lambdas/src/handlers/sisHandler.ts
@@ -14,6 +14,7 @@ import {
   buildUnauthorisedResponse,
 } from "../domain/errorResponse";
 import { getUserIdFromBearerToken } from "../utils/tokenVerifier";
+import { UserIdentityRequestBody } from "../domain/userIdentity";
 
 const AUTHORISATION_HEADER = "Authorization";
 
@@ -34,9 +35,9 @@ export const postUserIdentityHandler = async (
       return buildApiResponse(400, buildBadRequestResponse("Missing user id"));
     }
 
-    validateUserIdentityRequestBody(event);
+    const validatedRequest = validateUserIdentityRequestBody(event);
 
-    const userIdentity = await getUserIdentity(userId);
+    const userIdentity = await getUserIdentity(userId, validatedRequest.vtr);
 
     if (!userIdentity) {
       return buildApiResponse(404, buildNotFoundResponse());
@@ -61,7 +62,9 @@ export const postUserIdentityHandler = async (
   }
 };
 
-const validateUserIdentityRequestBody = (event: APIGatewayProxyEvent) => {
+const validateUserIdentityRequestBody = (
+  event: APIGatewayProxyEvent,
+): UserIdentityRequestBody => {
   console.info("---Parsing user identity request body---");
 
   if (!event.body) {
@@ -79,4 +82,6 @@ const validateUserIdentityRequestBody = (event: APIGatewayProxyEvent) => {
       "Missing govukSigninJourneyId in request body",
     );
   }
+
+  return requestBody;
 };

--- a/di-ipv-sis-stub/lambdas/src/services/sisService.ts
+++ b/di-ipv-sis-stub/lambdas/src/services/sisService.ts
@@ -31,24 +31,34 @@ export const getUserIdentity = async (
 
   const parsedResponse = response.Items.map((siItem) => {
     const { storedIdentity, levelOfConfidence, isValid } = unmarshall(siItem);
-    const matchedProfile = levelOfConfidence
-      ? getVotForUserIdentity(levelOfConfidence, requestedVtrs)
-      : undefined;
 
     return {
       content: storedIdentity,
-      vot: matchedProfile,
-      isValid: !!(isValid && matchedProfile && matchedProfile != "P0"),
-      // defaulting to false as the ttl is set to the default
-      // retention of VCs which is 120 years
-      expired: false,
-      // defaulting to true for below as we don't use these
-      kidValid: true,
-      signatureValid: true,
+      vot: levelOfConfidence,
+      isValid,
     };
   });
 
-  return validateUserIdentityResponse(parsedResponse[0]);
+  const validatedResponse = validateUserIdentityResponse(parsedResponse[0]);
+  const matchedProfile = validatedResponse.vot
+    ? getVotForUserIdentity(validatedResponse.vot, requestedVtrs)
+    : undefined;
+
+  return {
+    ...validatedResponse,
+    vot: matchedProfile,
+    isValid: !!(
+      validatedResponse.isValid &&
+      matchedProfile &&
+      matchedProfile != "P0"
+    ),
+    // defaulting to false as the ttl is set to the default
+    // retention of VCs which is 120 years
+    expired: false,
+    // defaulting to true for below as we don't use these
+    kidValid: true,
+    signatureValid: true,
+  };
 };
 
 /* eslint-disable  @typescript-eslint/no-explicit-any */

--- a/di-ipv-sis-stub/lambdas/src/utils/votHelper.ts
+++ b/di-ipv-sis-stub/lambdas/src/utils/votHelper.ts
@@ -1,0 +1,28 @@
+const VOTS_BY_ASCENDING_STRENGTH = ["P0", "P1", "P2", "P3", "P4"];
+
+export const getVotForUserIdentity = (
+  sisVot: string,
+  requestedVtrs: string[],
+) => {
+  const sisVotIndex = VOTS_BY_ASCENDING_STRENGTH.indexOf(sisVot);
+
+  if (sisVotIndex < 0) {
+    throw new Error("Invalid level of confidence from SIS record");
+  }
+
+  const validProfiles = requestedVtrs.filter((vot) => {
+    const idx = VOTS_BY_ASCENDING_STRENGTH.indexOf(vot);
+    return idx >= 0 && idx <= sisVotIndex;
+  });
+
+  if (validProfiles.length === 0) {
+    return "P0";
+  }
+
+  validProfiles.sort(
+    (a, b) =>
+      VOTS_BY_ASCENDING_STRENGTH.indexOf(b) -
+      VOTS_BY_ASCENDING_STRENGTH.indexOf(a),
+  );
+  return validProfiles[0];
+};

--- a/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
@@ -30,7 +30,7 @@ describe("getUserIdentity", () => {
     });
 
     // Act
-    const res = await getUserIdentity(TEST_USER_ID);
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
     expect(res).toEqual({
@@ -51,7 +51,7 @@ describe("getUserIdentity", () => {
     });
 
     // Act
-    const res = await getUserIdentity(TEST_USER_ID);
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
     expect(res).toEqual({
@@ -70,7 +70,7 @@ describe("getUserIdentity", () => {
     });
 
     // Act
-    const res = await getUserIdentity(TEST_USER_ID);
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
     expect(res).toBeNull();

--- a/di-ipv-sis-stub/lambdas/test/utils/votHelper.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/utils/votHelper.test.ts
@@ -1,0 +1,46 @@
+import { getVotForUserIdentity } from "../../src/utils/votHelper";
+
+describe("getVotForUserIdentity", () => {
+  it.each([
+    {
+      case: "return the matched vot in requestedVtr",
+      sisVot: "P2",
+      requestedVtrs: ["P2", "P1"],
+      expectedVtr: "P2",
+    },
+    {
+      case: "return P0 if sisVot does not meet any of the requestedVtr",
+      sisVot: "P1",
+      requestedVtrs: ["P2", "P3"],
+      expectedVtr: "P0",
+    },
+    {
+      case: "return highest vot within requestedVtr if no match",
+      sisVot: "P3",
+      requestedVtrs: ["P2", "P1"],
+      expectedVtr: "P2",
+    },
+    {
+      case: "return highest vot within requestedVtr where there are VTRs higher and lower than sisVot",
+      sisVot: "P2",
+      requestedVtrs: ["P3", "P1"],
+      expectedVtr: "P1",
+    },
+  ])(
+    "should return $expectedVtr when $case",
+    ({ sisVot, requestedVtrs, expectedVtr }) => {
+      // Act
+      const res = getVotForUserIdentity(sisVot, requestedVtrs);
+
+      // Assert
+      expect(res).toBe(expectedVtr);
+    },
+  );
+
+  it("should throw if sisVot is invalid", () => {
+    // Act/Assert
+    expect(() => getVotForUserIdentity("notValidVot", ["P2"])).toThrow(
+      new Error("Invalid level of confidence from SIS record"),
+    );
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- update SIS isValid logic so that it is invalid when
    - SIS returns isValid = false
    - returned levelOfConfidence is not included in the requested VTRs
    - matched profile is P0
- update logic for returned vot and isValid
    - vot should be the strongest matched profile from the requested VTRs
    - isValid should be true when a profile has been matched and is not P0
- remove requirement for api key
- update pre-merge workflow to run unit tests for sis and ais stubs


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ