### PR TITLE
PYIC-8971: fix 502s from SIS lambda

### DIFF
--- a/di-ipv-sis-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-sis-stub/core-dev-deploy/template.yaml
@@ -135,7 +135,11 @@ Resources:
         Minify: true
         Target: "es2022"
         Format: esm
+        OutExtension:
+          - .js=.mjs
         Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
         EntryPoints:
           - src/handlers/sisHandler.ts
 

--- a/di-ipv-sis-stub/deploy/template.yaml
+++ b/di-ipv-sis-stub/deploy/template.yaml
@@ -144,7 +144,7 @@ Resources:
     Properties:
       FunctionName: !Sub "sisPostUserIdentity-${Environment}"
       CodeUri: "../lambdas"
-      Handler: sisHandler.postUserIdentityHandler
+      Handler: src/handlers/sisHandler.postUserIdentityHandler
       Runtime: nodejs22.x
       PackageType: Zip
       Architectures:
@@ -197,7 +197,11 @@ Resources:
         Minify: true
         Target: "es2022"
         Format: esm
+        OutExtension:
+          - .js=.mjs
         Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
         EntryPoints:
           - src/handlers/sisHandler.ts
 


### PR DESCRIPTION
- specify OutExtension so that esbuild re-names outputs to use .mjs so they're treated as ESM not CommonJs
- inject createRequire t the top of the bundle with Banner so that any CJS require() calls still work within ESM (as some dependencies still use commonjs internally)

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated
