### PR TITLE
BAU: update deploy-credential-issuer-stub.yml to remove use of tj-actions

### DIFF
--- a/.github/workflows/deploy-credential-issuer-stub.yml
+++ b/.github/workflows/deploy-credential-issuer-stub.yml
@@ -17,130 +17,64 @@ jobs:
   decide-stubs-to-deploy:
     runs-on: ubuntu-latest
     outputs:
-      deploy-all-stubs: ${{ steps.get-shared-changed-files.outputs.any_changed }}
-      deploy-address-stub: ${{ steps.get-address-changed-files.outputs.any_changed }}
-      deploy-bav-stub: ${{ steps.get-bav-changed-files.outputs.any_changed }}
-      deploy-ci-stub: ${{ steps.get-ci-changed-files.outputs.any_changed }}
-      deploy-dcmaw-stub: ${{ steps.get-dcmaw-changed-files.outputs.any_changed }}
-      deploy-dl-stub: ${{ steps.get-dl-changed-files.outputs.any_changed }}
-      deploy-dwp-kbv-stub: ${{ steps.get-dwp-kbv-changed-files.outputs.any_changed }}
-      deploy-experian-kbv-stub: ${{ steps.get-experian-kbv-changed-files.outputs.any_changed }}
-      deploy-f2f-stub: ${{ steps.get-f2f-changed-files.outputs.any_changed }}
-      deploy-fraud-stub: ${{ steps.get-fraud-changed-files.outputs.any_changed }}
-      deploy-nino-stub: ${{ steps.get-nino-changed-files.outputs.any_changed }}
-      deploy-passport-stub: ${{ steps.get-passport-changed-files.outputs.any_changed }}
+      deploy-all-stubs: ${{ steps.get-changed-files.outputs.shared_changed }}
+      deploy-address-stub: ${{ steps.get-changed-files.outputs.address_changed }}
+      deploy-bav-stub: ${{ steps.get-changed-files.outputs.bav_changed }}
+      deploy-ci-stub: ${{ steps.get-changed-files.outputs.ci_changed }}
+      deploy-dcmaw-stub: ${{ steps.get-changed-files.outputs.dcmaw_changed }}
+      deploy-dl-stub: ${{ steps.get-changed-files.outputs.dl_changed }}
+      deploy-dwp-kbv-stub: ${{ steps.get-changed-files.outputs.dwp_kbv_changed }}
+      deploy-experian-kbv-stub: ${{ steps.get-changed-files.outputs.experian_kbv_changed }}
+      deploy-f2f-stub: ${{ steps.get-changed-files.outputs.f2f_changed }}
+      deploy-fraud-stub: ${{ steps.get-changed-files.outputs.fraud_changed }}
+      deploy-nino-stub: ${{ steps.get-changed-files.outputs.nino_changed }}
+      deploy-passport-stub: ${{ steps.get-changed-files.outputs.passport_changed }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@5250492686b253f06fa55861556d1027b067aeb5 # v9.0.2
-
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
         id: last_successful_commit_push_on_main
         with:
-          main-branch-name: ${{ steps.branch-name.outputs.default_branch }}
+          main-branch-name: main
 
-      - name: Get changed shared files
-        id: get-shared-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/gradle/**
-            di-ipv-credential-issuer-stub/src/**
-            di-ipv-credential-issuer-stub/*
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
+      - name: Get changed files
+        id: get-changed-files
+        run: |
+          BASE_SHA="${{ steps.last_successful_commit_push_on_main.outputs.base }}"
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD)
 
-      - name: Get changed address files
-        id: get-address-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/address/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
+          check_changes() {
+            local id="$1"
+            shift
+            local found="false"
+            for pattern in "$@"; do
+              if echo "$CHANGED" | grep -q "$pattern"; then
+                found="true"
+                break
+              fi
+            done
+            echo "${id}=${found}" >> "$GITHUB_OUTPUT"
+          }
 
-      - name: Get changed bav files
-        id: get-bav-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/bav/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
+          check_changes "shared_changed" \
+            "^di-ipv-credential-issuer-stub/gradle/" \
+            "^di-ipv-credential-issuer-stub/src/" \
+            "^di-ipv-credential-issuer-stub/[^/]*$"
 
-      - name: Get changed CI files
-        id: get-ci-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/claimed-identity/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed dcmaw files
-        id: get-dcmaw-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/dcmaw/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed driving licence files
-        id: get-dl-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/driving-licence/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed DWP KBV files
-        id: get-dwp-kbv-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/dwp-kbv/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed Experian KBV files
-        id: get-experian-kbv-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/experian-kbv/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed F2F files
-        id: get-f2f-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/face-to-face/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed fraud files
-        id: get-fraud-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/fraud/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed nino files
-        id: get-nino-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/nino/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
-
-      - name: Get changed passport files
-        id: get-passport-changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
-        with:
-          files: |
-            di-ipv-credential-issuer-stub/deploy/passport/**
-          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
+          check_changes "address_changed" "^di-ipv-credential-issuer-stub/deploy/address/"
+          check_changes "bav_changed" "^di-ipv-credential-issuer-stub/deploy/bav/"
+          check_changes "ci_changed" "^di-ipv-credential-issuer-stub/deploy/claimed-identity/"
+          check_changes "dcmaw_changed" "^di-ipv-credential-issuer-stub/deploy/dcmaw/"
+          check_changes "dl_changed" "^di-ipv-credential-issuer-stub/deploy/driving-licence/"
+          check_changes "dwp_kbv_changed" "^di-ipv-credential-issuer-stub/deploy/dwp-kbv/"
+          check_changes "experian_kbv_changed" "^di-ipv-credential-issuer-stub/deploy/experian-kbv/"
+          check_changes "f2f_changed" "^di-ipv-credential-issuer-stub/deploy/face-to-face/"
+          check_changes "fraud_changed" "^di-ipv-credential-issuer-stub/deploy/fraud/"
+          check_changes "nino_changed" "^di-ipv-credential-issuer-stub/deploy/nino/"
+          check_changes "passport_changed" "^di-ipv-credential-issuer-stub/deploy/passport/"
 
   deploy-address-stub:
     needs:


### PR DESCRIPTION
## Proposed changes

### What changed

update deploy-credential-issuer-stub.yml to remove use of tj-actions

### Why did it change

tj-actions/branch-names and tj-actions/changed-files is not certified in the GH marketplace and so is causing our CI to fail due to a rule preventing uncertified actions from running in the pipeline. This PR removes the use of tj-actions and replaces it with a script to check for the changed files

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated
