### PR TITLE
PYIC-8381: update stub so that recalculated vot is returned in respon…

### DIFF
--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
@@ -6,6 +6,7 @@ export async function vcToSignedJwt(vc: JWTPayload, signingKey: string) {
     `-----BEGIN PRIVATE KEY-----\n${signingKey}\n-----END PRIVATE KEY-----`, // pragma: allowlist secret - the key is coming from config
     "ES256",
   );
+  console.log("");
   return await new SignJWT(vc)
     .setProtectedHeader({ alg: "ES256", typ: "JWT" })
     .sign(formattedSigningKey);

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
@@ -6,7 +6,6 @@ export async function vcToSignedJwt(vc: JWTPayload, signingKey: string) {
     `-----BEGIN PRIVATE KEY-----\n${signingKey}\n-----END PRIVATE KEY-----`, // pragma: allowlist secret - the key is coming from config
     "ES256",
   );
-  console.log("");
   return await new SignJWT(vc)
     .setProtectedHeader({ alg: "ES256", typ: "JWT" })
     .sign(formattedSigningKey);

--- a/di-ipv-sis-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-sis-stub/core-dev-deploy/template.yaml
@@ -98,6 +98,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          SIS_PARAM_BASE_PATH: "/stubs/core/sis/"
           EVCS_STORED_IDENTITY_TABLE:
             Fn::ImportValue: !Sub ${EvcsSisStoreTableName}-${Environment}
           NODE_OPTIONS: --enable-source-maps
@@ -111,6 +112,8 @@ Resources:
         - VPCAccessPolicy: { }
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/sis/*
         - KMSDecryptPolicy:
             KeyId:
               Fn::ImportValue: !Sub ${EvcsDynamoDbKmsKey}-${Environment}

--- a/di-ipv-sis-stub/deploy/template.yaml
+++ b/di-ipv-sis-stub/deploy/template.yaml
@@ -160,6 +160,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
+          SIS_PARAM_BASE_PATH: "/stubs/core/sis/"
           EVCS_STORED_IDENTITY_TABLE:
             Fn::ImportValue: !Sub ${EvcsSisStoreTableName}-${Environment}
           NODE_OPTIONS: --enable-source-maps
@@ -173,6 +174,8 @@ Resources:
         - VPCAccessPolicy: { }
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/sis/*
         - KMSDecryptPolicy:
             KeyId:
               Fn::ImportValue: !Sub ${EvcsDynamoDbKmsKey}-${Environment}

--- a/di-ipv-sis-stub/lambdas/src/config/config.ts
+++ b/di-ipv-sis-stub/lambdas/src/config/config.ts
@@ -5,7 +5,5 @@ export const config = {
   localDynamoDbEndpoint: process.env.LOCAL_DYNAMODB_ENDPOINT,
   evcsStoredIdentityObjectTableName: process.env.EVCS_STORED_IDENTITY_TABLE,
   evcsParamBasePath: process.env.EVCS_PARAM_BASE_PATH,
-  sisSigningKeyId: process.env.SIS_SIGNING_KEY_ID,
-  didStoredIdentityId: process.env.DID_STORED_IDENTITY_ID,
-  sisSigningKey: process.env.SIS_SIGNING_KEY,
+  sisParamsBasePath: process.env.SIS_PARAM_BASE_PATH,
 };

--- a/di-ipv-sis-stub/lambdas/src/config/config.ts
+++ b/di-ipv-sis-stub/lambdas/src/config/config.ts
@@ -5,4 +5,7 @@ export const config = {
   localDynamoDbEndpoint: process.env.LOCAL_DYNAMODB_ENDPOINT,
   evcsStoredIdentityObjectTableName: process.env.EVCS_STORED_IDENTITY_TABLE,
   evcsParamBasePath: process.env.EVCS_PARAM_BASE_PATH,
+  sisSigningKeyId: process.env.SIS_SIGNING_KEY_ID,
+  didStoredIdentityId: process.env.DID_STORED_IDENTITY_ID,
+  sisSigningKey: process.env.SIS_SIGNING_KEY,
 };

--- a/di-ipv-sis-stub/lambdas/src/domain/userIdentity.ts
+++ b/di-ipv-sis-stub/lambdas/src/domain/userIdentity.ts
@@ -1,3 +1,5 @@
+import { JWTPayload } from "jose";
+
 export interface UserIdentity {
   content: string;
   isValid: boolean;
@@ -10,4 +12,12 @@ export interface UserIdentity {
 export interface UserIdentityRequestBody {
   govukSigninJourneyId: string;
   vtr: string[];
+}
+
+export interface StoredIdentityJwt extends JWTPayload {
+  claims?: object;
+  vot?: string;
+  credentials?: string[];
+  sub: string;
+  aud: string;
 }

--- a/di-ipv-sis-stub/lambdas/src/services/sisService.ts
+++ b/di-ipv-sis-stub/lambdas/src/services/sisService.ts
@@ -5,7 +5,7 @@ import { dynamoClient } from "../clients/dynamodbClient";
 import { StoredIdentityJwt, UserIdentity } from "../domain/userIdentity";
 import { getVotForUserIdentity } from "../utils/votHelper";
 import { decodeJwt } from "jose";
-import { createSignedJwt, updateVotOnSiVot } from "../utils/signedJwtHelper";
+import { createSignedJwt, updateVotOnSiJwt } from "../utils/signedJwtHelper";
 
 const GPG45_RECORD_TYPE = "idrec:gpg45";
 
@@ -54,7 +54,7 @@ export const getUserIdentity = async (
       validatedResponse.isValid,
     );
 
-    const jwt = updateVotOnSiVot(decodedSiJwt, matchedProfile);
+    const jwt = updateVotOnSiJwt(decodedSiJwt, matchedProfile);
     signedJwt = await createSignedJwt(jwt);
   }
 

--- a/di-ipv-sis-stub/lambdas/src/utils/signedJwtHelper.ts
+++ b/di-ipv-sis-stub/lambdas/src/utils/signedJwtHelper.ts
@@ -32,7 +32,7 @@ const createKid = async () => {
   return hash.update(`${didStoredIdentityId}#${sisSigningKeyId}`).digest("hex");
 };
 
-export const updateVotOnSiVot = (
+export const updateVotOnSiJwt = (
   siJwt: StoredIdentityJwt,
   matchedProfile: string | undefined,
 ) => {
@@ -46,8 +46,8 @@ export const updateVotOnSiVot = (
     jwt.setAudience(siJwt.aud);
   }
 
-  if (siJwt.aud) {
-    jwt.setAudience(siJwt.aud);
+  if (siJwt.sub) {
+    jwt.setAudience(siJwt.sub);
   }
 
   if (siJwt.nbf) {

--- a/di-ipv-sis-stub/lambdas/src/utils/signedJwtHelper.ts
+++ b/di-ipv-sis-stub/lambdas/src/utils/signedJwtHelper.ts
@@ -1,0 +1,59 @@
+import { importPKCS8, SignJWT } from "jose";
+import { createHash } from "node:crypto";
+import { config } from "../config/config";
+import { StoredIdentityJwt } from "../domain/userIdentity";
+
+export const createSignedJwt = async (jwt: SignJWT) => {
+  if (!config.sisSigningKey) {
+    throw new Error("No signing key found");
+  }
+
+  const signingKey = await importPKCS8(
+    `-----BEGIN PRIVATE KEY-----\n${config.sisSigningKey}\n-----END PRIVATE KEY-----`, // pragma: allowlist secret
+    "ES256",
+  );
+
+  return await jwt
+    .setProtectedHeader({ alg: "ES256", typ: "JWT", kid: createKid() })
+    .sign(signingKey);
+};
+
+const createKid = () => {
+  const hash = createHash("sha256");
+  return hash
+    .update(`${config.didStoredIdentityId}#${config.sisSigningKeyId}`)
+    .digest("hex");
+};
+
+export const updateVotOnSiVot = (
+  siJwt: StoredIdentityJwt,
+  matchedProfile: string | undefined,
+) => {
+  const jwt = new SignJWT({
+    claims: siJwt.claims,
+    vot: matchedProfile,
+    credentials: siJwt.credentials,
+  });
+
+  if (siJwt.aud) {
+    jwt.setAudience(siJwt.aud);
+  }
+
+  if (siJwt.aud) {
+    jwt.setAudience(siJwt.aud);
+  }
+
+  if (siJwt.nbf) {
+    jwt.setNotBefore(siJwt.nbf);
+  }
+
+  if (siJwt.iss) {
+    jwt.setIssuer(siJwt.iss);
+  }
+
+  if (siJwt.iat) {
+    jwt.setIssuedAt(siJwt.iat);
+  }
+
+  return jwt;
+};


### PR DESCRIPTION
…se.content.vot and not response.vot

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

update stub so that recalculated vot is returned in response.content.vot and not response.vot

### Why did it change
To match spec

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ