### PR TITLE
BAU: Fix Jackson annotation version Maven is missing the last ".0"

### DIFF
--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.3.0",
 			"com.amazonaws:aws-lambda-java-events:3.16.1",
 			"software.amazon.awssdk:dynamodb-enhanced:2.32.31",
-			"com.fasterxml.jackson.core:jackson-annotations:2.20.0",
+			"com.fasterxml.jackson.core:jackson-annotations:2.20",
 			"com.fasterxml.jackson.core:jackson-databind:2.20.0",
 			"org.apache.logging.log4j:log4j-api:2.25.1",
 			"org.apache.logging.log4j:log4j-core:2.25.1",

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.3.0",
 			"com.amazonaws:aws-lambda-java-events:3.16.1",
 			"software.amazon.awssdk:dynamodb-enhanced:2.32.31",
-			"com.fasterxml.jackson.core:jackson-annotations:2.20.0",
+			"com.fasterxml.jackson.core:jackson-annotations:2.20",
 			"com.fasterxml.jackson.core:jackson-databind:2.20.0",
 			"org.apache.logging.log4j:log4j-api:2.25.1",
 			"org.apache.logging.log4j:log4j-core:2.25.1",

--- a/di-ipv-credential-issuer-stub/build.gradle
+++ b/di-ipv-credential-issuer-stub/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:11.27",
 			"com.fasterxml.jackson.core:jackson-core:2.20.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.20.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.20.0",
+			"com.fasterxml.jackson.core:jackson-annotations:2.20",
 			"com.google.code.gson:gson:2.13.1",
 			"org.slf4j:slf4j-simple:2.0.17",
 			"software.amazon.awssdk:ssm:2.33.0",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Version number

### Why did it change

Dependabot went for the expected 2.20.0, but Maven only has 2.20

