### PR TITLE
BAU: pass secrets into nested jobs for CRI stub deployment

### DIFF
--- a/.github/workflows/cri-address-stub.yml
+++ b/.github/workflows/cri-address-stub.yml
@@ -2,6 +2,17 @@ name: Address CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_ADDRESS_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_ADDRESS_ECR_REPOSITORY:
+        required: true
+      CRI_ADDRESS_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-bav-stub.yml
+++ b/.github/workflows/cri-bav-stub.yml
@@ -2,6 +2,17 @@ name: Bank account verification CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_BAV_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_BAV_ECR_REPOSITORY:
+        required: true
+      CRI_BAV_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-claimed-identity-stub.yml
+++ b/.github/workflows/cri-claimed-identity-stub.yml
@@ -2,6 +2,17 @@ name: Claimed Identity Collector CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_CI_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_CI_ECR_REPOSITORY:
+        required: true
+      CRI_CI_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-dcmaw-stub.yml
+++ b/.github/workflows/cri-dcmaw-stub.yml
@@ -2,6 +2,17 @@ name: DCMAW CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_DCMAW_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_DCMAW_ECR_REPOSITORY:
+        required: true
+      CRI_DCMAW_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-driving-licence-stub.yml
+++ b/.github/workflows/cri-driving-licence-stub.yml
@@ -2,6 +2,17 @@ name: Driving Licence CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_DRV_LICENCE_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_DRV_LICENCE_ECR_REPOSITORY:
+        required: true
+      CRI_DRV_LICENCE_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-dwp-kbv-stub.yml
+++ b/.github/workflows/cri-dwp-kbv-stub.yml
@@ -2,6 +2,17 @@ name: DWP KBV CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_DWP_KBV_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_DWP_KBV_ECR_REPOSITORY:
+        required: true
+      CRI_DWP_KBV_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-experian-kbv-stub.yml
+++ b/.github/workflows/cri-experian-kbv-stub.yml
@@ -2,6 +2,17 @@ name: Experian KBV CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_EXPERIAN_KBV_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_EXPERIAN_KBV_ECR_REPOSITORY:
+        required: true
+      CRI_EXPERIAN_KBV_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-f2f-stub.yml
+++ b/.github/workflows/cri-f2f-stub.yml
@@ -2,6 +2,17 @@ name: Face to Face CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_F2F_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_F2F_ECR_REPOSITORY:
+        required: true
+      CRI_F2F_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-fraud-stub.yml
+++ b/.github/workflows/cri-fraud-stub.yml
@@ -2,6 +2,17 @@ name: Fraud CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_FRAUD_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_FRAUD_ECR_REPOSITORY:
+        required: true
+      CRI_FRAUD_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-nino-stub.yml
+++ b/.github/workflows/cri-nino-stub.yml
@@ -2,6 +2,17 @@ name: NINO CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_NINO_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_NINO_ECR_REPOSITORY:
+        required: true
+      CRI_NINO_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/cri-passport-stub.yml
+++ b/.github/workflows/cri-passport-stub.yml
@@ -2,6 +2,17 @@ name: Passport CRI Stub - Secure Pipeline build, push & Ship
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CRI_PASSPORT_ARTIFACT_BUCKET_NAME:
+        required: true
+      CONTAINER_SIGN_KMS_KEY:
+        required: true
+      DYNATRACE_PAAS_TOKEN:
+        required: true
+      CRI_PASSPORT_ECR_REPOSITORY:
+        required: true
+      CRI_PASSPORT_GH_ACTIONS_ROLE_ARN:
+        required: true
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/deploy-credential-issuer-stub.yml
+++ b/.github/workflows/deploy-credential-issuer-stub.yml
@@ -154,6 +154,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_ADDRESS_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_ADDRESS_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_ADDRESS_ECR_REPOSITORY: ${{ secrets.CRI_ADDRESS_ECR_REPOSITORY }}
+      CRI_ADDRESS_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_ADDRESS_GH_ACTIONS_ROLE_ARN }}
 
   deploy-bav-stub:
     needs:
@@ -167,6 +173,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_BAV_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_BAV_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_BAV_ECR_REPOSITORY: ${{ secrets.CRI_BAV_ECR_REPOSITORY }}
+      CRI_BAV_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_BAV_GH_ACTIONS_ROLE_ARN }}
 
   deploy-ci-stub:
     needs:
@@ -180,6 +192,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_CI_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_CI_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_CI_ECR_REPOSITORY: ${{ secrets.CRI_CI_ECR_REPOSITORY }}
+      CRI_CI_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_CI_GH_ACTIONS_ROLE_ARN }}
 
   deploy-dcmaw-stub:
     needs:
@@ -193,6 +211,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_DCMAW_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_DCMAW_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_DCMAW_ECR_REPOSITORY: ${{ secrets.CRI_DCMAW_ECR_REPOSITORY }}
+      CRI_DCMAW_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_DCMAW_GH_ACTIONS_ROLE_ARN }}
 
   deploy-dl-stub:
     needs:
@@ -206,6 +230,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_DRV_LICENCE_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_DRV_LICENCE_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_DRV_LICENCE_ECR_REPOSITORY: ${{ secrets.CRI_DRV_LICENCE_ECR_REPOSITORY }}
+      CRI_DRV_LICENCE_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_DRV_LICENCE_GH_ACTIONS_ROLE_ARN }}
 
   deploy-dwp-kbv-stub:
     needs:
@@ -219,6 +249,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_DWP_KBV_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_DWP_KBV_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_DWP_KBV_ECR_REPOSITORY: ${{ secrets.CRI_DWP_KBV_ECR_REPOSITORY }}
+      CRI_DWP_KBV_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_DWP_KBV_GH_ACTIONS_ROLE_ARN }}
 
   deploy-experian-kbv-stub:
     needs:
@@ -232,6 +268,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_EXPERIAN_KBV_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_EXPERIAN_KBV_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_EXPERIAN_KBV_ECR_REPOSITORY: ${{ secrets.CRI_EXPERIAN_KBV_ECR_REPOSITORY }}
+      CRI_EXPERIAN_KBV_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_EXPERIAN_KBV_GH_ACTIONS_ROLE_ARN }}
 
   deploy-f2f-stub:
     needs:
@@ -245,6 +287,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_F2F_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_F2F_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_F2F_ECR_REPOSITORY: ${{ secrets.CRI_F2F_ECR_REPOSITORY }}
+      CRI_F2F_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_F2F_GH_ACTIONS_ROLE_ARN }}
 
   deploy-fraud-stub:
     needs:
@@ -258,6 +306,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_FRAUD_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_FRAUD_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_FRAUD_ECR_REPOSITORY: ${{ secrets.CRI_FRAUD_ECR_REPOSITORY }}
+      CRI_FRAUD_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_FRAUD_GH_ACTIONS_ROLE_ARN }}
 
   deploy-nino-stub:
     needs:
@@ -271,6 +325,12 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_NINO_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_NINO_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_NINO_ECR_REPOSITORY: ${{ secrets.CRI_NINO_ECR_REPOSITORY }}
+      CRI_NINO_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_NINO_GH_ACTIONS_ROLE_ARN }}
 
   deploy-passport-stub:
     needs:
@@ -284,3 +344,9 @@ jobs:
       id-token: write
       contents: read
       packages: read
+    secrets:
+      CRI_PASSPORT_ARTIFACT_BUCKET_NAME: ${{ secrets.CRI_PASSPORT_ARTIFACT_BUCKET_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+      DYNATRACE_PAAS_TOKEN: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      CRI_PASSPORT_ECR_REPOSITORY: ${{ secrets.CRI_PASSPORT_ECR_REPOSITORY }}
+      CRI_PASSPORT_GH_ACTIONS_ROLE_ARN: ${{ secrets.CRI_PASSPORT_GH_ACTIONS_ROLE_ARN }}

--- a/di-ipv-credential-issuer-stub/README.MD
+++ b/di-ipv-credential-issuer-stub/README.MD
@@ -4,7 +4,7 @@
 
 
 
-A Credential Issuer stub using Spark Java
+A Credential Issuer stub using Spark Java.
 
 ## About
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

pass secrets into nested jobs for CRI stub deployment

### Why did it change

Deployments were failing because the nested jobs didn't have access to the secrets when being called from the `deploy-credential-issuer-stub.yml` file


## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated
