### PR TITLE
PYIC-8901: Point cimit api gateway at TS lambdas.

### DIFF
--- a/di-ipv-cimit-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-cimit-stub/core-dev-deploy/template.yaml
@@ -147,7 +147,7 @@ Resources:
   PostMitigationsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunction }]
+      FunctionName: !Sub ["${function}:live", { function: !Ref PostMitigationsFunctionTS }]
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/mitigate"
@@ -244,7 +244,7 @@ Resources:
   PutContraIndicatorsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunctionTS } ]
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/detect"
@@ -339,7 +339,7 @@ Resources:
   GetContraIndicatorCredentialLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
+      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunctionTS } ]
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/GET/contra-indicators"
@@ -357,6 +357,49 @@ Resources:
       CodeUri: "../lambdas/stub-management"
       Handler: uk.gov.di.ipv.core.stubmanagement.StubManagementHandler::handleRequest
       Runtime: java21
+      PackageType: Zip
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          CIMIT_PARAM_BASE_PATH: "/stubs/core/cimit/"
+          IS_LOCAL: false
+          CIMIT_STUB_TABLE_NAME: !Ref CimitStubTable
+          PENDING_MITIGATIONS_TABLE: !Ref PendingMitigationsTable
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        SecurityGroupIds:
+          - !GetAtt CimitLambdaSecurityGroup.GroupId
+      Policies:
+        - VPCAccessPolicy: { }
+        - SSMParameterReadPolicy:
+            ParameterName: stubs/core/cimit/*
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CimitStubTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PendingMitigationsTable
+      AutoPublishAlias: live
+
+  StubManagementFunctionTS:
+    Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
+    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+    DependsOn:
+      - "StubManagementFunctionLogGroup"
+    Properties:
+      FunctionName: !Sub "stubManagement-ts-${Environment}"
+      CodeUri: "../../di-ipv-cimit-stub-ts/lambdas/src/external-api/stub-management"
+      Handler: stubManagementHandler.handler
+      Runtime: nodejs22.x
       PackageType: Zip
       Architectures:
         - arm64
@@ -412,49 +455,6 @@ Resources:
             RestApiId: !Ref RestApiGateway
             Path: /user/{userId}/mitigations/{ci}
             Method: PUT
-
-  StubManagementFunctionTS:
-    Type: AWS::Serverless::Function
-    # checkov:skip=CKV_AWS_109: this requires a broad set of permissions
-    # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
-    # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
-    DependsOn:
-      - "StubManagementFunctionLogGroup"
-    Properties:
-      FunctionName: !Sub "stubManagement-ts-${Environment}"
-      CodeUri: "../../di-ipv-cimit-stub-ts/lambdas/src/external-api/stub-management"
-      Handler: stubManagementHandler.handler
-      Runtime: nodejs22.x
-      PackageType: Zip
-      Architectures:
-        - arm64
-      MemorySize: 2048
-      Tracing: Active
-      Environment:
-        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
-        Variables:
-          ENVIRONMENT: !Sub "${Environment}"
-          CIMIT_PARAM_BASE_PATH: "/stubs/core/cimit/"
-          IS_LOCAL: false
-          CIMIT_STUB_TABLE_NAME: !Ref CimitStubTable
-          PENDING_MITIGATIONS_TABLE: !Ref PendingMitigationsTable
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
-        SecurityGroupIds:
-          - !GetAtt CimitLambdaSecurityGroup.GroupId
-      Policies:
-        - VPCAccessPolicy: { }
-        - SSMParameterReadPolicy:
-            ParameterName: stubs/core/cimit/*
-        - KMSDecryptPolicy:
-            KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBCrudPolicy:
-            TableName: !Ref CimitStubTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref PendingMitigationsTable
-      AutoPublishAlias: live
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -738,9 +738,9 @@ Resources:
   InternalRestApiGateway:
     Type: AWS::Serverless::Api
     DependsOn:
-      - GetContraIndicatorCredentialFunction
-      - PostMitigationsFunction
-      - PutContraIndicatorsFunction
+      - GetContraIndicatorCredentialFunctionTS
+      - PostMitigationsFunctionTS
+      - PutContraIndicatorsFunctionTS
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub Internal CIMIT API Gateway ${Environment}
@@ -791,7 +791,7 @@ Resources:
 
   RestApiGateway:
     Type: AWS::Serverless::Api
-    DependsOn: StubManagementFunction
+    DependsOn: StubManagementFunctionTS
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub CIMIT API Gateway ${Environment}

--- a/di-ipv-cimit-stub/deploy/template.yaml
+++ b/di-ipv-cimit-stub/deploy/template.yaml
@@ -191,7 +191,7 @@ Resources:
   PostMitigationsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunction } ]
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PostMitigationsFunctionTS } ]
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/mitigate"
@@ -288,7 +288,7 @@ Resources:
   PutContraIndicatorsLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunction } ]
+      FunctionName: !Sub [ "${function}:live", { function: !Ref PutContraIndicatorsFunctionTS } ]
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/POST/contra-indicators/detect"
@@ -383,7 +383,7 @@ Resources:
   GetContraIndicatorCredentialLiveAliasFunctionInternalRestApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunction } ]
+      FunctionName: !Sub [ "${function}:live", { function: !Ref GetContraIndicatorCredentialFunctionTS } ]
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${InternalRestApiGateway}/*/GET/contra-indicators"
@@ -431,31 +431,6 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref PendingMitigationsTable
       AutoPublishAlias: live
-      Events:
-        PostCis:
-          Type: Api
-          Properties:
-            RestApiId: !Ref RestApiGateway
-            Path: /user/{userId}/cis
-            Method: POST
-        PutCis:
-          Type: Api
-          Properties:
-            RestApiId: !Ref RestApiGateway
-            Path: /user/{userId}/cis
-            Method: PUT
-        PostMitigations:
-          Type: Api
-          Properties:
-            RestApiId: !Ref RestApiGateway
-            Path: /user/{userId}/mitigations/{ci}
-            Method: POST
-        PutMitigations:
-          Type: Api
-          Properties:
-            RestApiId: !Ref RestApiGateway
-            Path: /user/{userId}/mitigations/{ci}
-            Method: PUT
 
   StubManagementFunctionTS:
     Type: AWS::Serverless::Function
@@ -499,6 +474,31 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref PendingMitigationsTable
       AutoPublishAlias: live
+      Events:
+        PostCisTS:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /user/{userId}/cis
+            Method: POST
+        PutCisTS:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /user/{userId}/cis
+            Method: PUT
+        PostMitigationsTS:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /user/{userId}/mitigations/{ci}
+            Method: POST
+        PutMitigationsTS:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /user/{userId}/mitigations/{ci}
+            Method: PUT
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -783,9 +783,9 @@ Resources:
   InternalRestApiGateway:
     Type: AWS::Serverless::Api
     DependsOn:
-      - GetContraIndicatorCredentialFunction
-      - PostMitigationsFunction
-      - PutContraIndicatorsFunction
+      - GetContraIndicatorCredentialFunctionTS
+      - PostMitigationsFunctionTS
+      - PutContraIndicatorsFunctionTS
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub Internal CIMIT API Gateway ${Environment}
@@ -836,7 +836,7 @@ Resources:
 
   RestApiGateway:
     Type: AWS::Serverless::Api
-    DependsOn: StubManagementFunction
+    DependsOn: StubManagementFunctionTS
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub CIMIT API Gateway ${Environment}

--- a/di-ipv-cimit-stub/openAPI/cimit-external.yaml
+++ b/di-ipv-cimit-stub/openAPI/cimit-external.yaml
@@ -53,7 +53,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunctionTS.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         requestTemplates:
           application/x-www-form-urlencoded:
@@ -81,7 +81,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunctionTS.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         requestTemplates:
           application/x-www-form-urlencoded:
@@ -123,7 +123,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunctionTS.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         requestTemplates:
           application/x-www-form-urlencoded:
@@ -164,7 +164,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StubManagementFunctionTS.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         requestTemplates:
           application/x-www-form-urlencoded:

--- a/di-ipv-cimit-stub/openAPI/cimit-internal.yaml
+++ b/di-ipv-cimit-stub/openAPI/cimit-internal.yaml
@@ -50,7 +50,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetContraIndicatorCredentialFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetContraIndicatorCredentialFunctionTS.Arn}:live/invocations
 
   /contra-indicators/detect:
     post:
@@ -95,7 +95,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PutContraIndicatorsFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PutContraIndicatorsFunctionTS.Arn}:live/invocations
 
   /contra-indicators/mitigate:
     post:
@@ -140,7 +140,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostMitigationsFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostMitigationsFunctionTS.Arn}:live/invocations
 
   /contra-indicators/healthcheck:
     get:


### PR DESCRIPTION


## Proposed changes

### What changed

Point cimit api gateway at TS lambdas.
This also involves moving event triggers from the java stub management lambda to the Typescript one

### Why did it change

This is part of the work to replace the Java cimit stub with a typescript one.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8901](https://govukverify.atlassian.net/browse/PYIC-8901)


## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8901]: https://govukverify.atlassian.net/browse/PYIC-8901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ