### PR TITLE
PYIC-8381: return 401 when missing headers

### DIFF
--- a/di-ipv-sis-stub/lambdas/src/handlers/sisHandler.ts
+++ b/di-ipv-sis-stub/lambdas/src/handlers/sisHandler.ts
@@ -23,7 +23,7 @@ export const postUserIdentityHandler = async (
 ): Promise<APIGatewayProxyResultV2> => {
   console.info("------------Processing GET user-identity request------------");
   try {
-    const authHeader = event.headers[AUTHORISATION_HEADER];
+    const authHeader = event.headers && event.headers[AUTHORISATION_HEADER];
 
     if (!authHeader) {
       throw new InvalidAuthHeader("Missing auth header");

--- a/di-ipv-sis-stub/lambdas/test/handlers/sisHandler.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/handlers/sisHandler.test.ts
@@ -170,6 +170,19 @@ describe("getUserIdentityHandler", () => {
     expect(res.body).toBe(JSON.stringify(buildUnauthorisedResponse()));
   });
 
+  it("should return 401 if missing header", async () => {
+    // Arrange
+
+    // Act
+    const res = (await postUserIdentityHandler({
+      headers: undefined,
+    } as unknown as APIGatewayProxyEvent)) as APIGatewayProxyStructuredResultV2;
+
+    // Assert
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toBe(JSON.stringify(buildUnauthorisedResponse()));
+  });
+
   it("should return 401 if getUserIdFromBearerToken throws InvalidAuthHeader", async () => {
     // Arrange
     jest


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

return 401 when missing headers

### Why did it change

Found as part of QA, we should be returning 401 if we're missing the auth header and the headers is empty

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ