### PR TITLE
PYIC-8702: require api key for SIS stub

### DIFF
--- a/di-ipv-sis-stub/README.md
+++ b/di-ipv-sis-stub/README.md
@@ -8,7 +8,7 @@ This will set up an API Gateway in front of a lambda to return the stored identi
 
 Gets a user's SI record.
 The endpoint does not accept any query/path parameters and does not accept a request body.
-It does however require an `Authorization: Bearer ...` header.
+It does however require an `Authorization: Bearer ...` header and an api key passed into the header.
 
 ### Example Response
 ```
@@ -16,7 +16,9 @@ It does however require an `Authorization: Bearer ...` header.
     "vot": "P2",
     "content": "eyJraWQiOiJ0ZXN0LXNpZ25pbmcta2V5IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJodHRwczovL3JldXNlLWlkZW50aXR5LmJ1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiZWFlMDFhYzI5MGE5ODRkMGVhN2MzM2NjNDVlMzZmMTIiLCJuYmYiOjE3NTA2ODIwMTgsImNyZWRlbnRpYWxzIjpbIk43UHhoZmtGa215VFFGS3lBWE15U19INk51Ri13RHpFa3RiX2RWdXJ1bFNSTU1YaG54aGJSMnJ4czlUYy1LUUIwaVhiMV85YUJJOFhDeTJBYkdRdkZRIiwiUzROSlBjaWltYmZ4MDhqczltOThoc3JLTDRiSkh0QlF5S0d0cmRJeklmWW1CUGpyVTlwYXpfdV8xaENySFo4aWp5UW81UlBtUWxNUC1fYzVldXZaSHciLCJBOU9IdUtJOE41aDRDNDU3UTRxdE52a1NGS2ZGZVZNNHNFR3dxUlBjU0hpUXlsemh4UnlxMDBlMURVUUxtU2RpZTlYSWswQ2ZpUVNBX3I3LW1tQ2JBdyIsInk0NHYwcEVBODh6dURoREZEQ0RjUGduOTZwOWJTRm9qeHZQQTFCeEdYTnhEMG5QelFONk1SaG1PWXBTUXg4TW92XzNLWUF4bmZ5aXdSemVBclhKa3FBIl0sImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkubG9jYWwuYWNjb3VudC5nb3YudWsiLCJjbGFpbXMiOnsiaHR0cHM6Ly92b2NhYi5hY2NvdW50Lmdvdi51ay92MS9jb3JlSWRlbnRpdHkiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NjUtMDctMDgifV19LCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL3YxL2FkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwiYnVpbGRpbmdOYW1lIjoiIiwiYnVpbGRpbmdOdW1iZXIiOiI4IiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJzdWJCdWlsZGluZ05hbWUiOiIiLCJ1cHJuIjoxMDAxMjAwMTIwNzcsInZhbGlkRnJvbSI6IjEwMDAtMDEtMDEifV0sImh0dHBzOi8vdm9jYWIuYWNjb3VudC5nb3YudWsvdjEvcGFzc3BvcnQiOlt7ImRvY3VtZW50TnVtYmVyIjoiMzIxNjU0OTg3IiwiZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJpY2FvSXNzdWVyQ29kZSI6IkdCUiJ9XX0sInZvdCI6IlAyIiwiaWF0IjoxNzUwNjgyMDE4fQ.nrbiwaOcvWM92TTAlORzerjjrrCuYD9fcxwEoXbf71J3YZUnwNW0KGUN5jaEvOysG0YWTXSLl_W4sN-Krf7PfQ", // pragma: allowlist secret
     "isValid": true,
-    "expired": false
+    "expired": false,
+    "govukSigninJourneyId": "someId",
+    "vtr": ["P2"]
 }
 ```
 

--- a/di-ipv-sis-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-sis-stub/core-dev-deploy/template.yaml
@@ -206,7 +206,9 @@ Resources:
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/sis-external.yaml"
+      ApiKeySourceType: HEADER #pragma: allowlist secret
       Auth:
+        ApiKeyRequired: true #pragma: allowlist secret
         UsagePlan:
           CreateUsagePlan: PER_API
           UsagePlanName: "SIS Usage Plan"

--- a/di-ipv-sis-stub/deploy/template.yaml
+++ b/di-ipv-sis-stub/deploy/template.yaml
@@ -252,7 +252,9 @@ Resources:
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/sis-external.yaml"
+      ApiKeySourceType: HEADER #pragma: allowlist secret
       Auth:
+        ApiKeyRequired: true #pragma: allowlist secret
         UsagePlan:
           CreateUsagePlan: PER_API
           UsagePlanName: "SIS Usage Plan"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Mark SIS stub API as requiring API key

### Why did it change

Real SIS needs an api key so we're updating our stub to match

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8702](https://govukverify.atlassian.net/browse/PYIC-8702)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8702]: https://govukverify.atlassian.net/browse/PYIC-8702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ