### PR TITLE
LIME-1905 Simplify ipv-core stub requests signing and improve error handling.

### DIFF
--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/JWTSigner.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/JWTSigner.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.stub.core.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+
+public class JWTSigner extends ECDSASigner {
+
+    private final String keyId;
+
+    JWTSigner(ECKey ecKey) throws JOSEException {
+        super(ecKey);
+        this.keyId = ecKey.getKeyID();
+    }
+
+    String getKeyId() {
+        return keyId;
+    }
+}

--- a/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/JwtHelper.java
+++ b/di-ipv-core-stub/src/main/java/uk/gov/di/ipv/stub/core/utils/JwtHelper.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.stub.core.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+public class JwtHelper {
+    private JwtHelper() {
+        // Utility Class
+    }
+
+    public static SignedJWT createSignedJwt(
+            JWTClaimsSet claimsSet, JWSSigner signer, String kid, JWSAlgorithm algorithm)
+            throws JOSEException {
+        JWSHeader jwsHeader = generateHeader(kid, algorithm);
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+
+    private static JWSHeader generateHeader(String kid, JWSAlgorithm algorithm) {
+        return new JWSHeader.Builder(algorithm).type(JOSEObjectType.JWT).keyID(kid).build();
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Switch JWT signing to the simpler approach used by IPV-Core.
  No longer recreates the jwtSigner when creating session jwts or handling token requests.

- Improve error handling on authcode, token and VC request failure. Existing request pattern had no error handling leading to a stub failure when the real failure was in the endpoint being called - which had returned an error message.

- Add CRI Name into key Journey log-lines to aid filtering the hosted stubs log group

- Reduce log lines containing redirects JWTs and claimsets These logs are verbose and contained large JWTs.

- Align Session and Token JWT signing.

### Why did it change

Correcting issues spotted when looking into signed token jwt issues.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1905](https://govukverify.atlassian.net/browse/LIME-1905)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[LIME-1905]: https://govukverify.atlassian.net/browse/LIME-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ