### PR TITLE
PYIC-8616: Remove reprove_identity from orch-stub.

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/handlers/IpvHandler.java
@@ -75,7 +75,6 @@ public class IpvHandler {
     private static final String JOURNEY_ID_PARAM = "signInJourneyIdText";
     private static final String VTR_PARAM = "vtrText";
     private static final String ENVIRONMENT_PARAM = "targetEnvironment";
-    private static final String REPROVE_IDENTITY_PARAM = "reproveIdentity";
     private static final String EMAIL_ADDRESS_PARAM = "emailAddress";
     private static final String MFA_RESET_PARAM = "mfaReset";
     private static final String ERROR_TYPE_PARAM = "error";
@@ -136,7 +135,6 @@ public class IpvHandler {
                             null,
                             errorType,
                             userEmailAddress,
-                            JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT,
                             environment,
                             scope,
                             clientId,
@@ -151,12 +149,6 @@ public class IpvHandler {
                             .filter(value -> !value.isEmpty())
                             .toList();
 
-            var reproveIdentityString = ctx.queryParam(REPROVE_IDENTITY_PARAM);
-            var reproveIdentityClaimValue =
-                    StringUtils.isNotBlank(reproveIdentityString)
-                            ? JwtBuilder.ReproveIdentityClaimValue.valueOf(reproveIdentityString)
-                            : JwtBuilder.ReproveIdentityClaimValue.NOT_PRESENT;
-
             claims =
                     JwtBuilder.buildAuthorizationRequestClaims(
                             userId,
@@ -165,7 +157,6 @@ public class IpvHandler {
                             vtr,
                             errorType,
                             userEmailAddress,
-                            reproveIdentityClaimValue,
                             environment,
                             scope,
                             clientId,

--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/JwtBuilder.java
@@ -61,12 +61,6 @@ public class JwtBuilder {
     private static final JWSSigner ORCH_SIGNER = createSigner(ORCHESTRATOR_SIGNING_JWK);
     private static final JWSSigner AUTH_SIGNER = createSigner(AUTH_SIGNING_JWK);
 
-    public enum ReproveIdentityClaimValue {
-        NOT_PRESENT,
-        TRUE,
-        FALSE
-    }
-
     public static JWTClaimsSet buildAuthorizationRequestClaims(
             String userId,
             String signInJourneyId,
@@ -74,7 +68,6 @@ public class JwtBuilder {
             List<String> vtr,
             String errorType,
             String userEmailAddress,
-            ReproveIdentityClaimValue reproveIdentityValue,
             String environment,
             Scope scope,
             String clientId,
@@ -112,10 +105,6 @@ public class JwtBuilder {
                         .claim("email_address", userEmailAddress)
                         .claim("vtr", vtr)
                         .claim("scope", scope.toString());
-        if (reproveIdentityValue != ReproveIdentityClaimValue.NOT_PRESENT) {
-            claimSetBuilder.claim(
-                    "reprove_identity", reproveIdentityValue == ReproveIdentityClaimValue.TRUE);
-        }
         return claimSetBuilder.build();
     }
 

--- a/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
+++ b/di-ipv-orchestrator-stub/src/main/resources/templates/home.mustache
@@ -89,14 +89,6 @@
                 </select>
             </div>
             <div class="govuk-form-group">
-                <label class="govuk-label" for="reproveIdentity">Choose a value for reprove_identity:</label>
-                <select class="govuk-select" name="reproveIdentity" id="reproveIdentity">
-                    <option value="NOT_PRESENT">Not set</option>
-                    <option value="TRUE">true</option>
-                    <option value="FALSE">false</option>
-                </select>
-            </div>
-            <div class="govuk-form-group">
                 <label class="govuk-label" for="emailAddress">Enter user's email address manually</label>
                 <input class="govuk-input" data-module="govuk-input" name="emailAddress" id="emailAddress" type="text" value="dev-platform-testing@digital.cabinet-office.gov.uk">
             </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- removed dropdown for reprove_identity
- removed logic that adds reprove_identity to jwt claims

### Why did it change

We are stopped using reprove_identity from claims in flavour of Account Intervention Service that is called at beginning of the journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8616](https://govukverify.atlassian.net/browse/PYIC-8616)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8616]: https://govukverify.atlassian.net/browse/PYIC-8616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ