### PR TITLE
PYIC-8720: update SIS to return 404 when SI record if malformed and t…

### DIFF
--- a/di-ipv-sis-stub/lambdas/src/services/sisService.ts
+++ b/di-ipv-sis-stub/lambdas/src/services/sisService.ts
@@ -54,6 +54,9 @@ export const getUserIdentity = async (
   });
 
   const validatedResponse = validateUserIdentityResponse(parsedResponse[0]);
+  if (!validatedResponse) {
+    return null;
+  }
 
   const signedJwt = validatedResponse.siJwt;
   let matchedProfile = validatedResponse.maxVot;
@@ -90,11 +93,7 @@ export const getUserIdentity = async (
   return {
     content: siContent,
     vot: validatedResponse.maxVot,
-    isValid: !!(
-      validatedResponse.isValid &&
-      matchedProfile &&
-      matchedProfile != "P0"
-    ),
+    isValid: validatedResponse.isValid,
     // defaulting to false as the ttl is set to the default
     // retention of VCs which is 120 years
     expired: false,
@@ -114,6 +113,7 @@ const validateUserIdentityResponse = (userIdentityResponse: any) => {
 
   if (missingProperties.length != 0) {
     console.info(`Missing required properties: ${missingProperties}`);
+    return null;
   }
 
   return userIdentityResponse;

--- a/di-ipv-sis-stub/lambdas/test/handlers/sisHandler.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/handlers/sisHandler.test.ts
@@ -92,7 +92,7 @@ describe("getUserIdentityHandler", () => {
     expect(res.body).toBe(JSON.stringify(expectedUserIdentity));
   });
 
-  it("should return 404 if no SI record is found for user", async () => {
+  it("should return 404 if no SI record is found for user or if si record if malformed", async () => {
     // Arrange
     jest.mocked(getUserIdentity).mockResolvedValue(null);
     jest.mocked(getUserIdFromBearerToken).mockResolvedValueOnce(TEST_USER_ID);

--- a/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
+++ b/di-ipv-sis-stub/lambdas/test/services/sisService.test.ts
@@ -129,7 +129,7 @@ describe("getUserIdentity", () => {
     });
   });
 
-  it("should return malformed JSON if required properties are missing and isValid=false", async () => {
+  it("should return null if required properties are missing", async () => {
     // Arrange
     const malformedJson = { isValid: true };
     dbMock.on(QueryCommand).resolves({
@@ -140,13 +140,7 @@ describe("getUserIdentity", () => {
     const res = await getUserIdentity(TEST_USER_ID, TEST_VTRS);
 
     // Assert
-    expect(res).toEqual({
-      ...malformedJson,
-      expired: false,
-      kidValid: true,
-      signatureValid: true,
-      isValid: false,
-    });
+    expect(res).toEqual(null);
   });
 
   it("should return null if it no SI exists for user", async () => {
@@ -162,7 +156,7 @@ describe("getUserIdentity", () => {
     expect(res).toBeNull();
   });
 
-  it("should return not valid and content.vot=P0 if level of confidence on sis record does not match any of the requested VTRs", async () => {
+  it("should return content.vot=P0 if level of confidence on sis record does not match any of the requested VTRs", async () => {
     // Arrange
     dbMock.on(QueryCommand).resolves({
       Items: [marshall({ ...MOCK_USER_IDENTITY, levelOfConfidence: "P1" })],
@@ -178,7 +172,7 @@ describe("getUserIdentity", () => {
       expired: false,
       kidValid: true,
       signatureValid: true,
-      isValid: false,
+      isValid: true,
     });
   });
 


### PR DESCRIPTION
…o return isValid=true even when vtr is not met

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

update SIS to return 404 when SI record if malformed and to return isValid=true even when vtr is not met

### Why did it change

Inconsistency in SIS verification raised so updating stub logic to match.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8720](https://govukverify.atlassian.net/browse/PYIC-8720)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8720]: https://govukverify.atlassian.net/browse/PYIC-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ