### PR TITLE
PYIC-8830: allow extra nbf parameter when calling /management/enqueueVc endpoint for canned data

### DIFF
--- a/di-ipv-dcmaw-async-stub/README.md
+++ b/di-ipv-dcmaw-async-stub/README.md
@@ -74,7 +74,8 @@ It's also possible to enqueue a VC with pre-defined claims to avoid having to cr
   "document_type": "drivingPermit", # Check the api spec to see what values we support for this
   "evidence_type": "success", # Check the api spec to see what values we support for this
   "driving_permit_expiry_date": "2030-01-01" # An optional parameter which overrides the expiry date of the driving permit set by the stub (by default, it is 30 days after the issued at date ie when the VC was generated),
-  "ci": ["CI1"]
+  "ci": ["CI1"], # An optional parameter. If not empty, the provided contra-indicators will be added to the evidence section of the VC.
+  "nbf": 1672531200 # An optional parameter to allow overriding the default nbf (set to the current datetime in epoch seconds)
 }
 ```
 

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/managementEnqueueRequest.ts
@@ -18,6 +18,7 @@ export interface ManagementEnqueueVcRequestIndividualDetails
   evidence_type: EvidenceType;
   driving_permit_expiry_date?: string;
   ci?: string[];
+  nbf?: number;
 }
 
 export function isManagementEnqueueVcRequestIndividualDetails(

--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/mockVc.ts
@@ -17,6 +17,7 @@ export async function buildMockVc(
   evidenceType: EvidenceType,
   drivingPermitExpiryDate?: string,
   ci: string[] = [],
+  nbf?: number,
 ) {
   const config = await getConfig();
   const currentTimestamp = Math.round(new Date().getTime() / 1000);
@@ -28,7 +29,7 @@ export async function buildMockVc(
     aud: config.vcAudience,
     sub: userId,
     iat: currentTimestamp,
-    nbf: currentTimestamp,
+    nbf: nbf || currentTimestamp,
     vc: {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -44,6 +44,7 @@ export async function handler(
         requestBody.evidence_type,
         requestBody.driving_permit_expiry_date,
         requestBody.ci,
+        requestBody.nbf,
       );
     } else if (isManagementEnqueueVcRequestEvidenceAndSubject(requestBody)) {
       vc = await buildMockVcFromSubjectAndEvidence(

--- a/di-ipv-dcmaw-async-stub/lambdas/test/domain/mockVc.test.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/test/domain/mockVc.test.ts
@@ -37,6 +37,7 @@ describe("buildMockVc", () => {
 
     // Assert
     expect(vc.sub).toEqual(TEST_USER_ID);
+    expect(vc.nbf).toEqual(1672531200); // 2023-01-01T00:00:00
 
     const credentials = vc.vc
       .credentialSubject as DrivingPermitCredentialSubject;
@@ -132,6 +133,47 @@ describe("buildMockVc", () => {
           EvidenceType.success
         ],
         ci: ["CI1", "CI2"],
+        txn: expect.any(String),
+      }),
+    );
+  });
+
+  test("returns mock driving licence with custom nbf", async () => {
+    // Act
+    const expectedNbf = 1769587200; // 2026-01-28T08:00:00
+    const vc = await buildMockVc(
+      TEST_USER_ID,
+      TestUser.kennethD,
+      DocumentType.drivingPermit,
+      EvidenceType.success,
+      undefined,
+      undefined,
+      expectedNbf,
+    );
+
+    // Assert
+    expect(vc.sub).toEqual(TEST_USER_ID);
+    expect(vc.nbf).toEqual(expectedNbf);
+
+    const credentials = vc.vc
+      .credentialSubject as DrivingPermitCredentialSubject;
+    expect(credentials["name"]).toEqual(USER_CLAIMS[TestUser.kennethD].name);
+    expect(credentials["birthDate"]).toEqual(
+      USER_CLAIMS[TestUser.kennethD].birthDate,
+    );
+
+    const expectedExpiryDate = "2023-01-31";
+    expect(credentials.drivingPermit).toEqual([
+      {
+        ...DOCUMENT_CLAIMS[DocumentType.drivingPermit].drivingPermit[0],
+        expiryDate: expectedExpiryDate,
+      },
+    ]);
+
+    expect(vc.vc.evidence[0]).toEqual(
+      expect.objectContaining({
+        ...EVIDENCE_CLAIMS[DocumentType.drivingPermit][EvidenceType.success],
+        ci: [],
         txn: expect.any(String),
       }),
     );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

allow extra nbf parameter when calling /management/enqueueVc endpoint for canned data

### Why did it change

QA are testing the core-back changes which check for expired DL. To allow them to test different scenarios (as well as write e2e tests later on), we need to be able to also control the nbf on the enqueue VC on the strategic app stub

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8830](https://govukverify.atlassian.net/browse/PYIC-8830)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8830]: https://govukverify.atlassian.net/browse/PYIC-8830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ