### PR TITLE
SPT-1699: EVCS Added unsignedVot to GET /identity

### DIFF
--- a/di-ipv-evcs-stub/lambdas/src/domain/sharedTypes.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/sharedTypes.ts
@@ -9,7 +9,7 @@ export interface VcDetails {
 
 export type StoredIdentityResponse = {
   si: Omit<VCIncludingStateAndMetadata, "state">;
-  vcs: VCIncludingStateAndMetadata[];
+  vcs: Omit<VCIncludingStateAndMetadata, "unsignedVot">[];
 };
 
 export interface VCIncludingStateAndMetadata {
@@ -17,4 +17,5 @@ export interface VCIncludingStateAndMetadata {
   vc: string;
   metadata?: Record<string, unknown>;
   signature?: string;
+  unsignedVot?: string;
 }

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -227,7 +227,10 @@ export async function processGetIdentityRequest(
   });
 
   const response: StoredIdentityResponse = {
-    si: { vc: getItemResponse.Item.storedIdentity.S },
+    si: {
+      vc: getItemResponse.Item.storedIdentity.S,
+      unsignedVot: getItemResponse.Item.levelOfConfidence.S,
+    },
     vcs:
       value.Items?.map((vc) => ({
         vc: vc.vc.S || "",

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -361,6 +361,9 @@ describe("processGetIdentityRequest", () => {
           isValid: {
             BOOL: true,
           },
+          levelOfConfidence: {
+            S: "P3",
+          },
         },
       } satisfies GetItemCommandOutput)
       .on(QueryCommand)
@@ -376,6 +379,7 @@ describe("processGetIdentityRequest", () => {
       response: {
         si: {
           vc: TEST_SI_JWT,
+          unsignedVot: "P3",
         },
         vcs: [],
       },
@@ -393,6 +397,9 @@ describe("processGetIdentityRequest", () => {
           },
           isValid: {
             BOOL: false,
+          },
+          levelOfConfidence: {
+            S: "P3",
           },
         },
       } satisfies GetItemCommandOutput)
@@ -423,6 +430,9 @@ describe("processGetIdentityRequest", () => {
           },
           isValid: {
             BOOL: true,
+          },
+          levelOfConfidence: {
+            S: "P3",
           },
         },
       } satisfies GetItemCommandOutput)
@@ -455,6 +465,7 @@ describe("processGetIdentityRequest", () => {
       response: {
         si: {
           vc: TEST_SI_JWT,
+          unsignedVot: "P3",
         },
         vcs: [
           {


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the EVCS `GET /identity` endpoint to return the additional field `unsignedVot` which will contain the value of the `vot` field within the DynamoDb record.

### Why did it change

There is been some confusion between the Vector of Trust (VOT) field within a signed Stored Identity JWT and the VOT field which is passed into EVCS when a Stored Identity is persisted. 

Currently EVCS and SIS are designed to return the VOT from within the signed Stored Identity JWT, however IPV Core were expecting the VOT which is stored alongside the signed JWT in a separate field in DynamoDb. This has lead to confusion as the VOT metadata may be `P3` but the Stored Identity JWT may be `P2`. So currently the Stored Identity Service are returning `P2` when IPV Core are expecting `P3`.

IPV Core are going to start including the `max_vot` field within the signed Stored Identity JWT which will be used by the Stored Identity Service moving forwards. However, there are a number of existing records where this field is not present. As a work around for this phase of work, SIS will use the `unsignedVot` when the `max_vot` is not present in the JWT.

### Issue tracking

- [SPT-1699](https://govukverify.atlassian.net/browse/SPT-1699)

## Checklists

- [x] Tests have been written/updated


[SPT-1699]: https://govukverify.atlassian.net/browse/SPT-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ