### PR TITLE
SPT-1643: If SIS record not valid return 404

### DIFF
--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -200,7 +200,10 @@ export async function processGetIdentityRequest(
     },
   });
 
-  if (!getItemResponse.Item?.storedIdentity?.S) {
+  if (
+    !getItemResponse.Item?.storedIdentity?.S ||
+    !getItemResponse.Item?.isValid?.BOOL
+  ) {
     return { statusCode: 404, response: { message: "Not found" } };
   }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Return `404` if the SIS record is invalid.

### Why did it change

EVCS should not return a SIS record if it's invalid.

### Issue tracking

- [SPT-1643](https://govukverify.atlassian.net/browse/SPT-1643)

## Checklists

## Checklists

- [x] Tests have been written/updated


[SPT-1643]: https://govukverify.atlassian.net/browse/SPT-1643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ