### PR TITLE
PYIC-8758: Exclude generated dev-deploy templates from Checkov pre-commit scans

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,9 +54,11 @@ repos:
   - repo: https://github.com/bridgecrewio/checkov.git
     rev: '3.2.452'
     hooks:
-      - id: checkov
-        args: ['--framework', 'cloudformation', '--quiet']
-        files: ^(.*/)?template\.(yml|yaml)$
+      - id: checkov_diff
+        args:
+          - '--framework'
+          - 'cloudformation'
+          - '-f'
 
   - repo: https://github.com/lovesegfault/beautysh
     rev: 'v6.2.1'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Configure the Checkov pre-commit hook to scan only deploy/**/template.yaml and explicitly skip dev-deploy and core-dev-deploy generated CloudFormation templates

### Why did it change

dev-deploy and core-dev-deploy generated CloudFormation templates that break linting due to stripped skip comments.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8758](https://govukverify.atlassian.net/browse/PYIC-8758)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8758]: https://govukverify.atlassian.net/browse/PYIC-8758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ