### PR TITLE
PYIC-8825: Disable running scripts during NPM install

### DIFF
--- a/di-ipv-ais-stub/lambdas/.npmrc
+++ b/di-ipv-ais-stub/lambdas/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-cimit-stub-ts/lambdas/.npmrc
+++ b/di-ipv-cimit-stub-ts/lambdas/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-core-stub/deploy/cri-http-api-basic-auth/.npmrc
+++ b/di-ipv-core-stub/deploy/cri-http-api-basic-auth/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-core-stub/deploy/cri-http-api-basic-auth/authorizer/.npmrc
+++ b/di-ipv-core-stub/deploy/cri-http-api-basic-auth/authorizer/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-core-stub/deploy/cri-rest-api/.npmrc
+++ b/di-ipv-core-stub/deploy/cri-rest-api/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-core-stub/deploy/cri-rest-api/authorizer/.npmrc
+++ b/di-ipv-core-stub/deploy/cri-rest-api/authorizer/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-dcmaw-async-stub/lambdas/.npmrc
+++ b/di-ipv-dcmaw-async-stub/lambdas/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-evcs-stub/lambdas/.npmrc
+++ b/di-ipv-evcs-stub/lambdas/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-queue-stub/enqueue-event/.npmrc
+++ b/di-ipv-queue-stub/enqueue-event/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-sis-stub/lambdas/.npmrc
+++ b/di-ipv-sis-stub/lambdas/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/di-ipv-ticf-stub/lambdas/.npmrc
+++ b/di-ipv-ticf-stub/lambdas/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/update-ecs-env-vars/.npmrc
+++ b/update-ecs-env-vars/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
There have been a couple of recent attacks where npm pre and post install scripts have been used to infect machines

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added `.npmrc` files to all npm folders

### Why did it change

To stop attacks that run in npm pre and post install scripts

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8825](https://govukverify.atlassian.net/browse/PYIC-8825)



[PYIC-8825]: https://govukverify.atlassian.net/browse/PYIC-8825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ