### PR TITLE
PYIC-8920: override org.eclipse.jetty:jetty-xml to resolve vulnerability

### DIFF
--- a/public-jwk-creator/build.gradle
+++ b/public-jwk-creator/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 		implementation("org.eclipse.jetty:jetty-server:9.4.58.v20250814") {
 			because "older versions introduce a vulnerability"
 		}
+
+		implementation("org.eclipse.jetty:jetty-xml:9.4.52.v20230823") {
+			because "older versions introduce a vulnerability"
+		}
 	}
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

override org.eclipse.jetty:jetty-xml to non-vulnerable version

### Why did it change

To resolve this vulnerability: https://github.com/govuk-one-login/ipv-stubs/security/dependabot/26

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8920](https://govukverify.atlassian.net/browse/PYIC-8920)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8920]: https://govukverify.atlassian.net/browse/PYIC-8920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ