### PR TITLE
BAU: Update deprecated docker image

### DIFF
--- a/public-jwk-creator/Dockerfile
+++ b/public-jwk-creator/Dockerfile
@@ -1,15 +1,15 @@
-FROM openjdk:17-jdk-slim AS build
+FROM amazoncorretto:17 AS build
 COPY . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN ./gradlew build --no-daemon
 
-FROM openjdk:17-jdk-slim
+FROM amazoncorretto:17
 
-ENV PORT 8084
-ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
-RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+ENV PORT=8084
+ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006"
+RUN yum update -y && yum install -y shadow-utils curl tar
+RUN groupadd -r -g 1001 appgroup && useradd -r -u 1001 -g appgroup appuser
 RUN mkdir /app
-RUN apt-get update && apt-get install -y curl
 COPY --from=build \
     /home/gradle/src/build/distributions/public-jwk-creator-1.0-SNAPSHOT.tar \
     /app/


### PR DESCRIPTION
openjdk:17-jdk-slim is deprecated so swapped to corretto which involved some command syntax changes.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Changed docker base image for public-jwk-creator

### Why did it change

The previous image is no longer available

