### PR TITLE
SPT-1817: Added SSM Parameter caching using layer

### DIFF
--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -13,6 +13,8 @@ Globals:
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
+    Layers:
+      - !Sub "arn:aws:lambda:${AWS::Region}:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension-Arm64:59"
 
 Description: >-
   This creates the infrastructure for EVCS stub .

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -51,6 +51,7 @@ Globals:
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     Layers:
+      - !Sub "arn:aws:lambda:${AWS::Region}:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension-Arm64:59"
       - !If
         - IsDevelopment
         - !Ref AWS::NoValue

--- a/di-ipv-evcs-stub/lambdas/src/common/ssmParameter.ts
+++ b/di-ipv-evcs-stub/lambdas/src/common/ssmParameter.ts
@@ -1,9 +1,19 @@
-import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
+import { GetParameterCommandOutput } from "@aws-sdk/client-ssm";
 
 export const getSsmParameter = async (name: string): Promise<string> => {
-  const parameter = await getParameter(name);
-  if (parameter === undefined) {
+  const encodedParamName = encodeURIComponent(name);
+  const url = `http://localhost:2773/systemsmanager/parameters/get?name=${encodedParamName}`;
+
+  const response = await fetch(url, {
+    headers: {
+      "X-Aws-Parameters-Secrets-Token": process.env.AWS_SESSION_TOKEN || "",
+    },
+  });
+
+  const data = (await response.json()) as GetParameterCommandOutput;
+  if (!data.Parameter?.Value) {
     throw new Error(`Could not retrieve ssm parameter: ${name}`);
   }
-  return parameter;
+
+  return data.Parameter.Value;
 };

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -21,14 +21,16 @@ import {
   processGetIdentityRequest,
 } from "../src/services/evcsService";
 import { VcState, VCProvenance } from "../src/domain/enums";
-import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/api-gateway-proxy";
 import {
   InvalidateIdentityRequest,
   PostIdentityRequest,
 } from "../src/domain/requests";
 import { Vot } from "../src/domain/enums/vot";
+import { getSsmParameter } from "../src/common/ssmParameter";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/common/ssmParameter");
 
 vi.mock("../src/services/evcsService", () => ({
   processGetUserVCsRequest: vi.fn(),
@@ -37,10 +39,6 @@ vi.mock("../src/services/evcsService", () => ({
   processGetIdentityRequest: vi.fn(),
   processPostIdentityRequest: vi.fn(),
   invalidateUserSi: vi.fn(),
-}));
-
-vi.mock("@aws-lambda-powertools/parameters/ssm", () => ({
-  getParameter: vi.fn(),
 }));
 
 const EVCS_VERIFY_KEY =
@@ -488,7 +486,8 @@ describe("evcs handlers", () => {
         statusCode: 200,
         response: testResult,
       });
-      vi.mocked(getParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
+
+      vi.mocked(getSsmParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
 
       // act
       const response = (await getHandler({
@@ -514,7 +513,8 @@ describe("evcs handlers", () => {
         statusCode: 200,
         response: testResult,
       });
-      vi.mocked(getParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
+
+      vi.mocked(getSsmParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
 
       // act
       const response = (await getHandler({
@@ -540,7 +540,8 @@ describe("evcs handlers", () => {
         statusCode: 200,
         response: testResult,
       });
-      vi.mocked(getParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
+
+      vi.mocked(getSsmParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
 
       // act
       const response = (await getHandler({
@@ -571,7 +572,6 @@ describe("evcs handlers", () => {
         statusCode: 200,
         response: testResult,
       });
-      vi.mocked(getParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
 
       const event = {
         pathParameters: TEST_PATH_PARAM,


### PR DESCRIPTION
## Proposed changes

### What changed

We have added the AWS-Parameters-and-Secrets-Lambda-Extension which in loaded into the Lambda runtime and should be shared across invocations of the Lambda. The Lambdas are able to call the Lambda Extension to obtain and cache the SSM parameter and therefore reduces the number of calls to SSM.

### Why did it change

The di-ipv-evcs-stub was failing performance tests as the number of calls to the stub was causing AWS to spin up a lot of lambdas. However, SSM has a quota of 40 SSM requests per second which was being exceeded by the number of lambdas being spun up.

### Issue tracking

- [SPT-1817](https://govukverify.atlassian.net/browse/SPT-1817)

## Checklists

- [x] Tests have been written/updated


[SPT-1817]: https://govukverify.atlassian.net/browse/SPT-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ