### PR TITLE
LIME-1905 Remove use-installer from core-stub actions

### DIFF
--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Setup SAM
         uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63
         with:
-          use-installer: true
           version: "1.134.0"
 
       - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Setup SAM
         uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63
         with:
-          use-installer: true
           version: "1.134.0"
 
       - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Setup SAM
         uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63
         with:
-          use-installer: true
           version: "1.134.0"
 
       - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527

--- a/.github/workflows/core-passport-stub.yml
+++ b/.github/workflows/core-passport-stub.yml
@@ -84,7 +84,6 @@ jobs:
       - name: Setup SAM
         uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63
         with:
-          use-installer: true
           version: "1.134.0"
 
       - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove use-installer from core-stub actions.

### Why did it change

setup sam is indicating it is unsupported with arm, even tho we are using a version that should be

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1905](https://govukverify.atlassian.net/browse/LIME-1905)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[LIME-1905]: https://govukverify.atlassian.net/browse/LIME-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ