### PR TITLE
PYIC-8394: Update identity get method from GET to POST

### DIFF
--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -324,7 +324,7 @@ Resources:
           Properties:
             RestApiId: !Ref RestApiGateway
             Path: /identity
-            Method: GET
+            Method: POST
     Metadata:
       # Manage esbuild properties
       BuildMethod: esbuild

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -384,7 +384,7 @@ Resources:
           Properties:
             RestApiId: !Ref RestApiGateway
             Path: /identity
-            Method: GET
+            Method: POST
     Metadata:
       # Manage esbuild properties
       BuildMethod: esbuild


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The SIS get identity method is now a POST rather than a GET (https://govukverify.atlassian.net/browse/PYIC-8380)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8394](https://govukverify.atlassian.net/browse/PYIC-8394)



[PYIC-8394]: https://govukverify.atlassian.net/browse/PYIC-8394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ