### PR TITLE
BAU: small README change to the di-ipv-credential-issuer-stub to trigger a deployment

### DIFF
--- a/di-ipv-credential-issuer-stub/README.MD
+++ b/di-ipv-credential-issuer-stub/README.MD
@@ -4,7 +4,7 @@
 
 
 
-A Credential Issuer stub using Spark Java
+A Credential Issuer stub using Spark Java.
 
 ## About
 


### PR DESCRIPTION
## Proposed changes

### What changed

small README change to the di-ipv-credential-issuer-stub to trigger a deployment

### Why did it change

We need to trigger the `deploy-credential-issuer-stub` workflow but it can only be triggered by merging in a commit that updates the di-ipv-credential-issuer-stub directory.

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated
