### PR TITLE
PYIC-8830: update driving permit test data so that they always expire in the future

### DIFF
--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataDcmaw.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataDcmaw.java
@@ -16,135 +16,124 @@ public class CriStubDataDcmaw {
         // Replace default public constructor
     }
 
-    public static final List<IdentityCheckSubjectCriStubData> Data =
-            List.of(
-                    createData(
-                            "Alice Doe (Valid) NFC Passport",
-                            Names.ALICE_JANE_LAURA_DOE,
-                            BirthDates.ALICE_DOE,
-                            Passports.ALICE_DOE_PASSPORT),
-                    createData(
-                            "Alice Parker (Valid) BRC",
-                            Names.ALICE_JANE_PARKER,
-                            BirthDates.ALICE_PARKER,
-                            ResidencePermits.ALICE_PARKER_BRC),
-                    createData(
-                            "Alice Parker BRP",
-                            Names.ALICE_JANE_PARKER,
-                            BirthDates.ALICE_PARKER,
-                            ResidencePermits.ALICE_PARKER_BRP),
-                    createData(
-                            "Alice Parker (Valid) DVLA Licence",
-                            Names.ALICE_JANE_PARKER,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Alice Parker (Changed First Name) DVLA Licence",
-                            Names.ALISON_JANE_PARKER,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Alice Parker (Changed Last Name) DVLA Licence",
-                            Names.ALICE_JANE_SMITH,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Billy Batson (Valid) DVA Licence",
-                            Names.Billy_Batson,
-                            BirthDates.BILLY_BATSON,
-                            DrivingLicences.BILLY_BATSON_DVA),
-                    createData(
-                            "Claire Aarts DVLA Licence (DWP)",
-                            Names.CLAIRE_AARTS,
-                            BirthDates.CLAIRE_AARTS,
-                            DrivingLicences.CLAIRE_AARTS_DVLA),
-                    createData(
-                            "Joe Shmoe (Valid) Driving Licence",
-                            Names.Joe_Schmoe,
-                            BirthDates.JOE_SHMOE,
-                            DrivingLicences.JOE_SHMOE_DVLA,
-                            Addresses.JOE_SCHMOE_ADDRESS),
-                    createData(
-                            "John Roberts (Invalid) DVA Licence",
-                            Names.John_Roberts,
-                            BirthDates.JOHN_ROBERTS,
-                            DrivingLicences.JOHN_ROBERTS_DVA_INVALID),
-                    createData(
-                            "Kabir Singh DVLA Licence (DWP)",
-                            Names.KABIR_SINGH,
-                            BirthDates.KABIR_SINGH,
-                            DrivingLicences.KABIR_SINGH_DVLA),
-                    createData(
-                            "Kenneth Decerqueira (Valid Experian) Passport",
-                            Names.KENNETH_DECERQUEIRA,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            Passports.KENNETH_DECERQUEIRA_PASSPORT),
-                    createData(
-                            "Kenneth Decerqueira (Changed First Name) Passport",
-                            Names.MICHAEL_DECERQUEIRA,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            Passports.KENNETH_DECERQUEIRA_PASSPORT),
-                    createData(
-                            "Kenneth Decerqueira (Changed Last Name) Passport",
-                            Names.KENNETH_JONES,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            Passports.KENNETH_DECERQUEIRA_PASSPORT),
-                    createData(
-                            "Kenneth Decerqueira (Valid) DVLA Licence",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            DrivingLicences.KENNETH_DECERQUEIRA_DVLA),
-                    createData(
-                            "Kenneth Decerqueira (Valid) DVLA Licence 2",
-                            Names.KENNETH_DECERQUEIRA,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            DrivingLicences.KENNETH_DECERQUEIRA_DVLA_2),
-                    createData(
-                            "Kenneth Decerqueira (Valid) DVA Licence",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            DrivingLicences.KENNETH_DECERQUEIRA_DVA),
-                    createData(
-                            "Kenneth Decerqueira (Invalid) DVLA Licence",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            DrivingLicences.KENNETH_DECERQUEIRA_DVLA_INVALID),
-                    createData(
-                            "Kenneth Decerqueira (Invalid) DVLA Licence 2",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            DrivingLicences.KENNETH_DECERQUEIRA_DVLA_2_INVALID),
-                    createData(
-                            "Kenneth Decerqueira (International)",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            Passports.KENNETH_DECERQUEIRA_INTERNATIONAL_PASSPORT),
-                    createData(
-                            "Nora Porter DVLA Licence (DWP)",
-                            Names.NORA_PORTER,
-                            BirthDates.NORA_PORTER,
-                            DrivingLicences.NORA_PORTER_DVLA),
-                    createData(
-                            "Saul Goodman BRC",
-                            Names.SAUL_GOODMAN,
-                            BirthDates.SAUL_GOODMAN,
-                            ResidencePermits.SAUL_GOODMAN_BRC),
-                    createData(
-                            "Tom Hardy DVLA Licence (DWP)",
-                            Names.TOM_HARDY,
-                            BirthDates.TOM_HARDY,
-                            DrivingLicences.TOM_HARDY_DVLA));
-
-    private static IdentityCheckSubjectCriStubData createData(
-            String label, Name name, BirthDate birthDate) {
-        return IdentityCheckSubjectCriStubData.builder()
-                .label(label)
-                .payload(
-                        IdentityCheckSubject.builder()
-                                .withName(List.of(name))
-                                .withBirthDate(List.of(birthDate))
-                                .build())
-                .build();
+    public static List<IdentityCheckSubjectCriStubData> getData() {
+        return List.of(
+                createData(
+                        "Alice Doe (Valid) NFC Passport",
+                        Names.ALICE_JANE_LAURA_DOE,
+                        BirthDates.ALICE_DOE,
+                        Passports.ALICE_DOE_PASSPORT),
+                createData(
+                        "Alice Parker (Valid) BRC",
+                        Names.ALICE_JANE_PARKER,
+                        BirthDates.ALICE_PARKER,
+                        ResidencePermits.ALICE_PARKER_BRC),
+                createData(
+                        "Alice Parker BRP",
+                        Names.ALICE_JANE_PARKER,
+                        BirthDates.ALICE_PARKER,
+                        ResidencePermits.ALICE_PARKER_BRP),
+                createData(
+                        "Alice Parker (Valid) DVLA Licence",
+                        Names.ALICE_JANE_PARKER,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Alice Parker (Changed First Name) DVLA Licence",
+                        Names.ALISON_JANE_PARKER,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Alice Parker (Changed Last Name) DVLA Licence",
+                        Names.ALICE_JANE_SMITH,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Billy Batson (Valid) DVA Licence",
+                        Names.Billy_Batson,
+                        BirthDates.BILLY_BATSON,
+                        DrivingLicences.getBillyBatsonDva()),
+                createData(
+                        "Claire Aarts DVLA Licence (DWP)",
+                        Names.CLAIRE_AARTS,
+                        BirthDates.CLAIRE_AARTS,
+                        DrivingLicences.getClaireAartsDvla()),
+                createData(
+                        "Joe Shmoe (Valid) Driving Licence",
+                        Names.Joe_Schmoe,
+                        BirthDates.JOE_SHMOE,
+                        DrivingLicences.getJoeShmoeDvla(),
+                        Addresses.JOE_SCHMOE_ADDRESS),
+                createData(
+                        "John Roberts (Invalid) DVA Licence",
+                        Names.John_Roberts,
+                        BirthDates.JOHN_ROBERTS,
+                        DrivingLicences.getJohnRobertsDvaInvalid()),
+                createData(
+                        "Kabir Singh DVLA Licence (DWP)",
+                        Names.KABIR_SINGH,
+                        BirthDates.KABIR_SINGH,
+                        DrivingLicences.getKabirSinghDvla()),
+                createData(
+                        "Kenneth Decerqueira (Valid Experian) Passport",
+                        Names.KENNETH_DECERQUEIRA,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        Passports.KENNETH_DECERQUEIRA_PASSPORT),
+                createData(
+                        "Kenneth Decerqueira (Changed First Name) Passport",
+                        Names.MICHAEL_DECERQUEIRA,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        Passports.KENNETH_DECERQUEIRA_PASSPORT),
+                createData(
+                        "Kenneth Decerqueira (Changed Last Name) Passport",
+                        Names.KENNETH_JONES,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        Passports.KENNETH_DECERQUEIRA_PASSPORT),
+                createData(
+                        "Kenneth Decerqueira (Valid) DVLA Licence",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        DrivingLicences.getKennethDecerqueiraDvla()),
+                createData(
+                        "Kenneth Decerqueira (Valid) DVLA Licence 2",
+                        Names.KENNETH_DECERQUEIRA,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        DrivingLicences.getKennethDecerqueiraDvla2()),
+                createData(
+                        "Kenneth Decerqueira (Valid) DVA Licence",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        DrivingLicences.getKennethDecerqueiraDva()),
+                createData(
+                        "Kenneth Decerqueira (Invalid) DVLA Licence",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        DrivingLicences.getKennethDecerqueiraDvlaInvalid()),
+                createData(
+                        "Kenneth Decerqueira (Invalid) DVLA Licence 2",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        DrivingLicences.getKennethDecerqueiraDvla2Invalid()),
+                createData(
+                        "Kenneth Decerqueira (International)",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        Passports.KENNETH_DECERQUEIRA_INTERNATIONAL_PASSPORT),
+                createData(
+                        "Nora Porter DVLA Licence (DWP)",
+                        Names.NORA_PORTER,
+                        BirthDates.NORA_PORTER,
+                        DrivingLicences.getNoraPorterDvla()),
+                createData(
+                        "Saul Goodman BRC",
+                        Names.SAUL_GOODMAN,
+                        BirthDates.SAUL_GOODMAN,
+                        ResidencePermits.SAUL_GOODMAN_BRC),
+                createData(
+                        "Tom Hardy DVLA Licence (DWP)",
+                        Names.TOM_HARDY,
+                        BirthDates.TOM_HARDY,
+                        DrivingLicences.getTomHardyDvla()));
     }
 
     private static IdentityCheckSubjectCriStubData createData(

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataDrivingLicence.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataDrivingLicence.java
@@ -13,53 +13,54 @@ public class CriStubDataDrivingLicence {
         // Replace default public constructor
     }
 
-    public static final List<IdentityCheckSubjectCriStubData> Data =
-            List.of(
-                    createData(
-                            "Alice Parker (Valid) DVLA Licence",
-                            Names.Alice_Jane_Parker,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Alice Parker (Changed First Name) DVLA Licence",
-                            Names.Alison_Jane_Parker,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Alice Parker (Changed Last Name) DVLA Licence",
-                            Names.Alice_Jane_Smith,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Bob Parker (Valid) DVA Licence",
-                            Names.Bob_Parker,
-                            BirthDates.BOB_PARKER,
-                            DrivingLicences.BOB_PARKER_DVA),
-                    createData(
-                            "Claire Aarts DVLA Licence (DWP)",
-                            Names.Claire_Aarts,
-                            BirthDates.CLAIRE_AARTS,
-                            DrivingLicences.CLAIRE_AARTS_DVLA),
-                    createData(
-                            "Kabir Singh DVLA Licence (DWP)",
-                            Names.Kabir_Singh,
-                            BirthDates.KABIR_SINGH,
-                            DrivingLicences.KABIR_SINGH_DVLA),
-                    createData(
-                            "Kenneth Decerqueira (Valid) DVLA Licence",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            DrivingLicences.KENNETH_DECERQUEIRA_DVLA),
-                    createData(
-                            "Nora Porter DVLA Licence (DWP)",
-                            Names.Nora_Porter,
-                            BirthDates.NORA_PORTER,
-                            DrivingLicences.NORA_PORTER_DVLA),
-                    createData(
-                            "Tom Hardy DVLA Licence (DWP)",
-                            Names.Tom_Hardy,
-                            BirthDates.TOM_HARDY,
-                            DrivingLicences.TOM_HARDY_DVLA));
+    public static List<IdentityCheckSubjectCriStubData> getData() {
+        return List.of(
+                createData(
+                        "Alice Parker (Valid) DVLA Licence",
+                        Names.Alice_Jane_Parker,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Alice Parker (Changed First Name) DVLA Licence",
+                        Names.Alison_Jane_Parker,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Alice Parker (Changed Last Name) DVLA Licence",
+                        Names.Alice_Jane_Smith,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Bob Parker (Valid) DVA Licence",
+                        Names.Bob_Parker,
+                        BirthDates.BOB_PARKER,
+                        DrivingLicences.getBobParkerDva()),
+                createData(
+                        "Claire Aarts DVLA Licence (DWP)",
+                        Names.Claire_Aarts,
+                        BirthDates.CLAIRE_AARTS,
+                        DrivingLicences.getClaireAartsDvla()),
+                createData(
+                        "Kabir Singh DVLA Licence (DWP)",
+                        Names.Kabir_Singh,
+                        BirthDates.KABIR_SINGH,
+                        DrivingLicences.getKabirSinghDvla()),
+                createData(
+                        "Kenneth Decerqueira (Valid) DVLA Licence",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        DrivingLicences.getKennethDecerqueiraDvla()),
+                createData(
+                        "Nora Porter DVLA Licence (DWP)",
+                        Names.Nora_Porter,
+                        BirthDates.NORA_PORTER,
+                        DrivingLicences.getNoraPorterDvla()),
+                createData(
+                        "Tom Hardy DVLA Licence (DWP)",
+                        Names.Tom_Hardy,
+                        BirthDates.TOM_HARDY,
+                        DrivingLicences.getTomHardyDvla()));
+    }
 
     private static IdentityCheckSubjectCriStubData createData(
             String label, Name name, BirthDate birthDate, DrivingPermitDetails drivingLicence) {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataF2f.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/CriStubDataF2f.java
@@ -16,53 +16,54 @@ public class CriStubDataF2f {
         // Replace default public constructor
     }
 
-    public static final List<IdentityCheckSubjectCriStubData> Data =
-            List.of(
-                    createData(
-                            "Alice Parker (Valid) DVLA Licence",
-                            Names.Alice_Jane_Parker,
-                            BirthDates.ALICE_PARKER,
-                            DrivingLicences.ALICE_PARKER_DVLA),
-                    createData(
-                            "Claire Aarts DVLA Licence (DWP)",
-                            Names.Claire_Aarts,
-                            BirthDates.CLAIRE_AARTS,
-                            DrivingLicences.CLAIRE_AARTS_DVLA),
-                    createData(
-                            "Kabir Singh DVLA Licence (DWP)",
-                            Names.Kabir_Singh,
-                            BirthDates.KABIR_SINGH,
-                            DrivingLicences.KABIR_SINGH_DVLA),
-                    createData(
-                            "Kenneth Decerqueira (Valid Passport)",
-                            Names.Kenneth_Decerqueira,
-                            BirthDates.KENNETH_DECERQUEIRA,
-                            Passports.KENNETH_DECERQUEIRA_PASSPORT),
-                    createData(
-                            "Nora Porter DVLA Licence (DWP)",
-                            Names.Nora_Porter,
-                            BirthDates.NORA_PORTER,
-                            DrivingLicences.NORA_PORTER_DVLA),
-                    createData(
-                            "Mary Watson (Valid Passport)",
-                            Names.Mary_Watson,
-                            BirthDates.MARY_WATSON,
-                            Passports.MARY_WATSON_F2F_PASSPORT),
-                    createData(
-                            "Saul Goodman BRC",
-                            Names.Saul_Goodman,
-                            BirthDates.SAUL_GOODMAN,
-                            ResidencePermits.SAUL_GOODMAN_BRC),
-                    createData(
-                            "Saul Goodman (Valid EEA Card)",
-                            Names.Saul_Goodman,
-                            BirthDates.SAUL_GOODMAN,
-                            IdCards.EEA_VALID),
-                    createData(
-                            "Tom Hardy DVLA Licence (DWP)",
-                            Names.Tom_Hardy,
-                            BirthDates.TOM_HARDY,
-                            DrivingLicences.TOM_HARDY_DVLA));
+    public static List<IdentityCheckSubjectCriStubData> getData() {
+        return List.of(
+                createData(
+                        "Alice Parker (Valid) DVLA Licence",
+                        Names.Alice_Jane_Parker,
+                        BirthDates.ALICE_PARKER,
+                        DrivingLicences.getAliceParkerDvla()),
+                createData(
+                        "Claire Aarts DVLA Licence (DWP)",
+                        Names.Claire_Aarts,
+                        BirthDates.CLAIRE_AARTS,
+                        DrivingLicences.getClaireAartsDvla()),
+                createData(
+                        "Kabir Singh DVLA Licence (DWP)",
+                        Names.Kabir_Singh,
+                        BirthDates.KABIR_SINGH,
+                        DrivingLicences.getKabirSinghDvla()),
+                createData(
+                        "Kenneth Decerqueira (Valid Passport)",
+                        Names.Kenneth_Decerqueira,
+                        BirthDates.KENNETH_DECERQUEIRA,
+                        Passports.KENNETH_DECERQUEIRA_PASSPORT),
+                createData(
+                        "Nora Porter DVLA Licence (DWP)",
+                        Names.Nora_Porter,
+                        BirthDates.NORA_PORTER,
+                        DrivingLicences.getNoraPorterDvla()),
+                createData(
+                        "Mary Watson (Valid Passport)",
+                        Names.Mary_Watson,
+                        BirthDates.MARY_WATSON,
+                        Passports.MARY_WATSON_F2F_PASSPORT),
+                createData(
+                        "Saul Goodman BRC",
+                        Names.Saul_Goodman,
+                        BirthDates.SAUL_GOODMAN,
+                        ResidencePermits.SAUL_GOODMAN_BRC),
+                createData(
+                        "Saul Goodman (Valid EEA Card)",
+                        Names.Saul_Goodman,
+                        BirthDates.SAUL_GOODMAN,
+                        IdCards.EEA_VALID),
+                createData(
+                        "Tom Hardy DVLA Licence (DWP)",
+                        Names.Tom_Hardy,
+                        BirthDates.TOM_HARDY,
+                        DrivingLicences.getTomHardyDvla()));
+    }
 
     private static IdentityCheckSubjectCriStubData createData(
             String label, Name name, BirthDate birthDate, DrivingPermitDetails drivingLicences) {

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/DrivingLicences.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/data/DrivingLicences.java
@@ -2,78 +2,149 @@ package uk.gov.di.ipv.stub.cred.data;
 
 import uk.gov.di.model.DrivingPermitDetails;
 
+import java.time.LocalDate;
+
 public class DrivingLicences {
 
-    // DVLA licences
-    public static final DrivingPermitDetails ALICE_PARKER_DVLA =
-            createDrivingPermit("PARKE710112PBFGA", "2032-02-02", "2005-02-02", "DVLA", "23", null);
-    public static final DrivingPermitDetails JOE_SHMOE_DVLA =
-            createDrivingPermit(
-                    "DOE99802085J99FG",
-                    "2023-01-18",
-                    "2010-01-18",
-                    "DVLA",
-                    "5",
-                    "122 BURNS CRESCENT EDINBURGH EH1 9GP");
-    public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVLA =
-            createDrivingPermit(
-                    "DECER607085K99AE",
-                    "2025-04-27",
-                    "2023-08-22",
-                    "DVLA",
-                    "16",
-                    "8 HADLEY ROAD BATH BA2 5AA");
-    public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVLA_2 =
-            createDrivingPermit(
-                    "DECER607085K99AE",
-                    "2035-05-01",
-                    "2025-05-02",
-                    "DVLA",
-                    "17",
-                    "8 HADLEY ROAD BATH BA2 5AA");
-    public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVLA_2_INVALID =
-            createDrivingPermit(
-                    "DECER607085K99AE",
-                    "2025-05-03",
-                    "2025-05-02",
-                    "DVLA",
-                    "17",
-                    "8 HADLEY ROAD BATH BA2 5AA");
-    public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVLA_INVALID =
-            createDrivingPermit(
-                    "", "2025-04-27", "2023-08-22", "DVLA", "11", "8 HADLEY ROAD BATH BR2 5LP");
+    // DVLA Licences
+    public static DrivingPermitDetails getAliceParkerDvla() {
+        return createDrivingPermit(
+                "PARKE710112PBFGA",
+                LocalDate.now().plusYears(5).toString(),
+                "2005-02-02",
+                "DVLA",
+                "23",
+                null);
+    }
 
-    // DVA licences
-    public static final DrivingPermitDetails BILLY_BATSON_DVA =
-            createDrivingPermit(
-                    "55667788",
-                    "2042-10-01",
-                    "2018-04-19",
-                    "DVA",
-                    null,
-                    "8 HADLEY ROAD BATH NW3 5RG");
-    public static final DrivingPermitDetails BOB_PARKER_DVA =
-            createDrivingPermit("55667789", "2032-02-02", "2005-02-02", "DVA", null, null);
-    public static final DrivingPermitDetails JOHN_ROBERTS_DVA_INVALID =
-            createDrivingPermit("12345678", "2030-11-12", "2020-12-12", "DVA", null, "BT205NE");
-    public static final DrivingPermitDetails KENNETH_DECERQUEIRA_DVA =
-            createDrivingPermit(
-                    "12345678",
-                    "2042-10-01",
-                    "2018-04-19",
-                    "DVA",
-                    null,
-                    "8 HADLEY ROAD BATH BA2 5AA");
+    public static DrivingPermitDetails getJoeShmoeDvla() {
+        return createDrivingPermit(
+                "DOE99802085J99FG",
+                LocalDate.now().plusYears(5).toString(),
+                "2010-01-18",
+                "DVLA",
+                "5",
+                "122 BURNS CRESCENT EDINBURGH EH1 9GP");
+    }
 
-    // DVLA driving licences for DWP users
-    public static final DrivingPermitDetails CLAIRE_AARTS_DVLA =
-            createDrivingPermit("AARTS710112PBFGA", "2032-02-02", "2015-02-02", "DVLA", null, null);
-    public static final DrivingPermitDetails KABIR_SINGH_DVLA =
-            createDrivingPermit("SINGH710112PBFGA", "2032-02-02", "2015-02-02", "DVLA", null, null);
-    public static final DrivingPermitDetails NORA_PORTER_DVLA =
-            createDrivingPermit("PORTE710112PBFGA", "2032-02-02", "2015-02-02", "DVLA", null, null);
-    public static final DrivingPermitDetails TOM_HARDY_DVLA =
-            createDrivingPermit("HARDY710112PBFGA", "2032-02-02", "2015-02-02", "DVLA", null, null);
+    public static DrivingPermitDetails getKennethDecerqueiraDvla() {
+        return createDrivingPermit(
+                "DECER607085K99AE",
+                LocalDate.now().plusYears(5).toString(),
+                "2023-08-22",
+                "DVLA",
+                "16",
+                "8 HADLEY ROAD BATH BA2 5AA");
+    }
+
+    public static DrivingPermitDetails getKennethDecerqueiraDvlaInvalid() {
+        return createDrivingPermit(
+                "",
+                LocalDate.now().plusYears(5).toString(),
+                "2023-08-22",
+                "DVLA",
+                "11",
+                "8 HADLEY ROAD BATH BR2 5LP");
+    }
+
+    // This doesn't have a dynamic expiry date as it's used in staging tests
+    // therefore needs to have the below values to be valid
+    public static DrivingPermitDetails getKennethDecerqueiraDvla2() {
+        return createDrivingPermit(
+                "DECER607085K99AE",
+                "2035-05-01",
+                "2025-05-02",
+                "DVLA",
+                "17",
+                "8 HADLEY ROAD BATH BA2 5AA");
+    }
+
+    // This doesn't have a dynamic expiry date as it's used in staging tests
+    // therefore needs to have the below values to be valid
+    public static DrivingPermitDetails getKennethDecerqueiraDvla2Invalid() {
+        return createDrivingPermit(
+                "DECER607085K99AE",
+                "2025-05-03",
+                "2025-05-02",
+                "DVLA",
+                "17",
+                "8 HADLEY ROAD BATH BA2 5AA");
+    }
+
+    public static DrivingPermitDetails getClaireAartsDvla() {
+        return createDrivingPermit(
+                "AARTS710112PBFGA",
+                LocalDate.now().plusYears(5).toString(),
+                "2015-02-02",
+                "DVLA",
+                null,
+                null);
+    }
+
+    public static DrivingPermitDetails getKabirSinghDvla() {
+        return createDrivingPermit(
+                "SINGH710112PBFGA",
+                LocalDate.now().plusYears(5).toString(),
+                "2015-02-02",
+                "DVLA",
+                null,
+                null);
+    }
+
+    // This doesn't have a dynamic expiry date as it's used in staging tests
+    // therefore needs to have the below values to be valid
+    public static DrivingPermitDetails getNoraPorterDvla() {
+        return createDrivingPermit(
+                "PORTE710112PBFGA", "2032-02-02", "2015-02-02", "DVLA", null, null);
+    }
+
+    // This doesn't have a dynamic expiry date as it's used in staging tests
+    // therefore needs to have the below values to be valid
+    public static DrivingPermitDetails getTomHardyDvla() {
+        return createDrivingPermit(
+                "HARDY710112PBFGA", "2032-02-02", "2015-02-02", "DVLA", null, null);
+    }
+
+    // DVA Licences
+    public static DrivingPermitDetails getBillyBatsonDva() {
+        return createDrivingPermit(
+                "55667788",
+                LocalDate.now().plusYears(5).toString(),
+                "2018-04-19",
+                "DVA",
+                null,
+                "8 HADLEY ROAD BATH NW3 5RG");
+    }
+
+    public static DrivingPermitDetails getBobParkerDva() {
+        return createDrivingPermit(
+                "55667789",
+                LocalDate.now().plusYears(5).toString(),
+                "2005-02-02",
+                "DVA",
+                null,
+                null);
+    }
+
+    public static DrivingPermitDetails getJohnRobertsDvaInvalid() {
+        return createDrivingPermit(
+                "12345678",
+                LocalDate.now().plusYears(5).toString(),
+                "2020-12-12",
+                "DVA",
+                null,
+                "BT205NE");
+    }
+
+    public static DrivingPermitDetails getKennethDecerqueiraDva() {
+        return createDrivingPermit(
+                "12345678",
+                LocalDate.now().plusYears(5).toString(),
+                "2018-04-19",
+                "DVA",
+                null,
+                "8 HADLEY ROAD BATH BA2 5AA");
+    }
 
     private DrivingLicences() {
         // Replace default public constructor

--- a/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
+++ b/di-ipv-credential-issuer-stub/src/main/java/uk/gov/di/ipv/stub/cred/handlers/AuthorizeHandler.java
@@ -740,19 +740,19 @@ public class AuthorizeHandler {
                 data = CriStubDataClaimedIdentity.Data;
                 break;
             case "DOC Checking App (Stub)":
-                data = CriStubDataDcmaw.Data;
+                data = CriStubDataDcmaw.getData();
                 break;
             case "DWP KBV (Stub)":
                 data = CriStubDataDwpKbv.Data;
                 break;
             case "Driving Licence (Stub)":
-                data = CriStubDataDrivingLicence.Data;
+                data = CriStubDataDrivingLicence.getData();
                 break;
             case "Experian Knowledge Based Verification (Stub)":
                 data = CriStubDataExperianKbv.Data;
                 break;
             case "Face to Face Check (Stub)":
-                data = CriStubDataF2f.Data;
+                data = CriStubDataF2f.getData();
                 break;
             case "Fraud Check (Stub)":
                 data = CriStubDataFraud.Data;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- update driving permit test data to always have an expiry date in the future

Note: I've only updated the driving permits that are NOT used for staging as these require specific values that need to be valid for the DL CRI

### Why did it change

We're adding DL expiry checks in core-back which means that any tests which use driving permit details with hard-coded expiry dates will fail in the future. This commit should future-proof the tests so they won't need to be updated once the hard-coded dates pass.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8830](https://govukverify.atlassian.net/browse/PYIC-8830)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8830]: https://govukverify.atlassian.net/browse/PYIC-8830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ