### PR TITLE
Revert "BAU: Bump org.eclipse.jetty:jetty-xml from 9.4.52.v20230823 to 12.1.6"

### DIFF
--- a/public-jwk-creator/build.gradle
+++ b/public-jwk-creator/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 			because "older versions introduce a vulnerability"
 		}
 
-		implementation("org.eclipse.jetty:jetty-xml:12.1.6") {
+		implementation("org.eclipse.jetty:jetty-xml:9.4.52.v20230823") {
 			because "older versions introduce a vulnerability"
 		}
 	}


### PR DESCRIPTION
Reverts govuk-one-login/ipv-stubs#1993 as caused `create-a-public-jwk` stack to break