### PR TITLE
PYIC-8874: Split TLS and SSL conditions for bucket access

### DIFF
--- a/experian-fraud-stub/deploy/template.yaml
+++ b/experian-fraud-stub/deploy/template.yaml
@@ -194,6 +194,14 @@ Resources:
             Condition:
               Bool:
                 "aws:SecureTransport": false
+          - Effect: Deny
+            Resource:
+              - !GetAtt AccessLogsBucket.Arn
+              - !Sub "${AccessLogsBucket.Arn}/*"
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Condition:
               NumericLessThan:
                 "s3:TlsVersion": "1.2"
 


### PR DESCRIPTION
Handed over to Lime team to progress

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Bucket policy

### Why did it change

When conditions are specified together they must both be satisfied for the rule to fire. We want to deny any TLS version less than 1.2 and any connection not using SSL so we need to split the two conditions up.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8874](https://govukverify.atlassian.net/browse/PYIC-8874)




[PYIC-8874]: https://govukverify.atlassian.net/browse/PYIC-8874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ