### PR TITLE
Pyic 8913 fraud mortality data

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -210,7 +210,7 @@
         "filename": "di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json",
         "hashed_secret": "51da07e5aabf9c96745c4dc5aa30306162fa13db",
         "is_verified": false,
-        "line_number": 405
+        "line_number": 437
       }
     ],
     "di-ipv-credential-issuer-stub/src/main/resources/templates/authorize.mustache": [
@@ -368,5 +368,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-07T16:38:43Z"
+  "generated_at": "2026-02-20T15:33:09Z"
 }

--- a/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
+++ b/di-ipv-credential-issuer-stub/src/main/resources/data/criStubEvidencePayloads.json
@@ -60,6 +60,38 @@
       }
     },
     {
+      "criType": "Fraud Check (Stub)",
+      "label": "Failed fraud check (Mortality) (M1C)",
+      "payload": {
+        "type": "IdentityCheck",
+        "identityFraudScore": 0,
+        "checkDetails": [
+          {
+            "checkMethod": "data",
+            "fraudCheck": "applicable_authoritative_source"
+          },
+          {
+            "checkMethod": "data",
+            "fraudCheck": "available_authoritative_source"
+          }
+        ],
+        "failedCheckDetails": [
+          {
+            "checkMethod": "data",
+            "fraudCheck": "mortality_check"
+          },
+          {
+            "checkMethod": "data",
+            "fraudCheck": "identity_theft_check"
+          },
+          {
+            "checkMethod": "data",
+            "fraudCheck": "synthetic_identity_check"
+          }
+        ]
+      }
+    },
+    {
       "criType": "Experian Knowledge Based Verification (Stub)",
       "label": "Passed verification (M1A) with checkDetails",
       "payload": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added fraud data for failed mortality check

### Why did it change

To make manual testing easier

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8913](https://govukverify.atlassian.net/browse/PYIC-8913)



[PYIC-8913]: https://govukverify.atlassian.net/browse/PYIC-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ