### PR TITLE
PYIC-8764: add invalid data for new DL details

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataDcmaw.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataDcmaw.java
@@ -110,6 +110,11 @@ public class CriStubDataDcmaw {
                             BirthDates.KENNETH_DECERQUEIRA,
                             DrivingLicences.KENNETH_DECERQUEIRA_DVLA_INVALID),
                     createData(
+                            "Kenneth Decerqueira (Invalid) DVLA Licence 2",
+                            Names.Kenneth_Decerqueira,
+                            BirthDates.KENNETH_DECERQUEIRA,
+                            DrivingLicences.KENNETH_DECERQUEIRA_DVLA_2_INVALID),
+                    createData(
                             "Kenneth Decerqueira (International)",
                             Names.Kenneth_Decerqueira,
                             BirthDates.KENNETH_DECERQUEIRA,

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/DrivingLicences.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/DrivingLicences.java
@@ -31,6 +31,14 @@ public class DrivingLicences {
                     "DVLA",
                     "17",
                     "8 HADLEY ROAD BATH BA2 5AA");
+    public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVLA_2_INVALID =
+            createDrivingPermit(
+                    "DECER607085K99AE",
+                    "2025-05-03",
+                    "2025-05-02",
+                    "DVLA",
+                    "17",
+                    "8 HADLEY ROAD BATH BA2 5AA");
     public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVLA_INVALID =
             createDrivingPermit(
                     "", "2025-04-27", "2023-08-22", "DVLA", "11", "8 HADLEY ROAD BATH BR2 5LP");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- add new invalid data for DVLA 2 details

### Why did it change

- the current invalid data set is only for the old DVLA details and aren't being properly processed by the DL CRI in staging (as part of another PR, I'll investigate whether we still need the old invalid DVLA details, and if not, remove them)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8764](https://govukverify.atlassian.net/browse/PYIC-8764)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8764]: https://govukverify.atlassian.net/browse/PYIC-8764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ