### PR TITLE
BAU: add permissions for cri deploy jobs

### DIFF
--- a/.github/workflows/deploy-credential-issuer-stub.yml
+++ b/.github/workflows/deploy-credential-issuer-stub.yml
@@ -150,6 +150,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-address-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-address-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-bav-stub:
     needs:
@@ -159,6 +163,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-bav-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-bav-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-ci-stub:
     needs:
@@ -168,6 +176,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-ci-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-claimed-identity-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-dcmaw-stub:
     needs:
@@ -177,6 +189,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-dcmaw-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-dcmaw-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-dl-stub:
     needs:
@@ -186,6 +202,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-dl-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-driving-licence-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-dwp-kbv-stub:
     needs:
@@ -195,6 +215,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-dwp-kbv-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-dwp-kbv-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-experian-kbv-stub:
     needs:
@@ -204,6 +228,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-experian-kbv-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-experian-kbv-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-f2f-stub:
     needs:
@@ -213,6 +241,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-f2f-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-f2f-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-fraud-stub:
     needs:
@@ -222,6 +254,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-fraud-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-fraud-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-nino-stub:
     needs:
@@ -231,6 +267,10 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-nino-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-nino-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
 
   deploy-passport-stub:
     needs:
@@ -240,3 +280,7 @@ jobs:
       needs.test-cri-stub.result == 'success' &&
       (needs.decide-stubs-to-deploy.outputs.deploy-passport-stub == 'true' || needs.decide-stubs-to-deploy.outputs.deploy-all-stubs == 'true')
     uses: ./.github/workflows/cri-passport-stub.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read

--- a/di-ipv-credential-issuer-stub/README.MD
+++ b/di-ipv-credential-issuer-stub/README.MD
@@ -4,7 +4,7 @@
 
 
 
-A Credential Issuer stub using Spark Java.
+A Credential Issuer stub using Spark Java
 
 ## About
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

add permissions for cri deploy jobs

### Why did it change
The GHA was failing to deploy the cri stubs because the calling job didn't have the right permissions for the nested jobs

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated
