### PR TITLE
OJ-2861:

### DIFF
--- a/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
+++ b/di-ipv-core-stub/src/main/resources/templates/credential-issuers.mustache
@@ -58,36 +58,42 @@
         </div>
 
         {{#cris}}
-            {{#isCheckHmrcCri}}
-                <a href="{{#isCheckHmrcCri}}/evidence-request{{/isCheckHmrcCri}}?cri={{id}}" >
-                    <input class="govuk-button" data-module="govuk-button" type="button"
-                           value="{{name}}{{#isCheckHmrcCri}} - Evidence Requested{{/isCheckHmrcCri}}">
-                </a>
-            {{/isCheckHmrcCri}}
             {{#isKbvCri}}
                 <a href="{{#isKbvCri}}/evidence-request{{/isKbvCri}}?cri={{id}}" >
-                <input class="govuk-button" data-module="govuk-button" type="button"
+                <input id={{id}} class="govuk-button" data-module="govuk-button" type="button"
                        value="{{name}}{{#isKbvCri}} - Evidence Requested{{/isKbvCri}}">
                 </a>
             {{/isKbvCri}}
             {{#isAddressCri}}
                 <div class="govuk-button-group">
                     <a href="/credential-issuer?cri={{id}}&context=international_user" >
-                    <input class="govuk-button" data-module="govuk-button" type="button"
+                    <input id={{id}} class="govuk-button" data-module="govuk-button" type="button"
                         value="{{name}}{{#isAddressCri}} - International Address{{/isAddressCri}}">
                     </a>
                 </div>
                 <div class="govuk-button-group">
                     <a href="{{#isAddressCri}}/edit-postcode{{/isAddressCri}}?cri={{id}}" >
-                    <input class="govuk-button" data-module="govuk-button" type="button"
+                    <input id={{id}} class="govuk-button" data-module="govuk-button" type="button"
                         value="{{name}}{{#isAddressCri}} - PostCode{{/isAddressCri}}">
                     </a>
                 </div>
             {{/isAddressCri}}
+            {{#isCheckHmrcCri}}
+            
+            {{!-- HMRC Check CRI with default evidence request parameters --}}
+            <div class="govuk-button-group">
+                <a href="/credential-issuer?cri={{id}}&evidence_request=gpg45&score=2&verification_score=2">
+                <input id={{id}} class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
+            </div>
+            {{/isCheckHmrcCri}}
+            
+            {{^isCheckHmrcCri}}
             <div class="govuk-button-group">
                 <a href="/credential-issuer?cri={{id}}">
-                <input class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
+                {{!-- Default button requiring only cri=id for all other CRIs i.e (except HMRC Check) see above --}}
+                <input id={{id}} class="govuk-button" data-module="govuk-button" type="button" value="{{name}}"></a>
             </div>
+            {{/isCheckHmrcCri}}
         {{/cris}}
     </main>
 </div>


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-2861

Remove journey distinction i.e. record_check / identity_check have just one button option

### What changed

Check HMRC CRI (NINo) was built to issue the relevant VC based on whether it was invoked to conduct a record check or an identity check.


Given that HMRC KBV is NOT going live, the Check HMRC CRI will only be used for identity checking. 

### Why did it change

Check HMRC CRI will only be used for identity checking, by the default the stub will include `evidenceRequested`
and therefore would have one button as shown below

<img width="613" height="655" alt="image" src="https://github.com/user-attachments/assets/cb67731d-b66c-4268-8224-e8ae2630724b" />

**VC generated** 

<img width="496" height="467" alt="image" src="https://github.com/user-attachments/assets/bac4d0b8-7a11-4e11-952f-44dd7491731c" />

- [OJ-2861](https://govukverify.atlassian.net/browse/OJ-2861)

### Issue tracking
**Note**: each button has been given an `id` this will make it easier location buttons in smoke-test instead 
see
- [OJ-2860](https://govukverify.atlassian.net/browse/OJ-2860)
 https://github.com/govuk-one-login/ipv-cri-check-hmrc-smoke-tests/pull/178



[OJ-2861]: https://govukverify.atlassian.net/browse/OJ-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OJ-2860]: https://govukverify.atlassian.net/browse/OJ-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ