### PR TITLE
PYIC-8879: update AIS stub to take custom state parameter

### DIFF
--- a/di-ipv-ais-stub/README.md
+++ b/di-ipv-ais-stub/README.md
@@ -12,13 +12,20 @@ This endpoint takes a request body which references the intervention description
 {
   "statusCode": 200,
   "intervention": "AIS_NO_INTERVENTION",
-  "responseDelay": 0
+  "responseDelay": 0,
+  "state": {
+    "blocked": "false",
+    "suspended": "false",
+    "resetPassword": "false", // pragma: allowlist secret
+    "reproveIdentity": "false"
+  }
 }
 ```
 
 - `statusCode` set on the response.
 - `intervention` mapped to a response body in `/lambdas/src/data`.
 - `responseDelay` delays the response when called.
+- `state` can be optionally provided to override the default state block associated with an `intervention` in `/lambdas/src/data`
 
 ## AIS Endpoint
 
@@ -31,7 +38,7 @@ It returns a response with code and body primed by the management endpoint after
 In order to test it works, you can run the following on the deployed environment. It shows the call to the management endpoint to stub the account interventions, followed by the call to get account interventions. In this example, we are using the `dev-mikec` environment:
 
 ```bash
-curl \                                                                                                       
+curl \
    -d '{ "intervention": "AIS_NO_INTERVENTION" }' \
    -H "Content-Type: application/json" \
    -X POST https://ais-dev-mikec.02.core.dev.stubs.account.gov.uk/management/user/urn:uuid:42810001-5786-4a2d-a8ee-6d54cc386881

--- a/di-ipv-ais-stub/README.md
+++ b/di-ipv-ais-stub/README.md
@@ -8,7 +8,7 @@ This will set up an API gateway in front of a lambda to return account intervent
 `POST /management/user/{userId}` artificially primes a user with an account intervention response.
 
 This endpoint takes a request body which references the intervention description. E.g.:
-```json
+```
 {
   "statusCode": 200,
   "intervention": "AIS_NO_INTERVENTION",

--- a/di-ipv-ais-stub/lambdas/src/handlers/managementHandler.ts
+++ b/di-ipv-ais-stub/lambdas/src/handlers/managementHandler.ts
@@ -55,5 +55,20 @@ function parseAndValidateRequest(
     );
   }
 
+  if (body.state) {
+    const requiredProperties = [
+      "blocked",
+      "suspended",
+      "reproveIdentity",
+      "resetPassword",
+    ];
+    const state = body.state;
+    if (!requiredProperties.every((property) => property in state)) {
+      throw new BadRequestError(
+        `If supplying a custom state block, the following properties are required: blocked, suspended, reproveIdentity, resetPassword`,
+      );
+    }
+  }
+
   return body;
 }

--- a/di-ipv-ais-stub/lambdas/src/utils/dataLayer.ts
+++ b/di-ipv-ais-stub/lambdas/src/utils/dataLayer.ts
@@ -9,7 +9,7 @@ export default async function persistFutureAisResponse(
   userId: string,
   userManagementRequest: UserManagementRequest,
 ): Promise<void> {
-  const { statusCode, responseDelay, intervention } = userManagementRequest;
+  const { statusCode, responseDelay, intervention, state } = userManagementRequest;
 
   console.info("Build response.");
   const response: Response = {
@@ -17,7 +17,10 @@ export default async function persistFutureAisResponse(
     statusCode: statusCode || 200,
     ttl: await getTtl(),
     responseDelay: responseDelay || 0,
-    responseBody: cases[intervention],
+    responseBody: {
+      ...cases[intervention],
+      ...(state ? {state} : {})
+    },
   };
 
   console.info("Store response.");

--- a/di-ipv-ais-stub/lambdas/src/utils/types.d.ts
+++ b/di-ipv-ais-stub/lambdas/src/utils/types.d.ts
@@ -23,7 +23,7 @@ interface Intervention {
   accountDeletedAt: number;
 }
 
-interface State {
+export interface State {
   blocked: boolean;
   suspended: boolean;
   reproveIdentity: boolean;
@@ -46,4 +46,5 @@ export type UserManagementRequest = Pick<
   "statusCode" | "responseDelay"
 > & {
   intervention: keyof typeof cases;
+  state?: State;
 };

--- a/di-ipv-ais-stub/lambdas/test/managementHandler.test.ts
+++ b/di-ipv-ais-stub/lambdas/test/managementHandler.test.ts
@@ -1,0 +1,106 @@
+import { State, UserManagementRequest } from "../src/utils/types";
+import {
+  APIGatewayProxyEventPathParameters,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyStructuredResultV2,
+} from "aws-lambda";
+import { handler as managementHandler } from "../src/handlers/managementHandler";
+import cases from "../src/cases";
+
+const TEST_USER_ID = "test-user-id";
+const TEST_USER_PATH_PARAM = {
+  userId: TEST_USER_ID,
+} as APIGatewayProxyEventPathParameters;
+
+describe("managementHandler", () => {
+  it("Returns 400 if missing intervention", async () => {
+    // arrange
+    const managementRequest = getManagementRequest({
+      statusCode: 200,
+      responseDelay: 0,
+    });
+
+    // act
+    const result = (await managementHandler(
+      managementRequest,
+    )) as APIGatewayProxyStructuredResultV2;
+
+    // assert
+    expect(result.statusCode).toStrictEqual(400);
+  });
+
+  it("Returns 400 if provided responseDelay greater than 40", async () => {
+    // arrange
+    const managementRequest = getManagementRequest({
+      statusCode: 200,
+      intervention: "AIS_ACCOUNT_BLOCKED",
+      responseDelay: 100,
+    });
+
+    // act
+    const result = (await managementHandler(
+      managementRequest,
+    )) as APIGatewayProxyStructuredResultV2;
+
+    // assert
+    expect(result.statusCode).toStrictEqual(400);
+  });
+
+  it.each([
+    {
+      case: "Missing resetPassword",
+      testState: { blocked: true, suspended: false, reproveIdentity: false },
+    },
+    {
+      case: "Missing reproveIdentity",
+      testState: { blocked: true, suspended: false, resetPassword: false },
+    },
+    {
+      case: "Missing blocked",
+      testState: {
+        reproveIdentity: true,
+        suspended: false,
+        resetPassword: false,
+      },
+    },
+    {
+      case: "Missing suspended",
+      testState: {
+        reproveIdentity: true,
+        blocked: false,
+        resetPassword: false,
+      },
+    },
+  ])(
+    "Returns 400 Bad Request when custom state block is $case",
+    async ({ testState }) => {
+      // arrange
+      const managementRequest = getManagementRequest({
+        statusCode: 200,
+        intervention: "AIS_ACCOUNT_BLOCKED",
+        responseDelay: 0,
+        state: testState,
+      });
+
+      // act
+      const result = (await managementHandler(
+        managementRequest,
+      )) as APIGatewayProxyStructuredResultV2;
+
+      // assert
+      expect(result.statusCode).toStrictEqual(400);
+    },
+  );
+});
+
+function getManagementRequest(
+  body: Omit<UserManagementRequest, "state" | "intervention"> & {
+    state?: Partial<State>;
+    intervention?: keyof typeof cases;
+  },
+): APIGatewayProxyEventV2 {
+  return {
+    pathParameters: TEST_USER_PATH_PARAM,
+    body: JSON.stringify(body),
+  } as APIGatewayProxyEventV2;
+}

--- a/di-ipv-ais-stub/openAPI/ais-external.yaml
+++ b/di-ipv-ais-stub/openAPI/ais-external.yaml
@@ -306,6 +306,22 @@ components:
           type: "integer"
           minimum: 400
           maximum: 599
+        state:
+          type: object
+          required: false
+          properties:
+            blocked:
+              type: "boolean"
+              required: true
+            suspended:
+              type: "boolean"
+              required: true
+            resetPassword:
+              type: "boolean"
+              required: true
+            reproveIdentity:
+              type: "boolean"
+              required: true
 
   parameters:
     UserId:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- updated AIS management stub endpoint to take custom `state` parameter to override default provided by the `intervention`

### Why did it change

- There real AIS doesn't update the intervention type when the user performs a remedial action but instead updates the state block. Currently, in our tests, we prime the stub to return AIS_NO_INTERVENTION which is inaccurate. To make testing more accurate we need to be able to prime the AIS stub to return a custom state block.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8879](https://govukverify.atlassian.net/browse/PYIC-8879)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8879]: https://govukverify.atlassian.net/browse/PYIC-8879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ