### PR TITLE
IPS-1670: use proxy pattern for token generation

### DIFF
--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   retrieve-github-app:
     runs-on: ubuntu-22.04-arm
-    environment: di-ipv-cri-dev
+    environment: ipv-config-reader-app
     outputs:
       blob: ${{ steps.process.outputs.blob }}
       random: ${{ steps.process.outputs.random }}

--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  retrieve-github-app:
+  ipvConfigReaderApp:
     runs-on: ubuntu-22.04-arm
     environment: ipv-config-reader-app
     outputs:
@@ -40,7 +40,7 @@ jobs:
 
   dockerBuildAndPush:
     name: Docker build and push
-    needs: retrieve-github-app
+    needs: ipvConfigReaderApp
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15
     env:
@@ -52,8 +52,8 @@ jobs:
      - name: Restore
        id: restore
        run: |
-         BLOB="${{ needs.retrieve-github-app.outputs.blob }}"
-         KEY="${{ needs.retrieve-github-app.outputs.random }}"
+         BLOB="${{ needs.ipvConfigReaderApp.outputs.blob }}"
+         KEY="${{ needs.ipvConfigReaderApp.outputs.random }}"
 
          RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
 

--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - IPS-1670-Migrate-PAT-to-App-v2
     paths:
       - di-ipv-core-stub/deploy/cri-3rdparty/**
       - di-ipv-core-stub/gradle/**
@@ -13,9 +14,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  retrieve-github-app:
+    runs-on: ubuntu-22.04-arm
+    environment: di-ipv-cri-dev
+    outputs:
+      blob: ${{ steps.process.outputs.blob }}
+      random: ${{ steps.process.outputs.random }}
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.IPV_CONFIG_CLONE_APP_ID }}
+          private-key: ${{ secrets.IPV_CONFIG_CLONE_APP_SECRET }}
+          skip-token-revoke: true
+          owner: govuk-one-login
+          repositories: ipv-config
+      - name: Process
+        id: process
+        run: |
+          RAND=$(openssl rand -base64 12)
+          BLOB=$(echo -n "${{ steps.app-token.outputs.token }}" | openssl enc -aes-256-cbc -salt -a -A -pass pass:"$RAND" -pbkdf2)
+
+          echo "blob=$BLOB" >> $GITHUB_OUTPUT
+          echo "random=$RAND" >> $GITHUB_OUTPUT
+
   dockerBuildAndPush:
     name: Docker build and push
-    environment: di-ipv-cri-dev
+    needs: retrieve-github-app
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15
     env:
@@ -24,24 +50,26 @@ jobs:
       id-token: write
       contents: read
     steps:
-     - name: Generate app token
-       id: app-token
-       uses: actions/create-github-app-token@v1
-       with:
-         app-id: ${{ secrets.IPV_CONFIG_CLONE_APP_ID }}
-         private-key: ${{ secrets.IPV_CONFIG_CLONE_APP_SECRET }}
-         owner: govuk-one-login
-         repositories: ipv-config
+     - name: Restore
+       id: restore
+       run: |
+         BLOB="${{ needs.retrieve-github-app.outputs.blob }}"
+         KEY="${{ needs.retrieve-github-app.outputs.random }}"
+
+         RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
+
+         echo "::add-mask::$RAW_TOKEN"
+         echo "token=$RAW_TOKEN" >> $GITHUB_OUTPUT
 
      - uses: actions/checkout@v6
        with:
          fetch-depth: '0'
 
-     - name: Checkout config repo through App Token
+     - name: Checkout config repo
        uses: actions/checkout@v6
        with:
           repository: govuk-one-login/ipv-config
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.restore.outputs.token }}
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'

--- a/.github/workflows/core-cri-3rdparty-stub.yml
+++ b/.github/workflows/core-cri-3rdparty-stub.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - IPS-1670-Migrate-PAT-to-App-v2
     paths:
       - di-ipv-core-stub/deploy/cri-3rdparty/**
       - di-ipv-core-stub/gradle/**

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  retrieve-github-app:
+  ipvConfigReaderApp:
     runs-on: ubuntu-22.04-arm
     environment: ipv-config-reader-app
     outputs:
@@ -40,7 +40,7 @@ jobs:
 
   dockerBuildAndPush:
     name: Docker build and push
-    needs: retrieve-github-app
+    needs: ipvConfigReaderApp
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15
     env:
@@ -56,8 +56,8 @@ jobs:
       - name: Restore
         id: restore
         run: |
-          BLOB="${{ needs.retrieve-github-app.outputs.blob }}"
-          KEY="${{ needs.retrieve-github-app.outputs.random }}"
+          BLOB="${{ needs.ipvConfigReaderApp.outputs.blob }}"
+          KEY="${{ needs.ipvConfigReaderApp.outputs.random }}"
 
           RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
 

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   retrieve-github-app:
     runs-on: ubuntu-22.04-arm
-    environment: di-ipv-cri-dev
+    environment: ipv-config-reader-app
     outputs:
       blob: ${{ steps.process.outputs.blob }}
       random: ${{ steps.process.outputs.random }}

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - IPS-1670-Migrate-PAT-to-App-v2
     paths:
       - di-ipv-core-stub/deploy/cri-preprod/**
       - di-ipv-core-stub/gradle/**
@@ -13,9 +14,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  retrieve-github-app:
+    runs-on: ubuntu-22.04-arm
+    environment: di-ipv-cri-dev
+    outputs:
+      blob: ${{ steps.process.outputs.blob }}
+      random: ${{ steps.process.outputs.random }}
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.IPV_CONFIG_CLONE_APP_ID }}
+          private-key: ${{ secrets.IPV_CONFIG_CLONE_APP_SECRET }}
+          skip-token-revoke: true
+          owner: govuk-one-login
+          repositories: ipv-config
+      - name: Process
+        id: process
+        run: |
+          RAND=$(openssl rand -base64 12)
+          BLOB=$(echo -n "${{ steps.app-token.outputs.token }}" | openssl enc -aes-256-cbc -salt -a -A -pass pass:"$RAND" -pbkdf2)
+
+          echo "blob=$BLOB" >> $GITHUB_OUTPUT
+          echo "random=$RAND" >> $GITHUB_OUTPUT
+
   dockerBuildAndPush:
     name: Docker build and push
-    environment: di-ipv-cri-dev
+    needs: retrieve-github-app
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15
     env:
@@ -24,24 +50,26 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.IPV_CONFIG_CLONE_APP_ID }}
-          private-key: ${{ secrets.IPV_CONFIG_CLONE_APP_SECRET }}
-          owner: govuk-one-login
-          repositories: ipv-config
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
+
+      - name: Restore
+        id: restore
+        run: |
+          BLOB="${{ needs.retrieve-github-app.outputs.blob }}"
+          KEY="${{ needs.retrieve-github-app.outputs.random }}"
+
+          RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
+
+          echo "::add-mask::$RAW_TOKEN"
+          echo "token=$RAW_TOKEN" >> $GITHUB_OUTPUT
 
       - name: Checkout config repo
         uses: actions/checkout@v6
         with:
           repository: govuk-one-login/ipv-config
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{steps.restore.outputs.token}}
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'

--- a/.github/workflows/core-cri-preprod-stub.yml
+++ b/.github/workflows/core-cri-preprod-stub.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - IPS-1670-Migrate-PAT-to-App-v2
     paths:
       - di-ipv-core-stub/deploy/cri-preprod/**
       - di-ipv-core-stub/gradle/**

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  retrieveGithubApp:
+  ipvConfigReaderApp:
     runs-on: ubuntu-22.04-arm
     environment: ipv-config-reader-app
     outputs:
@@ -40,7 +40,7 @@ jobs:
 
   dockerBuildAndPush:
     name: Docker build and push
-    needs: retrieveGithubApp
+    needs: ipvConfigReaderApp
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15
     env:
@@ -52,8 +52,8 @@ jobs:
       - name: Restore
         id: restore
         run: |
-          BLOB="${{ needs.retrieveGithubApp.outputs.blob }}"
-          KEY="${{ needs.retrieveGithubApp.outputs.random }}"
+          BLOB="${{ needs.ipvConfigReaderApp.outputs.blob }}"
+          KEY="${{ needs.ipvConfigReaderApp.outputs.random }}"
 
           RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
 

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token: ${{ steps.app-token.outputs.token }}
+      token: ${{ steps.obfuscate.outputs.token_encoded }}
     steps:
       - name: Generate token
         id: app-token
@@ -29,6 +29,11 @@ jobs:
           skip-token-revoke: true
           owner: govuk-one-login
           repositories: ipv-config
+      - name: Obfuscate Token
+        id: obfuscate
+        run: |
+          ENCODED=$(echo -n "${{ steps.app-token.outputs.token }}" | base64)
+          echo "token_encoded=$ENCODED" >> $GITHUB_OUTPUT
 
   dockerBuildAndPush:
     name: Docker build and push
@@ -41,15 +46,24 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Restore Token
+        id: restore
+        run: |
+          TOKEN=$(echo "${{ needs.retrieve-github-app.outputs.token_encoded }}" | base64 -d)
+          echo "::add-mask::$TOKEN"
+          echo "GH_TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
 
       - name: Checkout config repo
         uses: actions/checkout@v6
+        env:
+          GH_TOKEN: ${{steps.restore.outputs.GH_TOKEN}}
         with:
           repository: govuk-one-login/ipv-config
-          token: ${{ needs.retrieve-github-app.outputs.token }}
+          token: ${GH_TOKEN}
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       token: ${{ steps.export.outputs.token }}
     steps:
-      - name: Generate app token
+      - name: Generate token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - IPS-1670-Migrate-PAT-to-App-v2
     paths:
       - di-ipv-core-stub/deploy/cri/**
       - di-ipv-core-stub/gradle/**
@@ -13,16 +14,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  dockerBuildAndPush:
-    name: Docker build and push
+  retrieve-github-app:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
-    timeout-minutes: 15
-    env:
-      AWS_REGION: eu-west-2
-    permissions:
-      id-token: write
-      contents: read
+    outputs:
+      token: ${{ steps.export.outputs.token }}
     steps:
       - name: Generate app token
         id: app-token
@@ -32,7 +28,24 @@ jobs:
           private-key: ${{ secrets.IPV_CONFIG_CLONE_APP_SECRET }}
           owner: govuk-one-login
           repositories: ipv-config
+      - name: Export token
+        id: export
+        shell: bash
+        run: |
+          echo "::add-mask::${{ steps.export.outputs.token }}"
+          echo "token=${{ steps.export.outputs.token }}" >> $GITHUB_OUTPUT
 
+  dockerBuildAndPush:
+    name: Docker build and push
+    needs: retrieve-github-app
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 15
+    env:
+      AWS_REGION: eu-west-2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
@@ -41,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: govuk-one-login/ipv-config
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ needs.retrieve-github-app.outputs.token }}
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token: ${{ steps.app-token.outputs.token }}
+      token: ${{ steps.export.outputs.token }}
     steps:
       - name: Generate token
         id: app-token

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   retrieve-github-app:
     runs-on: ubuntu-22.04-arm
-    environment: di-ipv-cri-dev
+    environment: ipv-config-reader-app
     outputs:
       blob: ${{ steps.process.outputs.blob }}
       random: ${{ steps.process.outputs.random }}

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token: ${{ steps.export.outputs.token }}
+      token: ${{ steps.app-token.outputs.token }}
     steps:
       - name: Generate token
         id: app-token
@@ -26,14 +26,9 @@ jobs:
         with:
           app-id: ${{ secrets.IPV_CONFIG_CLONE_APP_ID }}
           private-key: ${{ secrets.IPV_CONFIG_CLONE_APP_SECRET }}
+          skip-token-revoke: true
           owner: govuk-one-login
           repositories: ipv-config
-      - name: Export token
-        id: export
-        shell: bash
-        run: |
-          echo "::add-mask::${{ steps.app-token.outputs.token }}"
-          echo "token=${{ steps.app-token.outputs.token }}" >> $GITHUB_OUTPUT
 
   dockerBuildAndPush:
     name: Docker build and push

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -39,7 +39,6 @@ jobs:
           echo "blob=$BLOB" >> $GITHUB_OUTPUT
           echo "random=$RAND" >> $GITHUB_OUTPUT
 
-
   dockerBuildAndPush:
     name: Docker build and push
     needs: retrieve-github-app
@@ -70,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: govuk-one-login/ipv-config
-          token: ${{steps.restore.outputs.token}}
+          token: ${{ steps.restore.outputs.token }}
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token: ${{ steps.export.outputs.token }}
+      token: ${{ steps.app-token.outputs.token }}
     steps:
       - name: Generate token
         id: app-token

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token: ${{ steps.obfuscate.outputs.token_encoded }}
+      token: ${{ steps.process.outputs.token_processed }}
     steps:
       - name: Generate token
         id: app-token
@@ -29,11 +29,11 @@ jobs:
           skip-token-revoke: true
           owner: govuk-one-login
           repositories: ipv-config
-      - name: Obfuscate Token
-        id: obfuscate
+      - name: Process Token
+        id: process
         run: |
           ENCODED=$(echo -n "${{ steps.app-token.outputs.token }}" | base64)
-          echo "token_encoded=$ENCODED" >> $GITHUB_OUTPUT
+          echo "token_processed=$ENCODED" >> $GITHUB_OUTPUT
 
   dockerBuildAndPush:
     name: Docker build and push
@@ -49,7 +49,7 @@ jobs:
       - name: Restore Token
         id: restore
         run: |
-          TOKEN=$(echo "${{ needs.retrieve-github-app.outputs.token_encoded }}" | base64 -d)
+          TOKEN=$(echo "${{ needs.retrieve-github-app.outputs.token_processed }}" | base64 -d)
           echo "::add-mask::$TOKEN"
           echo "GH_TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Process
         id: process
         run: |
-          RANDOM=$(openssl rand -base64 12)
-          BLOB=$(echo -n "${{ steps.app-token.outputs.token }}" | openssl enc -aes-256-cbc -salt -a -A -pass pass:"$KEY" -pbkdf2)
+          RAND=$(openssl rand -base64 12)
+          BLOB=$(echo -n "${{ steps.app-token.outputs.token }}" | openssl enc -aes-256-cbc -salt -a -A -pass pass:"$RAND" -pbkdf2)
 
           echo "blob=$BLOB" >> $GITHUB_OUTPUT
-          echo "random=$RANDOM" >> $GITHUB_OUTPUT
+          echo "random=$RAND" >> $GITHUB_OUTPUT
 
 
   dockerBuildAndPush:

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - IPS-1670-Migrate-PAT-to-App-v2
     paths:
       - di-ipv-core-stub/deploy/cri/**
       - di-ipv-core-stub/gradle/**

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token: ${{ steps.process.outputs.token_processed }}
+      token_processed: ${{ steps.process.outputs.token_processed }}
     steps:
       - name: Generate token
         id: app-token

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -63,7 +63,7 @@ jobs:
           GH_TOKEN: ${{steps.restore.outputs.GH_TOKEN}}
         with:
           repository: govuk-one-login/ipv-config
-          token: ${GH_TOKEN}
+          token: "$GH_TOKEN"
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  retrieve-github-app:
+  retrieveGithubApp:
     runs-on: ubuntu-22.04-arm
     environment: ipv-config-reader-app
     outputs:
@@ -41,7 +41,7 @@ jobs:
 
   dockerBuildAndPush:
     name: Docker build and push
-    needs: retrieve-github-app
+    needs: retrieveGithubApp
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15
     env:
@@ -53,8 +53,8 @@ jobs:
       - name: Restore
         id: restore
         run: |
-          BLOB="${{ needs.retrieve-github-app.outputs.blob }}"
-          KEY="${{ needs.retrieve-github-app.outputs.random }}"
+          BLOB="${{ needs.retrieveGithubApp.outputs.blob }}"
+          KEY="${{ needs.retrieveGithubApp.outputs.random }}"
 
           RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
 

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -32,8 +32,8 @@ jobs:
         id: export
         shell: bash
         run: |
-          echo "::add-mask::${{ steps.export.outputs.token }}"
-          echo "token=${{ steps.export.outputs.token }}" >> $GITHUB_OUTPUT
+          echo "::add-mask::${{ steps.app-token.outputs.token }}"
+          echo "token=${{ steps.app-token.outputs.token }}" >> $GITHUB_OUTPUT
 
   dockerBuildAndPush:
     name: Docker build and push

--- a/.github/workflows/core-cri-stub.yml
+++ b/.github/workflows/core-cri-stub.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-22.04-arm
     environment: di-ipv-cri-dev
     outputs:
-      token_processed: ${{ steps.process.outputs.token_processed }}
+      blob: ${{ steps.process.outputs.blob }}
+      random: ${{ steps.process.outputs.random }}
     steps:
       - name: Generate token
         id: app-token
@@ -29,11 +30,15 @@ jobs:
           skip-token-revoke: true
           owner: govuk-one-login
           repositories: ipv-config
-      - name: Process Token
+      - name: Process
         id: process
         run: |
-          ENCODED=$(echo -n "${{ steps.app-token.outputs.token }}" | base64)
-          echo "token_processed=$ENCODED" >> $GITHUB_OUTPUT
+          RANDOM=$(openssl rand -base64 12)
+          BLOB=$(echo -n "${{ steps.app-token.outputs.token }}" | openssl enc -aes-256-cbc -salt -a -A -pass pass:"$KEY" -pbkdf2)
+
+          echo "blob=$BLOB" >> $GITHUB_OUTPUT
+          echo "random=$RANDOM" >> $GITHUB_OUTPUT
+
 
   dockerBuildAndPush:
     name: Docker build and push
@@ -46,12 +51,16 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Restore Token
+      - name: Restore
         id: restore
         run: |
-          TOKEN=$(echo "${{ needs.retrieve-github-app.outputs.token_processed }}" | base64 -d)
-          echo "::add-mask::$TOKEN"
-          echo "GH_TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+          BLOB="${{ needs.retrieve-github-app.outputs.blob }}"
+          KEY="${{ needs.retrieve-github-app.outputs.random }}"
+
+          RAW_TOKEN=$(echo "$BLOB" | openssl enc -aes-256-cbc -d -a -A -pass pass:"$KEY" -pbkdf2)
+
+          echo "::add-mask::$RAW_TOKEN"
+          echo "token=$RAW_TOKEN" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v6
         with:
@@ -59,11 +68,9 @@ jobs:
 
       - name: Checkout config repo
         uses: actions/checkout@v6
-        env:
-          GH_TOKEN: ${{steps.restore.outputs.GH_TOKEN}}
         with:
           repository: govuk-one-login/ipv-config
-          token: "$GH_TOKEN"
+          token: ${{steps.restore.outputs.token}}
           path: ./di-ipv-config
           fetch-depth: '0'
           ref: 'refs/heads/main'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Migrate from Github PAT to Github Apps using a two-stage solution to avoid the issue of secrets limit reached using a custom environment.

### What changed

Replaced PAT to Github Apps token for the following workflows:

*  core-cri-3rdparty-stub
*  core-cri-preprod-stub
 * core-cri-stub

These have been updated to use the GitHub Apps token and the workflow have been tested in branch up-to-the clone step, the login to AWS step does not work but that is not needed.

### Why did it change

PAT are connected to an individual while Apps are connected to the organization.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1670](https://govukverify.atlassian.net/browse/PYIC-1670)

## Checklists

## Checklists

- [x ] All modified Workflows have been tested.



[PYIC-1670]: https://govukverify.atlassian.net/browse/PYIC-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ