### PR TITLE
PYIC-8873: Remove EnforceStayinSpecificVpc policy from queue stub.

### DIFF
--- a/di-ipv-queue-stub/deploy/template.yaml
+++ b/di-ipv-queue-stub/deploy/template.yaml
@@ -98,18 +98,6 @@ Resources:
       Policies:
         - VPCAccessPolicy: { }
         - Statement:
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
-        - Statement:
             - Sid: AllowSQS
               Effect: Allow
               Action:
@@ -179,18 +167,6 @@ Resources:
           - !GetAtt QueueStubLambdaSecurityGroup.GroupId
       Policies:
         - VPCAccessPolicy: { }
-        - Statement:
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - Statement:
             - Sid: AllowSQS
               Effect: Allow
@@ -377,18 +353,6 @@ Resources:
           - !GetAtt QueueStubLambdaSecurityGroup.GroupId
       Policies:
         - VPCAccessPolicy: { }
-        - Statement:
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - Statement:
             - Sid: ListQueues
               Effect: Allow


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Remove EnforceStayinSpecificVpc policy from queue stub's lambdas

### Why did it change

The ITHC discovered some potentially overly-permissioned Lambdas, including (most seriously) all of our application Lambdas being granted CreateFunction and UpdateFunctionConfiguration permissions against all resources. This can be found within a historical EnforceStayinSpecificVpc policy defined on each function. It’s not clear why this was added in the first place and what purpose it was intended to serve, but application functions shouldn't need to be able to create and update any further functions themselves.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8873](https://govukverify.atlassian.net/browse/PYIC-8873)


[PYIC-8873]: https://govukverify.atlassian.net/browse/PYIC-8873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ