### PR TITLE
PYIC-8692 cleanup trailing comments and console.log from translation

### DIFF
--- a/di-ipv-cimit-stub-ts/lambdas/src/common/pendingMitigationService.ts
+++ b/di-ipv-cimit-stub-ts/lambdas/src/common/pendingMitigationService.ts
@@ -22,7 +22,7 @@ export async function persistPendingMitigation(
   ci: string,
   method: string,
 ): Promise<void> {
-  console.log("Creating pending mitigation", {
+  console.info("Creating pending mitigation", {
     request: userMitigationRequest,
     ci,
     requestMethod: method,
@@ -43,7 +43,7 @@ export async function completePendingMitigation(
   const pendingMitigationItem = await getPendingMitigationItem(jwtId);
 
   if (!pendingMitigationItem) {
-    console.log("No pending mitigations found", { jwtId, userId });
+    console.info("No pending mitigations found", { jwtId, userId });
     return;
   }
 
@@ -83,7 +83,7 @@ export async function completePendingMitigation(
   }
 
   await cimitStubItemService.persistCimitStubItem(itemToMitigate);
-  console.log("CI mitigated", {
+  console.info("CI mitigated", {
     jwtId,
     userId,
     ci: pendingMitigationItem.mitigatedCi,

--- a/di-ipv-cimit-stub-ts/lambdas/src/external-api/stub-management/service/userService.ts
+++ b/di-ipv-cimit-stub-ts/lambdas/src/external-api/stub-management/service/userService.ts
@@ -19,7 +19,7 @@ export async function addUserCis(
     await cimitStubItemService.persistCimitStubItem(cimitStubItem);
   }
 
-  console.log("Inserted User CI data to the Cimit Stub DynamoDB Table.");
+  console.info("Inserted User CI data to the Cimit Stub DynamoDB Table.");
 }
 
 export async function updateUserCis(

--- a/di-ipv-cimit-stub-ts/lambdas/src/external-api/stub-management/stubManagementHandler.ts
+++ b/di-ipv-cimit-stub-ts/lambdas/src/external-api/stub-management/stubManagementHandler.ts
@@ -24,7 +24,7 @@ export const handler = async (
 
   try {
     const path = decodeURIComponent(event.path);
-    console.log(`Received '${httpMethod}' event with path '${path}'`);
+    console.info(`Received '${httpMethod}' event with path '${path}'`);
 
     if (!SUPPORTED_HTTP_METHODS.includes(httpMethod)) {
       return buildErrorResponse("Http Method is not supported.", 400);

--- a/di-ipv-cimit-stub-ts/lambdas/src/internal-api/post-mitigations/postMitigationsHandler.ts
+++ b/di-ipv-cimit-stub-ts/lambdas/src/internal-api/post-mitigations/postMitigationsHandler.ts
@@ -18,8 +18,6 @@ export const postMitigationsHandler = async (
     const postMitigationsRequest = buildParsedRequest(request);
     postMitigationsRequest.signed_jwts?.forEach((vc) => {
       const payload = decodeJwt(vc) as JWTPayload;
-      console.log("decoding complete");
-
       const subject = payload.sub || "";
       const jwtid = payload.jti || "";
       completePendingMitigation(jwtid, subject);
@@ -40,26 +38,6 @@ export const postMitigationsHandler = async (
       });
     }
   }
-
-  // extract necessary information from incoming request
-
-  // for each of the VCs (string) in the request (in the list SignedJwtVCs)
-  //    parse the VC
-
-  //    get the corresponding JWTClaimsSet
-  //    completePendingMitigation using
-  //      JWTID from the JWTClaimsSet
-  //      Subject from the JWTClaimsSet
-  //      and the CimitStubItemService
-  // steps in completePendingMitigation
-  //    retrieve a PendingMitigationItem from DB by jwtId
-  //    (check an item actuallly came back)
-  //    get a list of CimitStubItems from DB by userID and CI
-  //    (check the list isn't null/empty)
-  //    add/set mitigations to the most recent CimitStubItem in the list (getIssuanceDate)
-  //    update the CimitStubItem in the DB
-  //        set the ttl in the CimitStubItem
-  //        then call the DB with the CimitStubItem
 };
 
 export interface PostMitigationsResponse {

--- a/di-ipv-cimit-stub-ts/lambdas/test/internal-api/post-mitigations/postMitigationsHandler.test.ts
+++ b/di-ipv-cimit-stub-ts/lambdas/test/internal-api/post-mitigations/postMitigationsHandler.test.ts
@@ -88,7 +88,6 @@ test.each([
   },
 );
 
-//  These cases align with the Java ones
 test.each([
   {
     case: "missing signed_jwts",
@@ -114,7 +113,6 @@ test.each([
     },
     body: undefined,
   },
-  // This test aligns with the Java versions
 ])(
   "should return 400 with fail result when given invalid request - $case",
   async ({ headers, body }) => {


### PR DESCRIPTION


## Proposed changes

### What changed

The pace of delivery necessitated a slightly less orderly than ideal merge order, which made a separate cleanup commit necessary.

### Why did it change

Keeping the code cleaner makes it more maintainable in the long run.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8692](https://govukverify.atlassian.net/browse/PYIC-8692)

## Checklists

## Checklists



[PYIC-8692]: https://govukverify.atlassian.net/browse/PYIC-8692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ