### PR TITLE
PYIC-8920: update com.nimbusds:nimbus-jose-jwt from 9.21 to 9.37.4

### DIFF
--- a/public-jwk-creator/build.gradle
+++ b/public-jwk-creator/build.gradle
@@ -19,7 +19,7 @@ java {
 dependencies {
 	implementation  'com.sparkjava:spark-core:2.9.4',
 			'com.sparkjava:spark-template-mustache:2.7.1',
-			'com.nimbusds:nimbus-jose-jwt:9.21',
+			'com.nimbusds:nimbus-jose-jwt:9.37.4',
 			'org.slf4j:slf4j-simple:1.7.36'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

update com.nimbusds:nimbus-jose-jwt from 9.21 to 9.37.4

### Why did it change

There was a previous dependabot PR to update this [here](https://github.com/govuk-one-login/ipv-stubs/pull/1956). However, the PR also updated jetty packages that didn't depend on nimbus-jose-jwt which were failing deployment. This PR solely updates com.nimbusds:nimbus-jose-jwt

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8920](https://govukverify.atlassian.net/browse/PYIC-8920)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8920]: https://govukverify.atlassian.net/browse/PYIC-8920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ