### PR TITLE
BAU - more expressive names for APIGW log groups for easier debugging

### DIFF
--- a/di-ipv-cimit-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-cimit-stub/core-dev-deploy/template.yaml
@@ -831,14 +831,14 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/restApi-${Environment}"
+      LogGroupName: !Sub "/aws/apigateway/cimitStubExternalApi-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   InternalRestApiLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      RetentionInDays: 1
-      LogGroupName: !Sub "/aws/lambda/internalRestApi-${Environment}"
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/apigateway/cimitStubInternalApi-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
 Outputs:

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -875,18 +875,18 @@ Resources:
           "responseLength":"$context.responseLength"
           }
 
-  InternalRestApiLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      RetentionInDays: 1
-      LogGroupName: !Sub "/aws/lambda/internalRestApi-${Environment}"
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
-
   RestApiLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/restApi-${Environment}"
+      LogGroupName: !Sub "/aws/apigateway/cimitStubExternalApi-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  InternalRestApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/apigateway/cimitStubInternalApi-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
 Outputs:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Renamed api gateway log groups for the cimit stub to make it easier
to find them when debugging in the console
Change the order of declaration in one of the templates so that deploy
and dev-deploy would be the same
Fixed the retention period so the two groups would be the same

### Why did it change

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8901](https://govukverify.atlassian.net/browse/PYIC-8901)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8901]: https://govukverify.atlassian.net/browse/PYIC-8901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ