### PR TITLE
PYIC-8973: correct jose imports for version upgrade

### DIFF
--- a/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/domain/signedJwt.ts
@@ -1,6 +1,4 @@
-import { importPKCS8, SignJWT } from "jose";
-import { JWTPayload } from "jose/dist/types/types";
-
+import { importPKCS8, SignJWT, JWTPayload } from "jose";
 export async function vcToSignedJwt(vc: JWTPayload, signingKey: string) {
   const formattedSigningKey = await importPKCS8(
     `-----BEGIN PRIVATE KEY-----\n${signingKey}\n-----END PRIVATE KEY-----`, // pragma: allowlist secret - the key is coming from config

--- a/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
+++ b/di-ipv-dcmaw-async-stub/lambdas/src/handlers/managementEnqueueVcHandler.ts
@@ -12,7 +12,7 @@ import {
 } from "../domain/managementEnqueueRequest";
 import { getUserStateItem } from "../services/userStateService";
 import getConfig from "../common/config";
-import { JWTPayload } from "jose/dist/types/types";
+import { JWTPayload } from "jose";
 import { vcToSignedJwt } from "../domain/signedJwt";
 
 export async function handler(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update JWTPayload imports to use the public jose entry point instead of internal dist paths to resolve TS2307 errors after the version upgrade

### Why did it change

correct jose imports for version upgrade

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8973](https://govukverify.atlassian.net/browse/PYIC-8973)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[PYIC-8973]: https://govukverify.atlassian.net/browse/PYIC-8973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ