### PR TITLE
PYIC-8831: Update DCMAW Async Stub to simulate the use of an expired Drivers License

### DIFF
--- a/di-ipv-dcmaw-async-stub/README.md
+++ b/di-ipv-dcmaw-async-stub/README.md
@@ -40,8 +40,14 @@ HTTP/1.1 201 Created
 }
 ```
 
-### Additionally a management endpoint is exposed, which can be hit manually (for example via curl).
+## Management Endpoints
+Additionally, a management endpoint is exposed, which can be hit manually (for example via curl).
+
+See `openAPI/dcmaw-async-external.yaml` for the shape of the requests and expected responses. The user id provided must be that of an already initialised DCMAW session (via the `async/credential` request). The oauth state value passed in the original `async/credential` request will have been stored against the user id so that it can be provided in the VC queue message.
+
+### `management/enqueueVc`
 The `management/enqueueVc` endpoint will build and sign a VC based on the inputs provided and push a VC message onto the CRI response queue (via the queue stub lambda).
+
 The message will look something like this:
 ```
 {
@@ -52,11 +58,31 @@ The message will look something like this:
 }
 ```
 
+Whilst it is possible to send an evidence and credential subject block in the request body:
+```
+{
+  "credential_subject": {...},
+  "evidence": {...}
+}
+```
+
+It's also possible to enqueue a VC with pre-defined claims to avoid having to create the credential and evidence blocks manually:
+```
+{
+  "userId": "a-user-id",
+  "test_user": "kennethD", # Check the api spec to see what values we support for this
+  "document_type": "drivingPermit", # Check the api spec to see what values we support for this
+  "evidence_type": "success", # Check the api spec to see what values we support for this
+  "driving_permit_expiry_date": "2030-01-01" # An optional parameter which overrides the expiry date of the driving permit set by the stub (by default, it is 30 days after the issued at date ie when the VC was generated),
+  "ci": ["CI1"]
+}
+```
+
+### `management/generateVc`
 The `management/generateVc` endpoint will build and sign a VC based on the inputs provided and return it directly.
 
+### `management/enqueueError`
 The `management/enqueueError` endpoint will push an error message onto the CRI response queue, for example to simulate an "access-denied" error scenario.
-
-See `openAPI/dcmaw-async-external.yaml` for the shape of the requests and expected responses. The user id provided must be that of an already initialised DCMAW session (via the `async/credential` request). The oauth state value passed in the original `async/credential` request will have been stored against the user id so that it can be provided in the VC queue message.
 
 ### Currently, following SSM parameters are used to control VC structure.
 To save hits to SSM we have a single config value in the form of a JSON string

--- a/di-ipv-dcmaw-async-stub/lambdas/src/data/vcDocumentClaims.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/data/vcDocumentClaims.ts
@@ -1,0 +1,25 @@
+import { DocumentType } from "../domain/managementEnqueueRequest";
+
+export const DOCUMENT_CLAIMS = {
+  [DocumentType.ukChippedPassport]: {
+    passport: [
+      {
+        documentNumber: "321654987",
+        expiryDate: "2030-01-01",
+        icaoIssuerCode: "GBR",
+      },
+    ],
+  },
+  [DocumentType.drivingPermit]: {
+    drivingPermit: [
+      {
+        expiryDate: "2033-01-18",
+        issueNumber: "5",
+        issuedBy: "DVLA",
+        fullAddress: "8 HADLEY ROAD BATH BA2 5AA",
+        personalNumber: "DECER607085K9123",
+        issueDate: "2023-01-18",
+      },
+    ],
+  },
+};

--- a/di-ipv-dcmaw-async-stub/lambdas/src/data/vcEvidenceClaims.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/data/vcEvidenceClaims.ts
@@ -1,0 +1,73 @@
+import { DocumentType, EvidenceType } from "../domain/managementEnqueueRequest";
+
+export const EVIDENCE_CLAIMS = {
+  [DocumentType.ukChippedPassport]: {
+    [EvidenceType.success]: {
+      type: "IdentityCheck",
+      strengthScore: 4,
+      validityScore: 3,
+      checkDetails: [
+        {
+          checkMethod: "vcrypt",
+          identityCheckPolicy: "published",
+          activityFrom: null,
+        },
+        {
+          checkMethod: "bvr",
+          biometricVerificationProcessLevel: 3,
+        },
+      ],
+    },
+    [EvidenceType.fail]: {
+      type: "IdentityCheck",
+      strengthScore: 4,
+      validityScore: 0,
+      failedCheckDetails: [
+        {
+          checkMethod: "vcrypt",
+          identityCheckPolicy: "published",
+          activityFrom: null,
+        },
+        {
+          checkMethod: "bvr",
+          biometricVerificationProcessLevel: 3,
+        },
+      ],
+    },
+  },
+  [DocumentType.drivingPermit]: {
+    [EvidenceType.success]: {
+      type: "IdentityCheck",
+      strengthScore: 3,
+      validityScore: 2,
+      activityHistoryScore: 1,
+      checkDetails: [
+        {
+          checkMethod: "vcrypt",
+          identityCheckPolicy: "published",
+          activityFrom: null,
+        },
+        {
+          checkMethod: "bvr",
+          biometricVerificationProcessLevel: 3,
+        },
+      ],
+    },
+    [EvidenceType.fail]: {
+      type: "IdentityCheck",
+      strengthScore: 4,
+      validityScore: 0,
+      failedCheckDetails: [
+        {
+          checkMethod: "vcrypt",
+          identityCheckPolicy: "published",
+          activityFrom: null,
+        },
+        {
+          checkMethod: "bvr",
+          biometricVerificationProcessLevel: 3,
+        },
+      ],
+    },
+  },
+};

--- a/di-ipv-dcmaw-async-stub/lambdas/src/data/vcEvidenceClaims.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/data/vcEvidenceClaims.ts
@@ -55,7 +55,7 @@ export const EVIDENCE_CLAIMS = {
     },
     [EvidenceType.fail]: {
       type: "IdentityCheck",
-      strengthScore: 4,
+      strengthScore: 3,
       validityScore: 0,
       failedCheckDetails: [
         {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/data/vcUserClaims.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/data/vcUserClaims.ts
@@ -1,0 +1,25 @@
+import { TestUser } from "../domain/managementEnqueueRequest";
+
+export const USER_CLAIMS = {
+  [TestUser.kennethD]: {
+    name: [
+      {
+        nameParts: [
+          {
+            value: "Kenneth",
+            type: "GivenName",
+          },
+          {
+            value: "Decerqueira",
+            type: "FamilyName",
+          },
+        ],
+      },
+    ],
+    birthDate: [
+      {
+        value: "1965-07-08",
+      },
+    ],
+  },
+};

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -63,6 +63,28 @@ export interface ManagementEnqueueErrorRequest {
   delay_seconds?: number;
 }
 
+interface DrivingPermitDetails {
+  expiryDate: string;
+  issueNumber: string;
+  issuedBy: string;
+  fullAddress: string;
+  personalNumber: string;
+  issueDate: string;
+}
+
+interface DrivingPermitCredentialSubject {
+  drivingPermit: DrivingPermitDetails[];
+}
+
+export function isDrivingPermitCredentialSubject(
+  documentDetails: unknown,
+): documentDetails is DrivingPermitCredentialSubject {
+  return (
+    (documentDetails as DrivingPermitCredentialSubject)["drivingPermit"] !==
+    null
+  );
+}
+
 export enum TestUser {
   kennethD = "kennethD",
 }

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -72,17 +72,23 @@ interface DrivingPermitDetails {
   issueDate: string;
 }
 
-interface DrivingPermitCredentialSubject {
+export interface DrivingPermitCredentialSubject extends BaseCredentialSubject {
   drivingPermit: DrivingPermitDetails[];
+}
+
+export interface PassportCredentialSubject extends BaseCredentialSubject {
+  passport: object;
 }
 
 export function isDrivingPermitCredentialSubject(
   documentDetails: unknown,
 ): documentDetails is DrivingPermitCredentialSubject {
-  return (
-    (documentDetails as DrivingPermitCredentialSubject)["drivingPermit"] !==
-    null
-  );
+  return "drivingPermit" in (documentDetails as DrivingPermitCredentialSubject);
+}
+
+interface BaseCredentialSubject {
+  name: object;
+  birthDate: object;
 }
 
 export enum TestUser {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -16,6 +16,7 @@ export interface ManagementEnqueueVcRequestIndividualDetails
   test_user: TestUser;
   document_type: DocumentType;
   evidence_type: EvidenceType;
+  driving_permit_expiry_date?: string;
   ci?: string[];
 }
 
@@ -68,6 +69,7 @@ export enum TestUser {
 
 export enum DocumentType {
   ukChippedPassport = "ukChippedPassport",
+  drivingPermit = "drivingPermit",
 }
 
 export enum EvidenceType {

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -96,7 +96,7 @@ export async function buildMockVcFromSubjectAndEvidence(
   };
 }
 
-const testUserClaims = {
+export const testUserClaims = {
   [TestUser.kennethD]: {
     name: [
       {
@@ -120,7 +120,7 @@ const testUserClaims = {
   },
 };
 
-const documentClaims = {
+export const documentClaims = {
   [DocumentType.ukChippedPassport]: {
     passport: [
       {
@@ -144,7 +144,7 @@ const documentClaims = {
   },
 };
 
-const evidence = {
+export const evidence = {
   [DocumentType.ukChippedPassport]: {
     [EvidenceType.success]: {
       type: "IdentityCheck",

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -44,7 +44,7 @@ export async function buildMockVc(
                   ...documentDetails.drivingPermit[0],
                   expiryDate:
                     drivingPermitExpiryDate ??
-                    getFutureExpiryDateStringFromIssuedAt(currentTimestamp),
+                    getFutureExpiryDateStringFromNbf(currentTimestamp),
                 },
               ],
             }
@@ -88,7 +88,7 @@ export async function buildMockVcFromSubjectAndEvidence(
   };
 }
 
-function getFutureExpiryDateStringFromIssuedAt(issuedAt: number): string {
+function getFutureExpiryDateStringFromNbf(issuedAt: number): string {
   // Create a default future date, 30 days ahead of the VC issued at date
   return new Date((issuedAt + 30 * 24 * 60 * 60) * 1000)
     .toISOString()

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -19,39 +19,37 @@ export async function buildMockVc(
   ci: string[] = [],
 ) {
   const config = await getConfig();
-  const timestamp = Math.round(new Date().getTime() / 1000);
-
+  const currentTimestamp = Math.round(new Date().getTime() / 1000);
   const documentDetails = DOCUMENT_CLAIMS[documentType];
-  const credentialSubject = {
-    ...USER_CLAIMS[testUser],
-    ...(isDrivingPermitCredentialSubject(documentDetails)
-      ? {
-          drivingPermit: [
-            {
-              ...documentDetails.drivingPermit[0],
-              expiryDate:
-                drivingPermitExpiryDate ??
-                getFutureExpiryDateStringFromIssuedAt(timestamp),
-            },
-          ],
-        }
-      : documentDetails),
-  };
 
   return {
     jti: crypto.randomUUID(),
     iss: config.vcIssuer,
     aud: config.vcAudience,
     sub: userId,
-    iat: timestamp,
-    nbf: timestamp,
+    iat: currentTimestamp,
+    nbf: currentTimestamp,
     vc: {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
         "https://vocab.account.gov.uk/contexts/identity-v1.jsonld",
       ],
       type: ["VerifiableCredential", "IdentityCheckCredential"],
-      credentialSubject,
+      credentialSubject: {
+        ...USER_CLAIMS[testUser],
+        ...(isDrivingPermitCredentialSubject(documentDetails)
+          ? {
+              drivingPermit: [
+                {
+                  ...documentDetails.drivingPermit[0],
+                  expiryDate:
+                    drivingPermitExpiryDate ??
+                    getFutureExpiryDateStringFromIssuedAt(currentTimestamp),
+                },
+              ],
+            }
+          : documentDetails),
+      },
       evidence: [
         {
           ...EVIDENCE_CLAIMS[documentType][evidenceType],

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -42,6 +42,7 @@ export async function handler(
         requestBody.test_user,
         requestBody.document_type,
         requestBody.evidence_type,
+        requestBody.driving_permit_expiry_date,
         requestBody.ci,
       );
     } else if (isManagementEnqueueVcRequestEvidenceAndSubject(requestBody)) {

--- a/di-ipv-dcmaw-async-stub/lambdas/test/domain/mockVc.test.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/test/domain/mockVc.test.ts
@@ -1,0 +1,139 @@
+import {
+  buildMockVc,
+  documentClaims,
+  evidence,
+  testUserClaims,
+} from "../../src/domain/mockVc";
+import {
+  DocumentType,
+  DrivingPermitCredentialSubject,
+  EvidenceType,
+  PassportCredentialSubject,
+  TestUser,
+} from "../../src/domain/managementEnqueueRequest";
+
+jest.useFakeTimers().setSystemTime(new Date("2023-01-01"));
+
+jest.mock(
+  "../../src/common/config",
+  () => () =>
+    Promise.resolve({
+      vcIssuer: "vc-issuer",
+      vcAudience: "vc-audience",
+    }),
+);
+
+const TEST_USER_ID = "testUserId";
+
+describe("buildMockVc", () => {
+  test("returns driving permit mock VC with future expiry date as 30 after current date if drivingPermitExpiryDate is not provided", async () => {
+    // Act
+    const vc = await buildMockVc(
+      TEST_USER_ID,
+      TestUser.kennethD,
+      DocumentType.drivingPermit,
+      EvidenceType.success,
+      undefined,
+      ["CI1", "CI2"],
+    );
+
+    // Assert
+    expect(vc.sub).toEqual(TEST_USER_ID);
+
+    const credentials = vc.vc
+      .credentialSubject as DrivingPermitCredentialSubject;
+    expect(credentials["name"]).toEqual(testUserClaims[TestUser.kennethD].name);
+    expect(credentials["birthDate"]).toEqual(
+      testUserClaims[TestUser.kennethD].birthDate,
+    );
+
+    const expectedExpiryDate = "2023-01-31";
+    expect(credentials.drivingPermit).toEqual([
+      {
+        ...documentClaims[DocumentType.drivingPermit].drivingPermit[0],
+        expiryDate: expectedExpiryDate,
+      },
+    ]);
+
+    expect(vc.vc.evidence[0]).toEqual(
+      expect.objectContaining({
+        ...evidence[DocumentType.drivingPermit][EvidenceType.success],
+        ci: ["CI1", "CI2"],
+        txn: expect.any(String),
+      }),
+    );
+  });
+
+  test("returns driving permit mock VC with custom drivingPermitExpiryDate when provided", async () => {
+    // Arrange
+    const expectedExpiryDate = "2022-01-01";
+
+    // Act
+    const vc = await buildMockVc(
+      TEST_USER_ID,
+      TestUser.kennethD,
+      DocumentType.drivingPermit,
+      EvidenceType.success,
+      expectedExpiryDate,
+      undefined,
+    );
+
+    // Assert
+    expect(vc.sub).toEqual(TEST_USER_ID);
+
+    const credentials = vc.vc
+      .credentialSubject as DrivingPermitCredentialSubject;
+    expect(credentials["name"]).toEqual(testUserClaims[TestUser.kennethD].name);
+    expect(credentials["birthDate"]).toEqual(
+      testUserClaims[TestUser.kennethD].birthDate,
+    );
+
+    expect(credentials.drivingPermit).toEqual([
+      {
+        ...documentClaims[DocumentType.drivingPermit].drivingPermit[0],
+        expiryDate: expectedExpiryDate,
+      },
+    ]);
+
+    expect(vc.vc.evidence[0]).toEqual(
+      expect.objectContaining({
+        ...evidence[DocumentType.drivingPermit][EvidenceType.success],
+        ci: [],
+        txn: expect.any(String),
+      }),
+    );
+  });
+
+  test("returns mock passport vc for given test user", async () => {
+    // Act
+    const vc = await buildMockVc(
+      TEST_USER_ID,
+      TestUser.kennethD,
+      DocumentType.ukChippedPassport,
+      EvidenceType.success,
+      undefined,
+      ["CI1", "CI2"],
+    );
+
+    // Assert
+    expect(vc.sub).toEqual(TEST_USER_ID);
+
+    const credentials = vc.vc.credentialSubject as PassportCredentialSubject;
+    expect(credentials["name"]).toEqual(testUserClaims[TestUser.kennethD].name);
+    expect(credentials["birthDate"]).toEqual(
+      testUserClaims[TestUser.kennethD].birthDate,
+    );
+
+    expect(credentials.passport).toEqual([
+      documentClaims[DocumentType.ukChippedPassport].passport[0],
+    ]);
+
+    expect(vc.vc.evidence[0]).toEqual(
+      expect.objectContaining({
+        ...evidence[DocumentType.ukChippedPassport][EvidenceType.success],
+        ci: ["CI1", "CI2"],
+        txn: expect.any(String),
+      }),
+    );
+  });
+});

--- a/di-ipv-dcmaw-async-stub/lambdas/test/domain/mockVc.test.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/test/domain/mockVc.test.ts
@@ -1,9 +1,4 @@
-import {
-  buildMockVc,
-  documentClaims,
-  evidence,
-  testUserClaims,
-} from "../../src/domain/mockVc";
+import { buildMockVc } from "../../src/domain/mockVc";
 import {
   DocumentType,
   DrivingPermitCredentialSubject,
@@ -11,6 +6,9 @@ import {
   PassportCredentialSubject,
   TestUser,
 } from "../../src/domain/managementEnqueueRequest";
+import { USER_CLAIMS } from "../../src/data/vcUserClaims";
+import { DOCUMENT_CLAIMS } from "../../src/data/vcDocumentClaims";
+import { EVIDENCE_CLAIMS } from "../../src/data/vcEvidenceClaims";
 
 jest.useFakeTimers().setSystemTime(new Date("2023-01-01"));
 
@@ -42,22 +40,22 @@ describe("buildMockVc", () => {
 
     const credentials = vc.vc
       .credentialSubject as DrivingPermitCredentialSubject;
-    expect(credentials["name"]).toEqual(testUserClaims[TestUser.kennethD].name);
+    expect(credentials["name"]).toEqual(USER_CLAIMS[TestUser.kennethD].name);
     expect(credentials["birthDate"]).toEqual(
-      testUserClaims[TestUser.kennethD].birthDate,
+      USER_CLAIMS[TestUser.kennethD].birthDate,
     );
 
     const expectedExpiryDate = "2023-01-31";
     expect(credentials.drivingPermit).toEqual([
       {
-        ...documentClaims[DocumentType.drivingPermit].drivingPermit[0],
+        ...DOCUMENT_CLAIMS[DocumentType.drivingPermit].drivingPermit[0],
         expiryDate: expectedExpiryDate,
       },
     ]);
 
     expect(vc.vc.evidence[0]).toEqual(
       expect.objectContaining({
-        ...evidence[DocumentType.drivingPermit][EvidenceType.success],
+        ...EVIDENCE_CLAIMS[DocumentType.drivingPermit][EvidenceType.success],
         ci: ["CI1", "CI2"],
         txn: expect.any(String),
       }),
@@ -83,21 +81,21 @@ describe("buildMockVc", () => {
 
     const credentials = vc.vc
       .credentialSubject as DrivingPermitCredentialSubject;
-    expect(credentials["name"]).toEqual(testUserClaims[TestUser.kennethD].name);
+    expect(credentials["name"]).toEqual(USER_CLAIMS[TestUser.kennethD].name);
     expect(credentials["birthDate"]).toEqual(
-      testUserClaims[TestUser.kennethD].birthDate,
+      USER_CLAIMS[TestUser.kennethD].birthDate,
     );
 
     expect(credentials.drivingPermit).toEqual([
       {
-        ...documentClaims[DocumentType.drivingPermit].drivingPermit[0],
+        ...DOCUMENT_CLAIMS[DocumentType.drivingPermit].drivingPermit[0],
         expiryDate: expectedExpiryDate,
       },
     ]);
 
     expect(vc.vc.evidence[0]).toEqual(
       expect.objectContaining({
-        ...evidence[DocumentType.drivingPermit][EvidenceType.success],
+        ...EVIDENCE_CLAIMS[DocumentType.drivingPermit][EvidenceType.success],
         ci: [],
         txn: expect.any(String),
       }),
@@ -119,18 +117,20 @@ describe("buildMockVc", () => {
     expect(vc.sub).toEqual(TEST_USER_ID);
 
     const credentials = vc.vc.credentialSubject as PassportCredentialSubject;
-    expect(credentials["name"]).toEqual(testUserClaims[TestUser.kennethD].name);
+    expect(credentials["name"]).toEqual(USER_CLAIMS[TestUser.kennethD].name);
     expect(credentials["birthDate"]).toEqual(
-      testUserClaims[TestUser.kennethD].birthDate,
+      USER_CLAIMS[TestUser.kennethD].birthDate,
     );
 
     expect(credentials.passport).toEqual([
-      documentClaims[DocumentType.ukChippedPassport].passport[0],
+      DOCUMENT_CLAIMS[DocumentType.ukChippedPassport].passport[0],
     ]);
 
     expect(vc.vc.evidence[0]).toEqual(
       expect.objectContaining({
-        ...evidence[DocumentType.ukChippedPassport][EvidenceType.success],
+        ...EVIDENCE_CLAIMS[DocumentType.ukChippedPassport][
+          EvidenceType.success
+        ],
         ci: ["CI1", "CI2"],
         txn: expect.any(String),
       }),

--- a/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
+++ b/di-ipv-dcmaw-async-stub/openAPI/dcmaw-async-external.yaml
@@ -286,12 +286,16 @@ components:
           description: The name/id of the test user to generate a VC for
         document_type:
           type: string
-          enum: [ukChippedPassport]
+          enum: [ukChippedPassport, drivingPermit]
           description: The document type of the VC
         evidence_type:
           type: string
           enum: [success, fail]
           description: The evidence type of the VC
+        # Optional driving permit expiry override
+        driving_permit_expiry_date:
+          type: string
+          description: Optional override for driving permit expiry date (YYYY-MM-DD)
         ci:
           type: array
           description: Optional array of CI codes


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Update DCMAW Async Stub to simulate the use of an expired Drivers License
- Add DL as a support document type and allow driving licence expiryDate to be overridden, this will allow us to dynamic test the expiryDate - expired, same day, future
- Instead of using a hard-coded expiry date (which means at some point the DL will be counted as expired), we can instead default to a DL VC which expires in future so we don't have to keep sending the request with a custom expiry date
- Extend the management enqueue VC schema to support driving permits and document the optional driving_permit_expiry_date field

### Why did it change

This allows teams to exercise and verify the new expired-licence grace-period logic and the midnight-pinned expiry rules in local and test environments.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8831](https://govukverify.atlassian.net/browse/PYIC-8831)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8831]: https://govukverify.atlassian.net/browse/PYIC-8831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ