### PR TITLE
PYIC-8679: Update CRI stubs to allow sending error responses from token + credential endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -201,7 +201,7 @@
         "filename": "di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java",
         "hashed_secret": "6dd4a86679769d70d9aee4fedad5ccc2acb6f4c3",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 47
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json": [
@@ -368,5 +368,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-29T16:46:59Z"
+  "generated_at": "2025-10-07T10:49:09Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -201,7 +201,7 @@
         "filename": "di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java",
         "hashed_secret": "6dd4a86679769d70d9aee4fedad5ccc2acb6f4c3",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 46
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json": [
@@ -368,5 +368,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-07T10:49:09Z"
+  "generated_at": "2025-10-07T16:38:43Z"
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -25,6 +25,10 @@ import java.net.http.HttpClient;
 import static uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig.getCriType;
 
 public class CredentialIssuer {
+    private static final String CREDENTIALS_ENDPOINT = "/credentials/issue";
+    private static final String AUTHORIZE_ENDPOINT = "/authorize";
+    private static final String TOKEN_ENDPOINT = "/token";
+    private static final String API_AUTHORIZE_ENDPOINT = "/api/authorize";
 
     private final AuthorizeHandler authorizeHandler;
     private final TokenHandler tokenHandler;
@@ -86,16 +90,16 @@ public class CredentialIssuer {
 
     private void initRoutes(Javalin app) {
         app.get("/", healthCheckHandler::healthy);
-        app.get("/authorize", authorizeHandler::doAuthorize);
-        app.post("/authorize", authorizeHandler::formAuthorize);
-        app.post("/api/authorize", authorizeHandler::apiAuthorize);
-        app.post("/token", tokenHandler::issueAccessToken);
+        app.get(AUTHORIZE_ENDPOINT, authorizeHandler::doAuthorize);
+        app.post(AUTHORIZE_ENDPOINT, authorizeHandler::formAuthorize);
+        app.post(API_AUTHORIZE_ENDPOINT, authorizeHandler::apiAuthorize);
+        app.post(TOKEN_ENDPOINT, tokenHandler::issueAccessToken);
         if (getCriType().equals(CriType.DOC_CHECK_APP_CRI_TYPE)) {
-            app.post("/credentials/issue", docAppCredentialHandler::getResource);
+            app.post(CREDENTIALS_ENDPOINT, docAppCredentialHandler::getResource);
         } else if (getCriType().equals(CriType.F2F_CRI_TYPE)) {
-            app.post("/credentials/issue", f2fHandler::getResource);
+            app.post(CREDENTIALS_ENDPOINT, f2fHandler::getResource);
         } else {
-            app.post("/credentials/issue", credentialHandler::getResource);
+            app.post(CREDENTIALS_ENDPOINT, credentialHandler::getResource);
         }
         app.post(
                 "/credentials/generate",

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/CredentialIssuer.java
@@ -67,12 +67,14 @@ public class CredentialIssuer {
                         validator,
                         clientJwtVerifier,
                         requestedErrorResponseService);
-        credentialHandler = new CredentialHandler(credentialService, tokenService);
+        credentialHandler =
+                new CredentialHandler(
+                        credentialService, tokenService, requestedErrorResponseService);
         docAppCredentialHandler =
                 new DocAppCredentialHandler(
                         credentialService, tokenService, requestedErrorResponseService);
         jwksHandler = new JwksHandler();
-        f2fHandler = new F2FHandler(credentialService, tokenService);
+        f2fHandler = new F2FHandler(credentialService, tokenService, requestedErrorResponseService);
         healthCheckHandler = new HealthCheckHandler();
         generateCredentialHandler = new GenerateCredentialHandler(vcGenerator);
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/RequestedError.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/RequestedError.java
@@ -2,18 +2,20 @@ package uk.gov.di.ipv.stub.cred.domain;
 
 import io.javalin.http.Context;
 
+import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_API_ERROR;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_OAUTH_ERROR;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_USERINFO_ERROR;
 
 public record RequestedError(
-        String error, String description, String endpoint, String userInfoError) {
+        String error, String description, String endpoint, String userInfoError, String apiError) {
     public static RequestedError fromFormContext(Context ctx) {
         return new RequestedError(
                 ctx.formParam(REQUESTED_OAUTH_ERROR),
                 ctx.formParam(REQUESTED_OAUTH_ERROR_DESCRIPTION),
                 ctx.formParam(REQUESTED_OAUTH_ERROR_ENDPOINT),
-                ctx.formParam(REQUESTED_USERINFO_ERROR));
+                ctx.formParam(REQUESTED_USERINFO_ERROR),
+                ctx.formParam(REQUESTED_API_ERROR));
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/RequestedError.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/domain/RequestedError.java
@@ -6,16 +6,13 @@ import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_A
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_OAUTH_ERROR;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT;
-import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUESTED_USERINFO_ERROR;
 
-public record RequestedError(
-        String error, String description, String endpoint, String userInfoError, String apiError) {
+public record RequestedError(String error, String description, String endpoint, String apiError) {
     public static RequestedError fromFormContext(Context ctx) {
         return new RequestedError(
                 ctx.formParam(REQUESTED_OAUTH_ERROR),
                 ctx.formParam(REQUESTED_OAUTH_ERROR_DESCRIPTION),
                 ctx.formParam(REQUESTED_OAUTH_ERROR_ENDPOINT),
-                ctx.formParam(REQUESTED_USERINFO_ERROR),
                 ctx.formParam(REQUESTED_API_ERROR));
     }
 }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandler.java
@@ -1,9 +1,12 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import io.javalin.http.Context;
 import io.javalin.http.Header;
 import io.javalin.http.HttpStatus;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 
@@ -13,20 +16,33 @@ public class CredentialHandler {
 
     private final CredentialService credentialService;
     private final TokenService tokenService;
+    private final RequestedErrorResponseService requestedErrorResponseService;
 
-    public CredentialHandler(CredentialService credentialService, TokenService tokenService) {
+    public CredentialHandler(
+            CredentialService credentialService,
+            TokenService tokenService,
+            RequestedErrorResponseService requestedErrorResponseService) {
         this.credentialService = credentialService;
         this.tokenService = tokenService;
+        this.requestedErrorResponseService = requestedErrorResponseService;
     }
 
     public void getResource(Context ctx) throws Exception {
         String accessTokenString = ctx.header(Header.AUTHORIZATION);
 
         ValidationResult validationResult = tokenService.validateAccessToken(accessTokenString);
-
         if (!validationResult.isValid()) {
             ctx.status(validationResult.getError().getHTTPStatusCode());
             ctx.result(validationResult.getError().getDescription());
+            return;
+        }
+
+        String accessTokenValue = BearerAccessToken.parse(accessTokenString).getValue();
+        UserInfoErrorResponse requestedUserInfoErrorResponse =
+                requestedErrorResponseService.getUserInfoErrorByToken(accessTokenValue);
+        if (requestedUserInfoErrorResponse != null) {
+            ctx.status(requestedUserInfoErrorResponse.getErrorObject().getHTTPStatusCode());
+            ctx.json(requestedUserInfoErrorResponse.getErrorObject().toJSONObject());
             return;
         }
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import io.javalin.http.Context;
@@ -9,7 +10,6 @@ import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 
 import java.util.List;
-import java.util.UUID;
 
 public class DocAppCredentialHandler extends CredentialHandler {
 
@@ -21,8 +21,10 @@ public class DocAppCredentialHandler extends CredentialHandler {
     }
 
     @Override
-    protected void sendResponse(Context ctx, String verifiableCredential) {
-        var userInfo = new UserInfo(new Subject("urn:fdc:gov.uk:2022:" + UUID.randomUUID()));
+    protected void sendResponse(Context ctx, String verifiableCredential) throws Exception {
+        String subject = SignedJWT.parse(verifiableCredential).getJWTClaimsSet().getSubject();
+
+        var userInfo = new UserInfo(new Subject(subject));
         userInfo.setClaim(
                 "https://vocab.account.gov.uk/v1/credentialJWT", List.of(verifiableCredential));
 

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandler.java
@@ -1,11 +1,8 @@
 package uk.gov.di.ipv.stub.cred.handlers;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import io.javalin.http.Context;
-import io.javalin.http.Header;
 import io.javalin.http.HttpStatus;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
 import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
@@ -15,29 +12,16 @@ import java.util.List;
 import java.util.UUID;
 
 public class DocAppCredentialHandler extends CredentialHandler {
-    private final RequestedErrorResponseService requestedErrorResponseService;
 
     public DocAppCredentialHandler(
             CredentialService credentialService,
             TokenService tokenService,
             RequestedErrorResponseService requestedErrorResponseService) {
-        super(credentialService, tokenService);
-        this.requestedErrorResponseService = requestedErrorResponseService;
+        super(credentialService, tokenService, requestedErrorResponseService);
     }
 
     @Override
-    protected void sendResponse(Context ctx, String verifiableCredential) throws Exception {
-        var accessTokenHeaderValue = ctx.header(Header.AUTHORIZATION);
-
-        String accessTokenValue = BearerAccessToken.parse(accessTokenHeaderValue).getValue();
-        UserInfoErrorResponse requestedUserInfoErrorResponse =
-                requestedErrorResponseService.getUserInfoErrorByToken(accessTokenValue);
-        if (requestedUserInfoErrorResponse != null) {
-            ctx.status(requestedUserInfoErrorResponse.getErrorObject().getHTTPStatusCode());
-            ctx.json(requestedUserInfoErrorResponse.getErrorObject().toJSONObject());
-            return;
-        }
-
+    protected void sendResponse(Context ctx, String verifiableCredential) {
         var userInfo = new UserInfo(new Subject("urn:fdc:gov.uk:2022:" + UUID.randomUUID()));
         userInfo.setClaim(
                 "https://vocab.account.gov.uk/v1/credentialJWT", List.of(verifiableCredential));

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandler.java
@@ -6,12 +6,16 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 
 public class F2FHandler extends CredentialHandler {
 
-    public F2FHandler(CredentialService credentialService, TokenService tokenService) {
-        super(credentialService, tokenService);
+    public F2FHandler(
+            CredentialService credentialService,
+            TokenService tokenService,
+            RequestedErrorResponseService requestedErrorResponseService) {
+        super(credentialService, tokenService, requestedErrorResponseService);
     }
 
     @Override

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -27,7 +27,6 @@ public class RequestParamConstants {
     public static final String REQUESTED_API_ERROR = "requested_api_error";
     public static final String REQUESTED_OAUTH_ERROR_DESCRIPTION =
             "requested_oauth_error_description";
-    public static final String REQUESTED_USERINFO_ERROR = "requested_userinfo_error";
 
     public static final String F2F_STUB_QUEUE_NAME = "f2f_stub_queue_name";
     public static final String F2F_SEND_VC_QUEUE = "f2f_send_vc_queue";

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/RequestParamConstants.java
@@ -22,8 +22,9 @@ public class RequestParamConstants {
     public static final String VERIFICATION = "verificationScore";
     public static final String BIOMETRIC_VERIFICATION = "biometricVerificationScore";
 
-    public static final String REQUESTED_OAUTH_ERROR = "requested_oauth_error";
     public static final String REQUESTED_OAUTH_ERROR_ENDPOINT = "requested_oauth_error_endpoint";
+    public static final String REQUESTED_OAUTH_ERROR = "requested_oauth_error";
+    public static final String REQUESTED_API_ERROR = "requested_api_error";
     public static final String REQUESTED_OAUTH_ERROR_DESCRIPTION =
             "requested_oauth_error_description";
     public static final String REQUESTED_USERINFO_ERROR = "requested_userinfo_error";

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandler.java
@@ -7,7 +7,6 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
 import io.javalin.http.Context;
-import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.stub.cred.auth.ClientJwtVerifier;
@@ -53,7 +52,7 @@ public class TokenHandler {
         TokenErrorResponse requestedTokenErrorResponse =
                 handleRequestedError(ctx.formParam(RequestParamConstants.AUTH_CODE));
         if (requestedTokenErrorResponse != null) {
-            ctx.status(HttpStatus.BAD_REQUEST_400);
+            ctx.status(requestedTokenErrorResponse.getErrorObject().getHTTPStatusCode());
             ctx.json(requestedTokenErrorResponse.toJSONObject());
             return;
         }
@@ -114,7 +113,10 @@ public class TokenHandler {
         authCodeService.revoke(code);
         tokenService.persist(accessToken, payloadAssociatedWithCode);
 
-        requestedErrorResponseService.persistUserInfoErrorAgainstToken(
+        // We need to persist any requested errors against the generated access
+        // token so that it can be accessed at the credentials endpoint where
+        // the access token is available but not the auth code
+        requestedErrorResponseService.persistUserInfoErrorAgainstAccessToken(
                 code, accessToken.toString());
 
         ctx.json(tokenResponse.toJSONObject());

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -48,8 +48,6 @@ public class RequestedErrorResponseService {
         paramsValuesMap.put(
                 RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION,
                 requestedError.description());
-        paramsValuesMap.put(
-                RequestParamConstants.REQUESTED_USERINFO_ERROR, requestedError.userInfoError());
         paramsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, requestedError.apiError());
 
         errorResponsesRequested.put(authCode, paramsValuesMap);

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -27,9 +27,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class RequestedErrorResponseService {
-    public static final String AUTH = "auth";
-    public static final String TOKEN = "token";
-    public static final String NONE = "none";
+    private static final String AUTH = "auth";
+    private static final String TOKEN = "token";
+    private static final String CREDENTIAL = "credential";
+    private static final String NONE = "none";
 
     private final Map<String, Map<String, String>> errorResponsesRequested;
 
@@ -50,6 +51,7 @@ public class RequestedErrorResponseService {
                 requestedError.description());
         parmsValuesMap.put(
                 RequestParamConstants.REQUESTED_USERINFO_ERROR, requestedError.userInfoError());
+        parmsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, requestedError.apiError());
 
         errorResponsesRequested.put(authCode, parmsValuesMap);
     }
@@ -86,7 +88,7 @@ public class RequestedErrorResponseService {
     public TokenErrorResponse getRequestedAccessTokenErrorResponse(String authCode) {
         Map<String, String> requestedErrorResponse = errorResponsesRequested.get(authCode);
         if (requestedErrorResponse != null) {
-            String error = requestedErrorResponse.get(RequestParamConstants.REQUESTED_OAUTH_ERROR);
+            String error = requestedErrorResponse.get(RequestParamConstants.REQUESTED_API_ERROR);
             String endpoint =
                     requestedErrorResponse.get(
                             RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT);
@@ -96,20 +98,23 @@ public class RequestedErrorResponseService {
                         new ErrorObject(
                                 error,
                                 requestedErrorResponse.get(
-                                        RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION)));
+                                        RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION),
+                                Integer.parseInt(error)));
             }
         }
         return null;
     }
 
-    public void persistUserInfoErrorAgainstToken(String authCode, String accessToken) {
+    public void persistUserInfoErrorAgainstAccessToken(String authCode, String accessToken) {
         Map<String, String> requestedErrorResponse = errorResponsesRequested.get(authCode);
         if (requestedErrorResponse != null) {
-            String error =
-                    requestedErrorResponse.get(RequestParamConstants.REQUESTED_USERINFO_ERROR);
-            if (error != null) {
+            String error = requestedErrorResponse.get(RequestParamConstants.REQUESTED_API_ERROR);
+            String endpoint =
+                    requestedErrorResponse.get(
+                            RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT);
+            if (error != null && CREDENTIAL.equals(endpoint)) {
                 Map<String, String> parmsValuesMap = new HashMap<>();
-                parmsValuesMap.put(RequestParamConstants.REQUESTED_USERINFO_ERROR, error);
+                parmsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, error);
                 errorResponsesRequested.put(accessToken, parmsValuesMap);
             }
         }

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -12,7 +12,6 @@ import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
-import org.eclipse.jetty.http.HttpStatus;
 import uk.gov.di.ipv.stub.cred.config.ClientConfig;
 import uk.gov.di.ipv.stub.cred.config.CredentialIssuerConfig;
 import uk.gov.di.ipv.stub.cred.domain.AuthRequest;
@@ -42,18 +41,18 @@ public class RequestedErrorResponseService {
         if (requestedError == null) {
             return;
         }
-        Map<String, String> parmsValuesMap = new HashMap<>();
-        parmsValuesMap.put(RequestParamConstants.REQUESTED_OAUTH_ERROR, requestedError.error());
-        parmsValuesMap.put(
+        Map<String, String> paramsValuesMap = new HashMap<>();
+        paramsValuesMap.put(RequestParamConstants.REQUESTED_OAUTH_ERROR, requestedError.error());
+        paramsValuesMap.put(
                 RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT, requestedError.endpoint());
-        parmsValuesMap.put(
+        paramsValuesMap.put(
                 RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION,
                 requestedError.description());
-        parmsValuesMap.put(
+        paramsValuesMap.put(
                 RequestParamConstants.REQUESTED_USERINFO_ERROR, requestedError.userInfoError());
-        parmsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, requestedError.apiError());
+        paramsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, requestedError.apiError());
 
-        errorResponsesRequested.put(authCode, parmsValuesMap);
+        errorResponsesRequested.put(authCode, paramsValuesMap);
     }
 
     public AuthorizationErrorResponse getRequestedAuthErrorResponse(AuthRequest authRequest)
@@ -113,9 +112,9 @@ public class RequestedErrorResponseService {
                     requestedErrorResponse.get(
                             RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT);
             if (error != null && CREDENTIAL.equals(endpoint)) {
-                Map<String, String> parmsValuesMap = new HashMap<>();
-                parmsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, error);
-                errorResponsesRequested.put(accessToken, parmsValuesMap);
+                Map<String, String> paramsValuesMap = new HashMap<>();
+                paramsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, error);
+                errorResponsesRequested.put(accessToken, paramsValuesMap);
             }
         }
     }
@@ -123,14 +122,16 @@ public class RequestedErrorResponseService {
     public UserInfoErrorResponse getUserInfoErrorByToken(String accessToken) {
         Map<String, String> requestedErrorResponse = errorResponsesRequested.get(accessToken);
         if (requestedErrorResponse != null) {
-            String error =
-                    requestedErrorResponse.get(RequestParamConstants.REQUESTED_USERINFO_ERROR);
-            if (error.equals("404")) {
+            String error = requestedErrorResponse.get(RequestParamConstants.REQUESTED_API_ERROR);
+            String endpoint =
+                    requestedErrorResponse.get(
+                            RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT);
+            if (error != null && CREDENTIAL.equals(endpoint)) {
                 return new UserInfoErrorResponse(
                         new ErrorObject(
                                 error,
-                                "UserInfo endpoint 404 triggered by stub",
-                                HttpStatus.NOT_FOUND_404));
+                                String.format("UserInfo endpoint %s triggered by stub", error),
+                                Integer.parseInt(error)));
             }
         }
         return null;

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/service/RequestedErrorResponseService.java
@@ -112,6 +112,7 @@ public class RequestedErrorResponseService {
             if (error != null && CREDENTIAL.equals(endpoint)) {
                 Map<String, String> paramsValuesMap = new HashMap<>();
                 paramsValuesMap.put(RequestParamConstants.REQUESTED_API_ERROR, error);
+                paramsValuesMap.put(RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT, endpoint);
                 errorResponsesRequested.put(accessToken, paramsValuesMap);
             }
         }

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -543,20 +543,26 @@
                                         <div class="govuk-radios" data-module="govuk-radios">
                                             <div class="govuk-radios__item">
                                                 <input class="govuk-radios__input" id="endpoint" name="requested_oauth_error_endpoint" type="radio" value="auth">
-                                                <label class="govuk-label govuk-radios__label" for="requested_oauth_error_endpoint">
+                                                <label class="govuk-label govuk-radios__label" for="endpoint">
                                                     Authorization
                                                 </label>
                                             </div>
                                             <div class="govuk-radios__item">
-                                                <input class="govuk-radios__input" id="requested_oauth_error_endpoint_2" name="requested_oauth_error_endpoint" type="radio" value="token">
-                                                <label class="govuk-label govuk-radios__label" for="requested_oauth_error_endpoint_2">
+                                                <input class="govuk-radios__input" id="endpoint_2" name="requested_oauth_error_endpoint" type="radio" value="token">
+                                                <label class="govuk-label govuk-radios__label" for="endpoint_2">
                                                     Access Token
+                                                </label>
+                                            </div>
+                                            <div class="govuk-radios__item">
+                                                <input class="govuk-radios__input" id="endpoint_3" name="requested_oauth_error_endpoint" type="radio" value="token">
+                                                <label class="govuk-label govuk-radios__label" for="endpoint_3">
+                                                    Credential (User Info)
                                                 </label>
                                             </div>
                                         </div>
                                     </div>
 
-                                    <div class="govuk-form-group">
+                                    <div class="govuk-form-group" id="requested_oauth_error_group">
                                         <label class="govuk-label" for="requested_oauth_error">
                                             OAuth error
                                         </label>
@@ -569,6 +575,21 @@
                                             <option value="invalid_scope">invalid_scope</option>
                                             <option value="server_error">server_error</option>
                                             <option value="temporarily_unavailable">temporarily_unavailable</option>
+                                        </select>
+                                    </div>
+
+                                    <div class="govuk-form-group" id="requested_api_error_group">
+                                        <label class="govuk-label" for="requested_api_error">
+                                            API Error Status Code
+                                        </label>
+                                        <select class="govuk-select" id="requested_api_error" name="requested_api_error">
+                                            <option value="none" selected>none</option>
+                                            <option value="400" selected>400 - Bad Request</option>
+                                            <option value="401" selected>401 - Unauthorised</option>
+                                            <option value="403" selected>403 - Forbidden</option>
+                                            <option value="404" selected>404 - Not Found</option>
+                                            <option value="500" selected>500 - Internal Server Error</option>
+                                            <option value="503" selected>503 - Service Unavailable</option>
                                         </select>
                                     </div>
 
@@ -629,14 +650,20 @@
   document.querySelector('form').addEventListener('submit', function(e) {
     const jsonPayload = document.getElementById('jsonPayload').value.trim();
     const oauthError = document.getElementById('requested_oauth_error').value;
-    const oauthErrorEndpoint = document.querySelector('input[name="requested_oauth_error_endpoint"]:checked');
+    const apiError = document.getElementById('requested_api_error').value;
+    const authEndpointSelected = document.querySelector('input[id="endpoint"]:checked');
+    const tokenOrCredentialEndpointSelected = document.querySelector('input[id="endpoint_2"]:checked') || document.querySelector('input[id="endpoint_3"]:checked');
 
     const isJsonPayloadFilled = !!jsonPayload;
-    const areOauthFieldsValid = oauthError !== 'none' && oauthErrorEndpoint;
+    const areOauthFieldsValid = oauthError !== 'none' && authEndpointSelected;
+    const areApiErrorFieldsValid = apiError !== 'none' && tokenOrCredentialEndpointSelected;
 
-    if (!isJsonPayloadFilled && !areOauthFieldsValid) {
+    if (!isJsonPayloadFilled && !areOauthFieldsValid && !areApiErrorFieldsValid) {
       e.preventDefault();
-      alert("Please either enter JSON payload data or select both an OAuth error and an endpoint.");
+      alert("Please enter JSON payload data (and select the credential/token endpoint with an API error if simulating an api error response from these endpoints) or select the authorization endpoint with a valid error.");
+    } else if (areApiErrorFieldsValid && !isJsonPayloadFilled) {
+        e.preventDefault();
+        alert("Please enter JSON payload data and select the credential/token endpoint with an API error if simulating an api error response from these endpoints");
     }
   });
 </script>
@@ -727,6 +754,17 @@
 
 
 </script>
-
+<script>
+    const authEndpoint = document.getElementById("endpoint");
+    const oauthErrorOptions = document.getElementById("requested_oauth_error_group");
+    const apiErrorOptions = document.getElementById("requested_api_error_group");
+    if (authEndpoint.checked) {
+        oauthErrorOptions.style.display = true;
+        apiErrorOptions.style.display = false;
+    } else {
+        oauthErrorOptions.style.display = false;
+        apiErrorOptions.style.display = true;
+    }
+</script>
 </body>
 </html>

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -554,7 +554,7 @@
                                                 </label>
                                             </div>
                                             <div class="govuk-radios__item">
-                                                <input class="govuk-radios__input" id="endpoint_3" name="requested_oauth_error_endpoint" type="radio" value="token">
+                                                <input class="govuk-radios__input" id="endpoint_3" name="requested_oauth_error_endpoint" type="radio" value="credential">
                                                 <label class="govuk-label govuk-radios__label" for="endpoint_3">
                                                     Credential (User Info)
                                                 </label>
@@ -562,7 +562,7 @@
                                         </div>
                                     </div>
 
-                                    <div class="govuk-form-group" id="requested_oauth_error_group">
+                                    <div class="govuk-form-group" id="requested_oauth_error_group" style="display:none">
                                         <label class="govuk-label" for="requested_oauth_error">
                                             OAuth error
                                         </label>
@@ -578,18 +578,18 @@
                                         </select>
                                     </div>
 
-                                    <div class="govuk-form-group" id="requested_api_error_group">
+                                    <div class="govuk-form-group" id="requested_api_error_group" style="display:none">
                                         <label class="govuk-label" for="requested_api_error">
                                             API Error Status Code
                                         </label>
                                         <select class="govuk-select" id="requested_api_error" name="requested_api_error">
                                             <option value="none" selected>none</option>
-                                            <option value="400" selected>400 - Bad Request</option>
-                                            <option value="401" selected>401 - Unauthorised</option>
-                                            <option value="403" selected>403 - Forbidden</option>
-                                            <option value="404" selected>404 - Not Found</option>
-                                            <option value="500" selected>500 - Internal Server Error</option>
-                                            <option value="503" selected>503 - Service Unavailable</option>
+                                            <option value="400">400 - Bad Request</option>
+                                            <option value="401">401 - Unauthorised</option>
+                                            <option value="403">403 - Forbidden</option>
+                                            <option value="404">404 - Not Found</option>
+                                            <option value="500">500 - Internal Server Error</option>
+                                            <option value="503">503 - Service Unavailable</option>
                                         </select>
                                     </div>
 
@@ -755,16 +755,29 @@
 
 </script>
 <script>
-    const authEndpoint = document.getElementById("endpoint");
     const oauthErrorOptions = document.getElementById("requested_oauth_error_group");
     const apiErrorOptions = document.getElementById("requested_api_error_group");
-    if (authEndpoint.checked) {
-        oauthErrorOptions.style.display = true;
-        apiErrorOptions.style.display = false;
-    } else {
-        oauthErrorOptions.style.display = false;
-        apiErrorOptions.style.display = true;
+
+    const authEndpoint = document.getElementById("endpoint");
+    function displayOauthErrorOptions() {
+        if (authEndpoint.checked) {
+            oauthErrorOptions.style.display = "block";
+            apiErrorOptions.style.display = "none";
+        }
     }
+    authEndpoint.addEventListener("change", displayOauthErrorOptions);
+
+    const tokenEndpoint = document.getElementById("endpoint_2");
+    const credentialEndpoint = document.getElementById("endpoint_3");
+
+    function displayApiErrorOptions() {
+        if (tokenEndpoint.checked || credentialEndpoint.checked) {
+            oauthErrorOptions.style.display = "none";
+            apiErrorOptions.style.display = "block";
+        }
+    }
+    tokenEndpoint.addEventListener("change", displayApiErrorOptions);
+    credentialEndpoint.addEventListener("change", displayApiErrorOptions);
 </script>
 </body>
 </html>

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -599,17 +599,6 @@
                                         </label>
                                         <input class="govuk-input" id="requested_oauth_error_description" name="requested_oauth_error_description" type="text" value="This error was triggered manually in the stub CRI">
                                     </div>
-                                    {{#isDocCheckingType}}
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="userinfo_error">
-                                            User Info (Credential) endpoint error
-                                        </label>
-                                        <select class="govuk-select" id="userinfo_error" name="requested_userinfo_error">
-                                            <option value="none" selected>none</option>
-                                            <option value="404">404</option>
-                                        </select>
-                                    </div>
-                                    {{/isDocCheckingType}}
                                 </fieldset>
                             </td>
                         </tr>

--- a/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
+++ b/di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache
@@ -649,10 +649,7 @@
 
     if (!isJsonPayloadFilled && !areOauthFieldsValid && !areApiErrorFieldsValid) {
       e.preventDefault();
-      alert("Please enter JSON payload data (and select the credential/token endpoint with an API error if simulating an api error response from these endpoints) or select the authorization endpoint with a valid error.");
-    } else if (areApiErrorFieldsValid && !isJsonPayloadFilled) {
-        e.preventDefault();
-        alert("Please enter JSON payload data and select the credential/token endpoint with an API error if simulating an api error response from these endpoints");
+      alert("Please enter JSON payload data or select an endpoint with a valid error.");
     }
   });
 </script>

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -873,7 +873,7 @@ class AuthorizeHandlerTest {
                                     null,
                                     null,
                                     null,
-                                    new RequestedError(null, null, null, "404", "404")));
+                                    new RequestedError(null, null, "credential", "404", "404")));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
             authorizeHandler.apiAuthorize(mockContext);

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -152,7 +152,7 @@ class AuthorizeHandlerTest {
     @Captor ArgumentCaptor<AuthorizationCode> authCoreArgumentCaptor;
 
     @BeforeAll
-    public static void beforeAllSetUp() {
+    static void beforeAllSetUp() {
         StubSsmClient.setClientConfigParams(CLIENT_CONFIG);
     }
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -97,6 +97,7 @@ import static uk.gov.di.ipv.stub.cred.handlers.AuthorizeHandler.SHARED_CLAIMS;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.CIMIT_STUB_API_KEY;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.CIMIT_STUB_URL;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.CLIENT_ID;
+import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.EVIDENCE_JSON_PAYLOAD;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.JSON_PAYLOAD;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.MITIGATED_CI;
 import static uk.gov.di.ipv.stub.cred.handlers.RequestParamConstants.REQUEST;
@@ -826,8 +827,7 @@ class AuthorizeHandlerTest {
         }
 
         @Test
-        void authorizeHandlerShouldPersistApiErrorResponseForTokenEndpoint()
-                throws Exception {
+        void authorizeHandlerShouldPersistApiErrorResponseForTokenEndpoint() throws Exception {
             when(mockContext.bodyAsClass(ApiAuthRequest.class))
                     .thenReturn(
                             new ApiAuthRequest(
@@ -859,8 +859,7 @@ class AuthorizeHandlerTest {
         }
 
         @Test
-        void authorizeHandlerShouldPersistApiErrorResponseForCredentialEndpoint()
-                throws Exception {
+        void authorizeHandlerShouldPersistApiErrorResponseForCredentialEndpoint() throws Exception {
             when(mockContext.bodyAsClass(ApiAuthRequest.class))
                     .thenReturn(
                             new ApiAuthRequest(
@@ -946,6 +945,7 @@ class AuthorizeHandlerTest {
 
     private Map<String, String> validGenerateResponseFormParams() {
         Map<String, String> queryParams = new HashMap<>();
+        queryParams.put(EVIDENCE_JSON_PAYLOAD, "{\"test\": \"test-value\"}");
         queryParams.put(JSON_PAYLOAD, "{\"test\": \"test-value\"}");
         queryParams.put(STRENGTH, "2");
         queryParams.put(VALIDITY, "3");

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -826,7 +826,7 @@ class AuthorizeHandlerTest {
         }
 
         @Test
-        void apiAuthorizeShouldAllowRequestedOAuthErrorResponseFromTokenEndpoint()
+        void authorizeHandlerShouldPersistApiErrorResponseForTokenEndpoint()
                 throws Exception {
             when(mockContext.bodyAsClass(ApiAuthRequest.class))
                     .thenReturn(
@@ -859,7 +859,7 @@ class AuthorizeHandlerTest {
         }
 
         @Test
-        void apiAuthorizeShouldAllowRequestedOAuthErrorResponseFromCredentialEndpoint()
+        void authorizeHandlerShouldPersistApiErrorResponseForCredentialEndpoint()
                 throws Exception {
             when(mockContext.bodyAsClass(ApiAuthRequest.class))
                     .thenReturn(

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -813,6 +813,7 @@ class AuthorizeHandlerTest {
                                             "invalid_request",
                                             "a bad thing happened",
                                             "auth",
+                                            null,
                                             null)));
 
             authorizeHandler.apiAuthorize(mockContext);
@@ -839,10 +840,11 @@ class AuthorizeHandlerTest {
                                     null,
                                     null,
                                     new RequestedError(
-                                            "invalid_request",
+                                            null,
                                             "a bad thing happened at the token endpoint",
                                             "token",
-                                            null)));
+                                            null,
+                                            "400")));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
             authorizeHandler.apiAuthorize(mockContext);
@@ -852,7 +854,7 @@ class AuthorizeHandlerTest {
                     requestedErrorResponseService
                             .getRequestedAccessTokenErrorResponse(stringArgumentCaptor.getValue())
                             .getErrorObject();
-            assertEquals("invalid_request", tokenErrorResponse.getCode());
+            assertEquals("400", tokenErrorResponse.getCode());
             assertEquals(
                     "a bad thing happened at the token endpoint",
                     tokenErrorResponse.getDescription());
@@ -871,7 +873,7 @@ class AuthorizeHandlerTest {
                                     null,
                                     null,
                                     null,
-                                    new RequestedError(null, null, null, "404")));
+                                    new RequestedError(null, null, null, "404", "404")));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
             authorizeHandler.apiAuthorize(mockContext);

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandlerTest.java
@@ -813,7 +813,6 @@ class AuthorizeHandlerTest {
                                             "invalid_request",
                                             "a bad thing happened",
                                             "auth",
-                                            null,
                                             null)));
 
             authorizeHandler.apiAuthorize(mockContext);
@@ -843,7 +842,6 @@ class AuthorizeHandlerTest {
                                             null,
                                             "a bad thing happened at the token endpoint",
                                             "token",
-                                            null,
                                             "400")));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
@@ -873,7 +871,7 @@ class AuthorizeHandlerTest {
                                     null,
                                     null,
                                     null,
-                                    new RequestedError(null, null, "credential", "404", "404")));
+                                    new RequestedError(null, null, "credential", "404")));
             when(mockVcGenerator.generate(any())).thenReturn(mockSignedJwt);
 
             authorizeHandler.apiAuthorize(mockContext);

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 
@@ -30,13 +31,16 @@ public class CredentialHandlerTest {
     @Mock private Context mockContext;
     @Mock private CredentialService mockCredentialService;
     @Mock private TokenService mockTokenService;
+    @Mock private RequestedErrorResponseService mockRequestedErrorResponseService;
     private CredentialHandler resourceHandler;
     private AccessToken accessToken;
 
     @BeforeEach
     void setup() {
         accessToken = new BearerAccessToken();
-        resourceHandler = new CredentialHandler(mockCredentialService, mockTokenService);
+        resourceHandler =
+                new CredentialHandler(
+                        mockCredentialService, mockTokenService, mockRequestedErrorResponseService);
     }
 
     @Test

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/CredentialHandlerTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class CredentialHandlerTest {
+class CredentialHandlerTest {
     private static final String DEFAULT_RESPONSE_CONTENT_TYPE = "application/jwt;charset=UTF-8";
     private static final ValidationResult INVALID_REQUEST =
             new ValidationResult(false, OAuth2Error.INVALID_REQUEST);
@@ -47,7 +47,7 @@ public class CredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn201AndProtectedResourceWhenValidRequestReceived() throws Exception {
+    void shouldReturn201AndProtectedResourceWhenValidRequestReceived() throws Exception {
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn("aResourceId");
         when(mockTokenService.validateAccessToken(Mockito.anyString()))
@@ -66,7 +66,7 @@ public class CredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenAccessTokenIsNotProvided() throws Exception {
+    void shouldReturn400WhenAccessTokenIsNotProvided() throws Exception {
         when(mockTokenService.validateAccessToken(Mockito.any())).thenReturn(INVALID_REQUEST);
 
         resourceHandler.getResource(mockContext);
@@ -76,8 +76,7 @@ public class CredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenIssuedAccessTokenDoesNotMatchRequestAccessToken()
-            throws Exception {
+    void shouldReturn400WhenIssuedAccessTokenDoesNotMatchRequestAccessToken() throws Exception {
         when(mockContext.header("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
         when(mockTokenService.validateAccessToken(Mockito.any())).thenReturn(INVALID_CLIENT);
 
@@ -88,7 +87,7 @@ public class CredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestAccessTokenIsNotValid() throws Exception {
+    void shouldReturn400WhenRequestAccessTokenIsNotValid() throws Exception {
         when(mockContext.header("Authorization")).thenReturn("invalid-token");
         when(mockTokenService.validateAccessToken(Mockito.any())).thenReturn(INVALID_CLIENT);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.DCMAW_VC;
 
 @ExtendWith(MockitoExtension.class)
-public class DocAppCredentialHandlerTest {
+class DocAppCredentialHandlerTest {
     private static final String JSON_RESPONSE_TYPE = "application/json;charset=UTF-8";
     private static final String SUBJECT = "urn:uuid:5d6d6833-8512-4e37-b5ea-be7de77948dd";
     private static final ValidationResult INVALID_REQUEST =
@@ -58,7 +58,7 @@ public class DocAppCredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn201AndUserInfoWhenValidRequestReceived() throws Exception {
+    void shouldReturn201AndUserInfoWhenValidRequestReceived() throws Exception {
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn("aResourceId");
         when(mockTokenService.validateAccessToken(Mockito.anyString()))
@@ -83,7 +83,7 @@ public class DocAppCredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenAccessTokenIsNotProvided() throws Exception {
+    void shouldReturn400WhenAccessTokenIsNotProvided() throws Exception {
         when(mockTokenService.validateAccessToken(any())).thenReturn(INVALID_REQUEST);
 
         resourceHandler.getResource(mockContext);
@@ -93,8 +93,7 @@ public class DocAppCredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenIssuedAccessTokenDoesNotMatchRequestAccessToken()
-            throws Exception {
+    void shouldReturn400WhenIssuedAccessTokenDoesNotMatchRequestAccessToken() throws Exception {
         when(mockContext.header("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
         when(mockTokenService.validateAccessToken(any())).thenReturn(INVALID_CLIENT);
 
@@ -105,7 +104,7 @@ public class DocAppCredentialHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestAccessTokenIsNotValid() throws Exception {
+    void shouldReturn400WhenRequestAccessTokenIsNotValid() throws Exception {
         when(mockContext.header("Authorization")).thenReturn("invalid-token");
         when(mockTokenService.validateAccessToken(any())).thenReturn(INVALID_CLIENT);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -116,18 +116,20 @@ public class DocAppCredentialHandlerTest {
     }
 
     @Test
-     void shouldReturnErrorWhenUserInfoErrorIsRequested() throws Exception {
+    void shouldReturnErrorWhenUserInfoErrorIsRequested() throws Exception {
         when(mockTokenService.validateAccessToken(Mockito.anyString()))
                 .thenReturn(ValidationResult.createValidResult());
         when(mockContext.header("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
 
-        var expectedError = new UserInfoErrorResponse(
-                new ErrorObject(
-                        "404",
-                        String.format("UserInfo endpoint %s triggered by stub", "404"),
-                        Integer.parseInt("404")));
+        var expectedError =
+                new UserInfoErrorResponse(
+                        new ErrorObject(
+                                "404",
+                                String.format("UserInfo endpoint %s triggered by stub", "404"),
+                                Integer.parseInt("404")));
 
-        when(mockRequestedErrorResponseService.getUserInfoErrorByToken(any())).thenReturn(expectedError);
+        when(mockRequestedErrorResponseService.getUserInfoErrorByToken(any()))
+                .thenReturn(expectedError);
 
         resourceHandler.getResource(mockContext);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -26,15 +26,16 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.DCMAW_VC;
 
 @ExtendWith(MockitoExtension.class)
 public class DocAppCredentialHandlerTest {
     private static final String JSON_RESPONSE_TYPE = "application/json;charset=UTF-8";
+    private static final String SUBJECT = "urn:uuid:5d6d6833-8512-4e37-b5ea-be7de77948dd";
     private static final ValidationResult INVALID_REQUEST =
             new ValidationResult(false, OAuth2Error.INVALID_REQUEST);
     private static final ValidationResult INVALID_CLIENT =
@@ -64,7 +65,7 @@ public class DocAppCredentialHandlerTest {
                 .thenReturn(ValidationResult.createValidResult());
         when(mockContext.header("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
         when(mockCredentialService.getCredentialSignedJwt("aResourceId"))
-                .thenReturn("A.VERIFIABLE.CREDENTIAL");
+                .thenReturn(DCMAW_VC);
 
         resourceHandler.getResource(mockContext);
 
@@ -74,12 +75,12 @@ public class DocAppCredentialHandlerTest {
         verify(mockTokenService).revoke(accessToken.toAuthorizationHeader());
 
         var docAppUserInfo = new UserInfo(responseCaptor.getValue());
-        assertTrue(docAppUserInfo.getSubject().getValue().startsWith("urn:fdc:gov.uk:2022:"));
+        assertEquals(SUBJECT, docAppUserInfo.getSubject().getValue());
         assertNotNull(docAppUserInfo.getClaim("https://vocab.account.gov.uk/v1/credentialJWT"));
         List<?> verifiedCredentials =
                 (List<?>) docAppUserInfo.getClaim("https://vocab.account.gov.uk/v1/credentialJWT");
         assertEquals(1, verifiedCredentials.size());
-        assertEquals("A.VERIFIABLE.CREDENTIAL", verifiedCredentials.get(0));
+        assertEquals(DCMAW_VC, verifiedCredentials.get(0));
     }
 
     @Test

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/DocAppCredentialHandlerTest.java
@@ -64,8 +64,7 @@ public class DocAppCredentialHandlerTest {
         when(mockTokenService.validateAccessToken(Mockito.anyString()))
                 .thenReturn(ValidationResult.createValidResult());
         when(mockContext.header("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
-        when(mockCredentialService.getCredentialSignedJwt("aResourceId"))
-                .thenReturn(DCMAW_VC);
+        when(mockCredentialService.getCredentialSignedJwt("aResourceId")).thenReturn(DCMAW_VC);
 
         resourceHandler.getResource(mockContext);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandlerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.DCMAW_VC;
 
 @ExtendWith(MockitoExtension.class)
-public class F2FHandlerTest {
+class F2FHandlerTest {
     private static final String SUBJECT = "urn:uuid:5d6d6833-8512-4e37-b5ea-be7de77948dd";
 
     private static final ValidationResult INVALID_REQUEST =
@@ -59,7 +59,7 @@ public class F2FHandlerTest {
     }
 
     @Test
-    public void shouldReturn200AndUserInfoWhenValidRequestReceived() throws Exception {
+    void shouldReturn200AndUserInfoWhenValidRequestReceived() throws Exception {
         when(mockTokenService.getPayload(accessToken.toAuthorizationHeader()))
                 .thenReturn(UUID.randomUUID().toString());
         when(mockTokenService.validateAccessToken(Mockito.anyString()))
@@ -82,7 +82,7 @@ public class F2FHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenAccessTokenIsNotProvided() throws Exception {
+    void shouldReturn400WhenAccessTokenIsNotProvided() throws Exception {
         when(mockTokenService.validateAccessToken(Mockito.any())).thenReturn(INVALID_REQUEST);
 
         resourceHandler.getResource(mockContext);
@@ -92,8 +92,7 @@ public class F2FHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenIssuedAccessTokenDoesNotMatchRequestAccessToken()
-            throws Exception {
+    void shouldReturn400WhenIssuedAccessTokenDoesNotMatchRequestAccessToken() throws Exception {
         when(mockContext.header("Authorization")).thenReturn(accessToken.toAuthorizationHeader());
         when(mockTokenService.validateAccessToken(Mockito.any())).thenReturn(INVALID_CLIENT);
 
@@ -104,7 +103,7 @@ public class F2FHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestAccessTokenIsNotValid() throws Exception {
+    void shouldReturn400WhenRequestAccessTokenIsNotValid() throws Exception {
         when(mockContext.header("Authorization")).thenReturn("invalid-token");
         when(mockTokenService.validateAccessToken(Mockito.any())).thenReturn(INVALID_CLIENT);
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/F2FHandlerTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.stub.cred.service.CredentialService;
+import uk.gov.di.ipv.stub.cred.service.RequestedErrorResponseService;
 import uk.gov.di.ipv.stub.cred.service.TokenService;
 import uk.gov.di.ipv.stub.cred.validation.ValidationResult;
 
@@ -39,6 +40,7 @@ public class F2FHandlerTest {
     @Mock private Context mockContext;
     @Mock private TokenService mockTokenService;
     @Mock private CredentialService mockCredentialService;
+    @Mock private RequestedErrorResponseService mockRequestedErrorResponseService;
     @Captor private ArgumentCaptor<JSONObject> resultCaptor;
     private F2FHandler resourceHandler;
     private AccessToken accessToken;
@@ -48,7 +50,9 @@ public class F2FHandlerTest {
     void setup() {
         credential = DCMAW_VC;
         accessToken = new BearerAccessToken();
-        resourceHandler = new F2FHandler(mockCredentialService, mockTokenService);
+        resourceHandler =
+                new F2FHandler(
+                        mockCredentialService, mockTokenService, mockRequestedErrorResponseService);
     }
 
     @Test

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/GenerateCredentialHandlerTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.stub.cred.handlers.GenerateCredentialHandler.JWT_CONTENT_TYPE;
 
 @ExtendWith(MockitoExtension.class)
-public class GenerateCredentialHandlerTest {
+class GenerateCredentialHandlerTest {
     @Mock private Context mockContext;
     @Mock private VerifiableCredentialGenerator mockCredentialGenerator;
     @InjectMocks private GenerateCredentialHandler generateCredentialHandler;

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/JwksHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/JwksHandlerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.RSA_PRIVATE_KEY_JWK;
 
 @ExtendWith({SystemStubsExtension.class, MockitoExtension.class})
-public class JwksHandlerTest {
+class JwksHandlerTest {
 
     @SystemStub
     private static final EnvironmentVariables ENVIRONMENT_VARIABLES =

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -54,7 +54,7 @@ import static uk.gov.di.ipv.stub.cred.fixtures.TestFixtures.CLIENT_CONFIG;
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class TokenHandlerTest {
+class TokenHandlerTest {
     private static final String TEST_REDIRECT_URI = "https://example.com";
     private static final String TEST_AUTH_CODE =
             "e2Ln9Vs6bwZ1mDM8gfl256hg8I88i8LLenVfqxKuDEg"; // pragma: allowlist secret

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -200,7 +200,7 @@ public class TokenHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfClientConfigureForAuthenticationProvidesClientId() throws Exception {
+    void shouldReturn400IfClientConfigureForAuthenticationProvidesClientId() {
         setupMockFormParams(Map.of(RequestParamConstants.CLIENT_ID, "clientIdValid"));
         when(mockValidator.validateTokenRequest(any()))
                 .thenReturn(ValidationResult.createValidResult());
@@ -217,7 +217,7 @@ public class TokenHandlerTest {
     }
 
     @Test
-    void shouldReturn400ResponseWhenRedirectUrlsDoNotMatch() throws Exception {
+    void shouldReturn400ResponseWhenRedirectUrlsDoNotMatch() {
         setupMockFormParams(Map.of(RequestParamConstants.CLIENT_ID, "noAuthenticationClient"));
 
         when(mockValidator.validateTokenRequest(any()))
@@ -237,25 +237,25 @@ public class TokenHandlerTest {
     }
 
     @Test
-    void shouldReturn400WithRequestedOAuthError() throws Exception {
+    void shouldReturn400WithRequestedApiError() {
         setupMockFormParams(
                 Map.of(
                         RequestParamConstants.AUTH_CODE, "anAuthCode",
-                        RequestParamConstants.REQUESTED_OAUTH_ERROR, "access_denied",
                         RequestParamConstants.REQUESTED_OAUTH_ERROR_ENDPOINT, "token",
+                        RequestParamConstants.REQUESTED_API_ERROR, "403",
                         RequestParamConstants.REQUESTED_OAUTH_ERROR_DESCRIPTION,
                                 "an requestedError description"));
 
         requestedErrorResponseService.persist(
                 "anAuthCode",
-                new RequestedError("access_denied", "an error description", "token", null));
+                new RequestedError(null, "an error description", "token", null, "403"));
 
         tokenHandler.issueAccessToken(mockContext);
 
-        verify(mockContext).status(HttpStatus.BAD_REQUEST.getCode());
+        verify(mockContext).status(HttpStatus.FORBIDDEN.getCode());
         verify(mockContext).json(resultCaptor.capture());
 
-        assertEquals("access_denied", resultCaptor.getValue().get("error"));
+        assertEquals("403", resultCaptor.getValue().get("error"));
         assertEquals("an error description", resultCaptor.getValue().get("error_description"));
     }
 

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -81,7 +81,7 @@ class TokenHandlerTest {
                     "TEST");
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         StubSsmClient.setClientConfigParams(CLIENT_CONFIG);
     }
 
@@ -165,7 +165,7 @@ class TokenHandlerTest {
     }
 
     @Test
-    void shouldReturnCorrectErrorResponseIfTokenRequestFailsValidation() throws Exception {
+    void shouldReturnCorrectErrorResponseIfTokenRequestFailsValidation() {
         when(mockValidator.validateTokenRequest(any()))
                 .thenReturn(new ValidationResult(false, OAuth2Error.INVALID_CLIENT));
 
@@ -237,7 +237,7 @@ class TokenHandlerTest {
     }
 
     @Test
-    void shouldReturn400WithRequestedApiError() {
+    void shouldReturn403FromRequestedApiError() {
         setupMockFormParams(
                 Map.of(
                         RequestParamConstants.AUTH_CODE, "anAuthCode",

--- a/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
+++ b/di-ipv-credential-issuer-stub/src/test/java/uk/gov/di/ipv/stub/cred/handlers/TokenHandlerTest.java
@@ -247,8 +247,7 @@ public class TokenHandlerTest {
                                 "an requestedError description"));
 
         requestedErrorResponseService.persist(
-                "anAuthCode",
-                new RequestedError(null, "an error description", "token", null, "403"));
+                "anAuthCode", new RequestedError(null, "an error description", "token", "403"));
 
         tokenHandler.issueAccessToken(mockContext);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable simulating error responses from the /token and /credential endpoints of the CRI stubs

<img width="938" height="477" alt="Screenshot 2025-10-08 at 10 20 06" src="https://github.com/user-attachments/assets/56bb77cc-2e6d-4ba3-9821-4f0482d84db8" />
<img width="940" height="487" alt="Screenshot 2025-10-08 at 10 20 15" src="https://github.com/user-attachments/assets/bb23c837-03c3-46b2-bb6d-da63378a1853" />


### Why did it change
So that we can test these cases more easily

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8679](https://govukverify.atlassian.net/browse/PYIC-8679)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8679]: https://govukverify.atlassian.net/browse/PYIC-8679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ