### PR TITLE
PYIC-8381: update returned vot so that if isValid=false, vot=P0

### DIFF
--- a/di-ipv-sis-stub/lambdas/src/services/sisService.ts
+++ b/di-ipv-sis-stub/lambdas/src/services/sisService.ts
@@ -41,7 +41,11 @@ export const getUserIdentity = async (
 
   const validatedResponse = validateUserIdentityResponse(parsedResponse[0]);
   const matchedProfile = validatedResponse.vot
-    ? getVotForUserIdentity(validatedResponse.vot, requestedVtrs)
+    ? getVotForUserIdentity(
+        validatedResponse.vot,
+        requestedVtrs,
+        validatedResponse.isValid,
+      )
     : undefined;
 
   return {

--- a/di-ipv-sis-stub/lambdas/src/utils/votHelper.ts
+++ b/di-ipv-sis-stub/lambdas/src/utils/votHelper.ts
@@ -3,7 +3,12 @@ const VOTS_BY_ASCENDING_STRENGTH = ["P0", "P1", "P2", "P3", "P4"];
 export const getVotForUserIdentity = (
   sisVot: string,
   requestedVtrs: string[],
+  isSisRecordValid: boolean,
 ) => {
+  if (!isSisRecordValid) {
+    return "P0";
+  }
+
   const sisVotIndex = VOTS_BY_ASCENDING_STRENGTH.indexOf(sisVot);
 
   if (sisVotIndex < 0) {

--- a/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
@@ -43,6 +43,26 @@ describe("getUserIdentity", () => {
     });
   });
 
+  it("should return P0 if isValid is false but levelOfConfidence meets requested vtr", async () => {
+    // Arrange
+    dbMock.on(QueryCommand).resolves({
+      Items: [marshall({ ...MOCK_USER_IDENTITY, isValid: false })],
+    });
+
+    // Act
+    const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
+
+    // Assert
+    expect(res).toEqual({
+      content: MOCK_USER_IDENTITY.storedIdentity,
+      vot: "P0",
+      expired: false,
+      isValid: false,
+      signatureValid: true,
+      kidValid: true,
+    });
+  });
+
   it("should return malformed JSON if required properties are missing and isValid=false", async () => {
     // Arrange
     const malformedJson = { isValid: true };

--- a/di-ipv-sis-stub/lambdas/test/utils/votHelper.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/utils/votHelper.test.ts
@@ -6,31 +6,56 @@ describe("getVotForUserIdentity", () => {
       case: "return the matched vot in requestedVtr",
       sisVot: "P2",
       requestedVtrs: ["P2", "P1"],
+      isValid: true,
       expectedVtr: "P2",
     },
     {
       case: "return P0 if sisVot does not meet any of the requestedVtr",
       sisVot: "P1",
       requestedVtrs: ["P2", "P3"],
+      isValid: true,
       expectedVtr: "P0",
     },
     {
       case: "return highest vot within requestedVtr if no match",
       sisVot: "P3",
       requestedVtrs: ["P2", "P1"],
+      isValid: true,
+      expectedVtr: "P2",
+    },
+    {
+      case: "return single requesterVtr if sisVot is stronger",
+      sisVot: "P3",
+      requestedVtrs: ["P2"],
+      isValid: true,
       expectedVtr: "P2",
     },
     {
       case: "return highest vot within requestedVtr where there are VTRs higher and lower than sisVot",
       sisVot: "P2",
       requestedVtrs: ["P3", "P1"],
+      isValid: true,
       expectedVtr: "P1",
+    },
+    {
+      case: "return sisVot if it matches lowest strength requested vtr",
+      sisVot: "P1",
+      requestedVtrs: ["P3", "P1"],
+      isValid: true,
+      expectedVtr: "P1",
+    },
+    {
+      case: "return P0 if SIS record is invalid",
+      sisVot: "P2",
+      requestedVtrs: ["P3", "P1"],
+      isValid: false,
+      expectedVtr: "P0",
     },
   ])(
     "should return $expectedVtr when $case",
-    ({ sisVot, requestedVtrs, expectedVtr }) => {
+    ({ sisVot, requestedVtrs, expectedVtr, isValid }) => {
       // Act
-      const res = getVotForUserIdentity(sisVot, requestedVtrs);
+      const res = getVotForUserIdentity(sisVot, requestedVtrs, isValid);
 
       // Assert
       expect(res).toBe(expectedVtr);
@@ -39,7 +64,7 @@ describe("getVotForUserIdentity", () => {
 
   it("should throw if sisVot is invalid", () => {
     // Act/Assert
-    expect(() => getVotForUserIdentity("notValidVot", ["P2"])).toThrow(
+    expect(() => getVotForUserIdentity("notValidVot", ["P2"], true)).toThrow(
       new Error("Invalid level of confidence from SIS record"),
     );
   });


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- update returned vot so that if isValid=false, vot=P0
- added more unit tests

### Why did it change

To more closely reflect the ACs defined in the real endpoint here: https://govukverify.atlassian.net/browse/SPT-1514

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ