### PR TITLE
PYIC-8920: override io.netty:netty-codec-http to resolve CRLF injection vulnerability

### DIFF
--- a/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/put-contra-indicators/build.gradle
@@ -25,6 +25,12 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:11.32",
 			project(":di-ipv-cimit-stub:lib")
 
+	constraints {
+		implementation("io.netty:netty-codec-http:4.2.8.Final") {
+			because "older versions introduced a CRLF Injection vulnerability"
+		}
+	}
+
 	compileOnly "org.projectlombok:lombok:1.18.42"
 	annotationProcessor "org.projectlombok:lombok:1.18.42"
 

--- a/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
+++ b/di-ipv-cimit-stub/lambdas/stub-management/build.gradle
@@ -24,6 +24,12 @@ dependencies {
 			"org.apache.logging.log4j:log4j-layout-template-json:2.25.3",
 			project(":di-ipv-cimit-stub:lib")
 
+	constraints {
+		implementation("io.netty:netty-codec-http:4.2.8.Final") {
+			because "older versions introduced a CRLF Injection vulnerability"
+		}
+	}
+
 	compileOnly "org.projectlombok:lombok:1.18.42"
 	annotationProcessor "org.projectlombok:lombok:1.18.42"
 

--- a/di-ipv-cimit-stub/lib/build.gradle
+++ b/di-ipv-cimit-stub/lib/build.gradle
@@ -16,6 +16,12 @@ dependencies {
 			"org.apache.logging.log4j:log4j-core:2.25.3",
 			"com.amazonaws:aws-lambda-java-events:3.16.1"
 
+	constraints {
+		implementation("io.netty:netty-codec-http:4.2.8.Final") {
+			because "older versions introduced a CRLF Injection vulnerability"
+		}
+	}
+
 	testImplementation "org.junit.jupiter:junit-jupiter:6.0.2",
 			"org.mockito:mockito-junit-jupiter:5.21.0",
 			'uk.org.webcompere:system-stubs-jupiter:2.1.8'


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

override io.netty:netty-codec-http to non-vulnerable version to resolve CRLF injection vulnerability

### Why did it change

To try and resolve this security vulnerability: https://github.com/govuk-one-login/ipv-stubs/security/dependabot/110

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8920](https://govukverify.atlassian.net/browse/PYIC-8920)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8920]: https://govukverify.atlassian.net/browse/PYIC-8920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ