### PR TITLE
SPT-1817: Refactored to use env instead of ssm

### DIFF
--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -13,8 +13,6 @@ Globals:
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
-    Layers:
-      - !Sub "arn:aws:lambda:${AWS::Region}:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension-Arm64:59"
 
 Description: >-
   This creates the infrastructure for EVCS stub .
@@ -52,7 +50,7 @@ Mappings:
 
 Conditions:
   IsDev01:
-    Fn::Equals: [ !Ref "AWS::AccountId", "130355686670"]
+    Fn::Equals: [!Ref "AWS::AccountId", "130355686670"]
 
   IsReuse:
     Fn::Or:
@@ -60,13 +58,13 @@ Conditions:
       - Condition: IsReuseBuild
 
   IsReuseDev:
-    Fn::Equals: [ !Ref "AWS::AccountId", "110869144943"]
+    Fn::Equals: [!Ref "AWS::AccountId", "110869144943"]
 
   IsReuseBuild:
-    Fn::Equals: [ !Ref "AWS::AccountId", "054367266435"]
+    Fn::Equals: [!Ref "AWS::AccountId", "054367266435"]
 
   IsReuseMain:
-    Fn::Equals: [ !Ref "AWS::StackName", "evcs-stub"]
+    Fn::Equals: [!Ref "AWS::StackName", "evcs-stub"]
 
   UsePermissionsBoundary:
     Fn::Not:
@@ -110,6 +108,8 @@ Resources:
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -118,7 +118,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -178,6 +178,8 @@ Resources:
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -186,7 +188,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -247,6 +249,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -255,7 +259,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -317,6 +321,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -388,6 +394,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -396,7 +404,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -458,6 +466,8 @@ Resources:
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -466,7 +476,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -533,6 +543,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -541,7 +553,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -604,6 +616,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -612,7 +626,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -839,18 +853,18 @@ Resources:
           - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
       DomainValidationOptions:
         - DomainName: !If
-          - IsReuse
-          - !If
-            - IsReuseDev
+            - IsReuse
             - !If
-              - IsReuseMain
-              - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
-              - !Sub "evcs-${AWS::StackName}.reuse.dev.stubs.account.gov.uk"
-            - !Sub "evcs.reuse.stubs.account.gov.uk"
-          - !If
-            - IsDev01
-            - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
-            - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
+              - IsReuseDev
+              - !If
+                - IsReuseMain
+                - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+                - !Sub "evcs-${AWS::StackName}.reuse.dev.stubs.account.gov.uk"
+              - !Sub "evcs.reuse.stubs.account.gov.uk"
+            - !If
+              - IsDev01
+              - !Sub "evcs-${Environment}.01.core.dev.stubs.account.gov.uk"
+              - !Sub "evcs-${Environment}.02.core.dev.stubs.account.gov.uk"
           HostedZoneId:
             Fn::ImportValue:
               Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]
@@ -939,7 +953,7 @@ Resources:
         paths: # workaround to get `sam validate` to work
           /foo:
             options: {} # workaround to get `sam validate` to work
-        'Fn::Transform':
+        "Fn::Transform":
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/evcs-external.yaml"

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -14,32 +14,52 @@ Globals:
           - IsDevelopment
           - !Ref "AWS::NoValue"
           - !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'  #pragma: allowlist secret
-            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+            - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}" #pragma: allowlist secret
+            - SecretArn: !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dynatraceSecretArn,
+                ] #pragma: allowlist secret
         DT_CONNECTION_BASE_URL: !If
           - IsDevelopment
           - !Ref "AWS::NoValue"
           - !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'   #pragma: allowlist secret
-            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+            - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}" #pragma: allowlist secret
+            - SecretArn: !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dynatraceSecretArn,
+                ] #pragma: allowlist secret
         DT_CLUSTER_ID: !If
           - IsDevelopment
           - !Ref "AWS::NoValue"
           - !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'   #pragma: allowlist secret
-            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+            - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}" #pragma: allowlist secret
+            - SecretArn: !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dynatraceSecretArn,
+                ] #pragma: allowlist secret
         DT_LOG_COLLECTION_AUTH_TOKEN: !If
           - IsDevelopment
           - !Ref "AWS::NoValue"
           - !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'  #pragma: allowlist secret
-            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]  #pragma: allowlist secret
+            - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}" #pragma: allowlist secret
+            - SecretArn: !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dynatraceSecretArn,
+                ] #pragma: allowlist secret
         DT_TENANT: !If
           - IsDevelopment
           - !Ref "AWS::NoValue"
           - !Sub
-            - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'   #pragma: allowlist secret
-            - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]   #pragma: allowlist secret
+            - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}" #pragma: allowlist secret
+            - SecretArn: !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  dynatraceSecretArn,
+                ] #pragma: allowlist secret
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
     Timeout: 30
     PermissionsBoundary: !If
@@ -51,15 +71,14 @@ Globals:
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     Layers:
-      - !Sub "arn:aws:lambda:${AWS::Region}:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension-Arm64:59"
       - !If
         - IsDevelopment
         - !Ref AWS::NoValue
         - !FindInMap [
-          EnvironmentConfiguration,
-          !Ref Environment,
-          dynatraceLayerArn,
-        ]
+            EnvironmentConfiguration,
+            !Ref Environment,
+            dynatraceLayerArn,
+          ]
 
 Description: >-
   This creates the infrastructure for EVCS stub .
@@ -86,24 +105,24 @@ Parameters:
 
 Conditions:
   IsDevelopment: !Or
-    - !Equals [ !Ref AWS::AccountId, "130355686670"]
-    - !Equals [ !Ref AWS::AccountId, "175872367215"]
-    - !Equals [ !Ref AWS::AccountId, "110869144943"]
-  IsProduction: !Equals [ !Ref Environment, "production" ]
-  IsNonProd: !Not [!Condition IsProduction ]
+    - !Equals [!Ref AWS::AccountId, "130355686670"]
+    - !Equals [!Ref AWS::AccountId, "175872367215"]
+    - !Equals [!Ref AWS::AccountId, "110869144943"]
+  IsProduction: !Equals [!Ref Environment, "production"]
+  IsNonProd: !Not [!Condition IsProduction]
   IsReuse:
     Fn::Or:
       - Condition: IsReuseDev
       - Condition: IsReuseBuild
 
   IsReuseDev:
-    Fn::Equals: [ !Ref "AWS::AccountId", "110869144943" ]
+    Fn::Equals: [!Ref "AWS::AccountId", "110869144943"]
 
   IsReuseBuild:
-    Fn::Equals: [ !Ref "AWS::AccountId", "054367266435" ]
+    Fn::Equals: [!Ref "AWS::AccountId", "054367266435"]
 
   IsReuseMain:
-    Fn::Equals: [ !Ref "AWS::StackName", "evcs-stub" ]
+    Fn::Equals: [!Ref "AWS::StackName", "evcs-stub"]
 
   UsePermissionsBoundary:
     Fn::Not:
@@ -119,13 +138,13 @@ Conditions:
 Mappings:
   EnvironmentConfiguration:
     dev:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables  #pragma: allowlist secret
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
     build:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables  #pragma: allowlist secret
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
     production:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables  #pragma: allowlist secret
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
 
   HostedZoneImportName:
@@ -169,6 +188,8 @@ Resources:
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -177,7 +198,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -237,6 +258,8 @@ Resources:
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -245,7 +268,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -306,6 +329,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -314,7 +339,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -376,6 +401,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -447,6 +474,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -455,7 +484,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -517,6 +546,8 @@ Resources:
           EVCS_PARAM_BASE_PATH: "/stubs/core/evcs/"
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -525,7 +556,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -592,6 +623,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -600,7 +633,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -663,6 +696,8 @@ Resources:
           ISSUER: "https://evcs-cri.stubs.account.gov.uk"
           EVCS_STUB_USER_VCS_STORE_TABLE_NAME: !Ref EvcsStubUserVcsStoreTable
           EVCS_STUB_STORED_IDENTITY_OBJECT_TABLE_NAME: !Ref EvcsStoredIdentityStoreTable
+          EVCS_STUB_TTL: !Sub "{{resolve:ssm:/stubs/core/evcs/evcsStubTtl}}"
+          EVCS_STUB_VERIFY_KEY: !Sub "{{resolve:ssm:/stubs/core/evcs/verifyKey}}"
           NODE_OPTIONS: --enable-source-maps
       VpcConfig:
         SubnetIds:
@@ -671,7 +706,7 @@ Resources:
         SecurityGroupIds:
           - !GetAtt EvcsLambdaSecurityGroup.GroupId
       Policies:
-        - VPCAccessPolicy: { }
+        - VPCAccessPolicy: {}
         - SSMParameterReadPolicy:
             ParameterName: stubs/core/evcs/*
         - KMSDecryptPolicy:
@@ -898,21 +933,21 @@ Resources:
           - evcs.stubs.account.gov.uk
       DomainValidationOptions:
         - DomainName: !If
-          - IsReuse
-          - !If
-            - IsReuseDev
+            - IsReuse
             - !If
-              - IsReuseMain
-              - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
-              - !Sub "evcs-${AWS::StackName}.reuse.dev.stubs.account.gov.uk"
-            - !Sub "evcs.reuse.stubs.account.gov.uk"
-          - !If
-            - IsNonProd
-            - !Sub "evcs.${Environment}.stubs.account.gov.uk"
-            - evcs.stubs.account.gov.uk
+              - IsReuseDev
+              - !If
+                - IsReuseMain
+                - !Sub "evcs.reuse.${Environment}.stubs.account.gov.uk"
+                - !Sub "evcs-${AWS::StackName}.reuse.dev.stubs.account.gov.uk"
+              - !Sub "evcs.reuse.stubs.account.gov.uk"
+            - !If
+              - IsNonProd
+              - !Sub "evcs.${Environment}.stubs.account.gov.uk"
+              - evcs.stubs.account.gov.uk
           HostedZoneId:
             Fn::ImportValue:
-              Fn::FindInMap: [ HostedZoneImportName, !Ref "AWS::AccountId", Name ]
+              Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]
       ValidationMethod: DNS
 
   # api domain entries / mapping
@@ -981,7 +1016,7 @@ Resources:
           - evcs.stubs.account.gov.uk
       HostedZoneId:
         Fn::ImportValue:
-          Fn::FindInMap: [ HostedZoneImportName, !Ref "AWS::AccountId", Name ]
+          Fn::FindInMap: [HostedZoneImportName, !Ref "AWS::AccountId", Name]
       AliasTarget:
         DNSName: !GetAtt EvcsStubRestApiDomain.RegionalDomainName
         HostedZoneId: !GetAtt EvcsStubRestApiDomain.RegionalHostedZoneId
@@ -998,7 +1033,7 @@ Resources:
         paths: # workaround to get `sam validate` to work
           /foo:
             options: {} # workaround to get `sam validate` to work
-        'Fn::Transform':
+        "Fn::Transform":
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/evcs-external.yaml"

--- a/di-ipv-evcs-stub/lambdas/package-lock.json
+++ b/di-ipv-evcs-stub/lambdas/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.31.0",
         "@aws-sdk/client-dynamodb": "^3.1004.0",
-        "@aws-sdk/client-ssm": "^3.1004.0",
         "@aws-sdk/lib-dynamodb": "^3.1004.0",
         "@aws-sdk/util-dynamodb": "^3.996.2",
         "esbuild": "0.27.3",
@@ -25,7 +24,6 @@
         "@types/uuid": "^9.0.8",
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/spy": "^4.0.18",
-        "aws-sdk-client-mock": "^4.1.0",
         "aws-sdk-client-mock-vitest": "^7.0.1",
         "eslint": "^10.0.3",
         "eslint-config-prettier": "^9.1.2",
@@ -247,6 +245,8 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1004.0.tgz",
       "integrity": "sha512-M0vxsZ8X2LFPNWgCS7XekM/8SUPOEnSWaMDXLoXmO/BxW8M3wV84ijXQx0x+8EcR+945ZOOWFD+9rpmGd3RX3A==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -298,6 +298,8 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
       "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
         "@smithy/types": "^4.13.0",
@@ -314,6 +316,8 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
       "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -326,6 +330,8 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
       "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
@@ -339,6 +345,8 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
       "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
@@ -1937,6 +1945,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1946,6 +1955,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
       "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "lodash.get": "^4.4.2",
@@ -1957,6 +1967,7 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -1965,7 +1976,8 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.11",
@@ -2812,6 +2824,7 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
       "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -2820,7 +2833,8 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -3343,6 +3357,7 @@
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -3448,6 +3463,7 @@
       "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4039,7 +4055,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4068,7 +4085,8 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -4199,6 +4217,7 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
       "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.1",
@@ -4212,6 +4231,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
       "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -4287,6 +4307,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -4456,6 +4477,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
       "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "11.2.2",
@@ -4474,6 +4496,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
       "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -4631,6 +4654,7 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5266,6 +5290,8 @@
       "version": "3.1004.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1004.0.tgz",
       "integrity": "sha512-M0vxsZ8X2LFPNWgCS7XekM/8SUPOEnSWaMDXLoXmO/BxW8M3wV84ijXQx0x+8EcR+945ZOOWFD+9rpmGd3RX3A==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -5313,6 +5339,8 @@
           "version": "3.996.4",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
           "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "@aws-sdk/types": "^3.973.5",
             "@smithy/types": "^4.13.0",
@@ -5325,6 +5353,8 @@
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
           "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -5333,6 +5363,8 @@
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
           "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
@@ -5342,6 +5374,8 @@
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
           "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
@@ -6296,6 +6330,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -6305,6 +6340,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
       "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.1",
         "lodash.get": "^4.4.2",
@@ -6315,7 +6351,8 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
           "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -6323,7 +6360,8 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@smithy/abort-controller": {
       "version": "4.2.11",
@@ -6955,6 +6993,7 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
       "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -6963,7 +7002,8 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/uuid": {
       "version": "9.0.8",
@@ -7292,6 +7332,7 @@
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -7363,7 +7404,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
       "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "es-module-lexer": {
       "version": "1.7.0",
@@ -7761,7 +7803,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "keyv": {
       "version": "4.5.4",
@@ -7786,7 +7829,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "magic-string": {
       "version": "0.30.21",
@@ -7883,6 +7927,7 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
       "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.1",
@@ -7896,6 +7941,7 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
           "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@sinonjs/commons": "^3.0.1"
           }
@@ -7952,7 +7998,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "pathe": {
       "version": "2.0.3",
@@ -8066,6 +8113,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
       "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "11.2.2",
@@ -8080,6 +8128,7 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
           "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@sinonjs/commons": "^3.0.0"
           }
@@ -8188,7 +8237,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "typescript": {
       "version": "5.9.3",

--- a/di-ipv-evcs-stub/lambdas/package.json
+++ b/di-ipv-evcs-stub/lambdas/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@aws-lambda-powertools/parameters": "^2.31.0",
     "@aws-sdk/client-dynamodb": "^3.1004.0",
-    "@aws-sdk/client-ssm": "^3.1004.0",
     "@aws-sdk/lib-dynamodb": "^3.1004.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "esbuild": "0.27.3",
@@ -23,7 +22,6 @@
     "@types/uuid": "^9.0.8",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/spy": "^4.0.18",
-    "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-vitest": "^7.0.1",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^9.1.2",

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -14,7 +14,6 @@ import { StatusCodes, VCProvenance, VcState } from "../domain/enums";
 import EvcsVcItem from "../model/evcsVcItem";
 
 import { config } from "../common/config";
-import { getSsmParameter } from "../common/ssmParameter";
 import { v4 as uuid } from "uuid";
 import {
   EvcsItemForUpdate,
@@ -428,7 +427,7 @@ async function updateUserVC(evcsVcItem: EvcsItemForUpdate) {
 
 async function getTtl(): Promise<number> {
   const evcsTtlSeconds: number = parseInt(
-    await getSsmParameter(config.evcsParamBasePath + "evcsStubTtl"),
+    process.env.EVCS_STUB_TTL ?? "604800",
   );
   return Math.floor(Date.now() / 1000) + evcsTtlSeconds;
 }

--- a/di-ipv-evcs-stub/lambdas/src/services/jwtService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/jwtService.ts
@@ -1,14 +1,10 @@
 import { JWTPayload, importSPKI, jwtVerify } from "jose";
-import { config } from "../common/config";
-import { getSsmParameter } from "../common/ssmParameter";
 import { getErrorMessage } from "../common/utils";
 
 export const verifyTokenAndReturnPayload = async (
   jwt: string,
 ): Promise<JWTPayload> => {
-  const EVCS_VERIFY_KEY = await getSsmParameter(
-    config.evcsParamBasePath + "verifyKey",
-  );
+  const EVCS_VERIFY_KEY = process.env.EVCS_STUB_VERIFY_KEY;
 
   let payload;
   try {

--- a/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/evcsHandler.test.ts
@@ -27,7 +27,6 @@ import {
   PostIdentityRequest,
 } from "../src/domain/requests";
 import { Vot } from "../src/domain/enums/vot";
-import { getSsmParameter } from "../src/common/ssmParameter";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../src/common/ssmParameter");
@@ -487,7 +486,7 @@ describe("evcs handlers", () => {
         response: testResult,
       });
 
-      vi.mocked(getSsmParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
+      vi.stubEnv("EVCS_STUB_VERIFY_KEY", EVCS_VERIFY_KEY);
 
       // act
       const response = (await getHandler({
@@ -514,7 +513,7 @@ describe("evcs handlers", () => {
         response: testResult,
       });
 
-      vi.mocked(getSsmParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
+      vi.stubEnv("EVCS_STUB_VERIFY_KEY", EVCS_VERIFY_KEY);
 
       // act
       const response = (await getHandler({
@@ -541,7 +540,7 @@ describe("evcs handlers", () => {
         response: testResult,
       });
 
-      vi.mocked(getSsmParameter).mockResolvedValueOnce(EVCS_VERIFY_KEY);
+      vi.stubEnv("EVCS_STUB_VERIFY_KEY", EVCS_VERIFY_KEY);
 
       // act
       const response = (await getHandler({

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -9,7 +9,6 @@ import {
   TransactWriteItemsCommand,
 } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
-import { getSsmParameter } from "../../src/common/ssmParameter";
 import {
   invalidateUserSi,
   processGetIdentityRequest,
@@ -24,14 +23,6 @@ import { StoredIdentityRecordType } from "../../src/domain/enums/StoredIdentityR
 import EvcsStoredIdentityItem from "../../src/model/storedIdentityItem";
 
 vi.useFakeTimers().setSystemTime(new Date("2025-01-01"));
-
-vi.mock("../../src/common/ssmParameter", async () => {
-  const module = vi.importActual("../../src/common/ssmParameter") as object;
-  return {
-    ...module,
-    getSsmParameter: vi.fn(),
-  };
-});
 
 const dbMock = mockClient(DynamoDB);
 
@@ -72,7 +63,7 @@ const MOCK_TTL = "3600";
 describe("processPostIdentityRequest", () => {
   beforeEach(() => {
     dbMock.reset();
-    vi.mocked(getSsmParameter).mockResolvedValue(MOCK_TTL);
+    vi.stubEnv("EVCS_STUB_TTL", MOCK_TTL);
   });
 
   it("should return 200 response when provided just an SI object", async () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Refactored to use environment variables instead of calling SSM. Instead SSM will be read from the CloudFormation templates.

Note that prettier rules changed formatting.

### Why did it change

IPV Stubs account is unable to use the AWS Lambda layer for SSM.

### Issue tracking

- [SPT-1817](https://govukverify.atlassian.net/browse/SPT-1817)

## Checklists

- [ ] Tests have been written/updated


[SPT-1817]: https://govukverify.atlassian.net/browse/SPT-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ