### PR TITLE
PYIC-8458: Update /identity POST endpoint to accept vcs.

### DIFF
--- a/di-ipv-evcs-stub/README.md
+++ b/di-ipv-evcs-stub/README.md
@@ -92,7 +92,7 @@ Example request
             "provenance": "ONLINE"
         }
     ]
-}    
+}
 ```
 Responses
 ```
@@ -265,11 +265,25 @@ https://evcs.build.stubs.account.gov.uk/vc-update
 Example request body
 ```
 {
- "userId": "userId",
- "si": {
+  "userId": "userId",
+  "govuk_signin_journey_id": "testJourneyId",
+  "si": {
     "jwt": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46dXVpZDo5NjI4OTgxNS0wZTUyLTQ4MDAtOTZkZi0xZmY3ZGU5ODFjZDQiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3NDYwODkxNTEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYnVpbGQuYWNjb3VudC5nb3YudWsiLCJhdWQiOiJodHRwczovL29yY2guc3R1YnMuYWNjb3VudC5nb3YudWsiLCJuYmYiOiIxNzc3NjI1MTUxIiwidm90IjoiUDIiLCJjcmVkZW50aWFscyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5pSjkuZXlKemRXSWlPaUoxY200NmRYVnBaRG81TmpJNE9UZ3hOUzB3WlRVeUxUUTRNREF0T1Raa1ppMHhabVkzWkdVNU9ERmpaRFFpTENKaGRXUWlPaUpvZEhSd2N6b3ZMMmxrWlc1MGFYUjVMbUoxYVd4a0xtRmpZMjkxYm5RdVoyOTJMblZySWl3aWJtSm1Jam94TnpRMk1Ea3lOVGszTENKcGMzTWlPaUpvZEhSd2N6b3ZMMkZrWkhKbGMzTXRZM0pwTG5OMGRXSnpMbUZqWTI5MWJuUXVaMjkyTG5Wcklpd2lkbU1pT25zaWRIbHdaU0k2V3lKV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSXNJa0ZrWkhKbGMzTkRjbVZrWlc1MGFXRnNJbDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltRmtaSEpsYzNNaU9sdDdJbUZrWkhKbGMzTkRiM1Z1ZEhKNUlqb2lSMElpTENKaWRXbHNaR2x1WjA1aGJXVWlPaUlpTENKemRISmxaWFJPWVcxbElqb2lTRUZFVEVWWklGSlBRVVFpTENKd2IzTjBZV3hEYjJSbElqb2lRa0V5SURWQlFTSXNJbUoxYVd4a2FXNW5UblZ0WW1WeUlqb2lPQ0lzSW1Ga1pISmxjM05NYjJOaGJHbDBlU0k2SWtKQlZFZ2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1EQXdMVEF4TFRBeEluMWRmWDBzSW1wMGFTSTZJblZ5YmpwMWRXbGtPbU13TlRWbFlXVmpMVEF5WmpVdE5EUTFOQzA1TnpreUxUWXlZemxqTldRM1l6QXdOeUo5LnhkSHlaVUV3d2k2VENpTTM4VXlOZEgtYkhkQjE0QnhtNm0xVWNuWE5SR1Z4cXFHR0R1cWgwODdsTDNtT0ZNd1BFVWxkTEU2TmVKOUI4dFZkSHJrUnlBIl0sImNsYWltcyI6W3siZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJpY2FvSXNzdWVyQ29kZSI6IkdCUiIsImRvY3VtZW50TnVtYmVyIjoiMzIxNjU0OTg3In0seyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NS0wNy0wOCJ9XX1dfQ.DjY3mL3f1U1ehHILXz0ifAosUBCLH3HdAnqYX9YH4t7JdQjSECU885RJKUKZqE33vMvG0n-Ip1tULP7hkQ0R_A", # pragma: allowlist secret
     "vot": "P2"
- }
+  },
+  "vcs": [
+    {
+      "vc": "zzJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.zf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", # pragma: allowlist secret
+      "state": "CURRENT",
+      "provenance": "ONLINE",
+      "metadata": {
+        "reason": "test-created",
+        "timestampMs": "1714478033959",
+        "txmaEventId": "txma-event-id",
+        "testProperty": "testProperty"
+      }
+    }
+  ]
 }
 ```
 Responses
@@ -289,6 +303,8 @@ Responses
           $ref: '#/components/responses/BadRequest'
         403:
           $ref: '#/components/responses/Forbidden'
+        409:
+          $ref: '#/components/responses/Conflict'
         500:
           $ref: '#/components/responses/ServerError'
 ```

--- a/di-ipv-evcs-stub/lambdas/src/common/utils.ts
+++ b/di-ipv-evcs-stub/lambdas/src/common/utils.ts
@@ -1,4 +1,39 @@
+import { decodeJwt } from "jose";
+
 export function getErrorMessage(error: unknown) {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+export function isValidJWT(token: string): boolean {
+  if (!token) {
+    return false;
+  }
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return false;
+  }
+  const [header, payload, signature] = parts;
+  if (!header || !payload || !signature) {
+    return false;
+  }
+  const isBase64Url = (str: string) => /^[A-Za-z0-9_-]+$/.test(str);
+  if (
+    !isBase64Url(header) ||
+    !isBase64Url(payload) ||
+    !isBase64Url(signature)
+  ) {
+    return false;
+  }
+
+  try {
+    decodeJwt(token);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export function getSignatureFromJwt(jwt: string): string {
+  return jwt.split(".")[2];
 }

--- a/di-ipv-evcs-stub/lambdas/src/common/utils.ts
+++ b/di-ipv-evcs-stub/lambdas/src/common/utils.ts
@@ -1,4 +1,5 @@
 import { decodeJwt } from "jose";
+import { decode } from "jose/base64url";
 
 export function getErrorMessage(error: unknown) {
   if (error instanceof Error) return error.message;
@@ -9,29 +10,25 @@ export function isValidJWT(token: string): boolean {
   if (!token) {
     return false;
   }
-  const parts = token.split(".");
-  if (parts.length !== 3) {
-    return false;
-  }
-  const [header, payload, signature] = parts;
-  if (!header || !payload || !signature) {
-    return false;
-  }
-  const isBase64Url = (str: string) => /^[A-Za-z0-9_-]+$/.test(str);
-  if (
-    !isBase64Url(header) ||
-    !isBase64Url(payload) ||
-    !isBase64Url(signature)
-  ) {
-    return false;
-  }
-
   try {
+    // decodeJwt validates only payload shape and 3 parts jwt format
     decodeJwt(token);
   } catch {
     return false;
   }
-  return true;
+  const parts = token.split(".");
+  const header = parts[0];
+  const signature = parts[2];
+  return !(!isBase64Url(header) || !isBase64Url(signature));
+}
+
+export function isBase64Url(str: string): boolean {
+  try {
+    decode(str);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getSignatureFromJwt(jwt: string): string {

--- a/di-ipv-evcs-stub/lambdas/src/domain/requests/identityEndpointRequests.ts
+++ b/di-ipv-evcs-stub/lambdas/src/domain/requests/identityEndpointRequests.ts
@@ -8,15 +8,12 @@ export interface StoredIdentityDetails {
   expired?: boolean; // For use through the management API
 }
 
-export type PostIdentityRequest = Omit<PutRequest, "vcs" | "si"> & {
+export type PostIdentityRequest = {
+  userId: string;
+  govuk_signin_journey_id?: string;
+  vcs?: VcDetails[];
   si: StoredIdentityDetails;
 };
-
-export interface PutRequest {
-  userId: string;
-  vcs: VcDetails[];
-  si?: StoredIdentityDetails;
-}
 
 export interface InvalidateIdentityRequest {
   userId: string;

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
@@ -221,6 +221,10 @@ function parsePostIdentityRequest(
     throw new Error("Invalid stored identity object: missing jwt");
   }
 
+  if (!isValidJWT(parsedPostIdentityRequest.si.jwt)) {
+    throw new Error("Invalid stored identity object jwt");
+  }
+
   if (!parsedPostIdentityRequest.si.vot) {
     throw new Error("Invalid stored identity object: missing vot");
   }
@@ -231,11 +235,7 @@ function parsePostIdentityRequest(
     (!parsedPostIdentityRequest.govuk_signin_journey_id &&
       parsedPostIdentityRequest.vcs)
   ) {
-    throw new Error("Both: govuk_signin_journey_id and vcs must be present.");
-  }
-
-  if (!isValidJWT(parsedPostIdentityRequest.si.jwt)) {
-    throw new Error("Invalid stored identity object jwt");
+    throw new Error("Either both govuk_signin_journey_id and vcs must be present or none of those.");
   }
 
   if (parsedPostIdentityRequest.vcs) {

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
@@ -22,7 +22,12 @@ import {
   processGetIdentityRequest,
 } from "../services/evcsService";
 import { verifyTokenAndReturnPayload } from "../services/jwtService";
-import { getErrorMessage } from "../common/utils";
+import {
+  getErrorMessage,
+  getSignatureFromJwt,
+  isValidJWT,
+} from "../common/utils";
+import { VcDetails } from "../domain/vcDetails";
 
 export async function postIdentityHandler(
   event: APIGatewayProxyEvent,
@@ -220,7 +225,49 @@ function parsePostIdentityRequest(
     throw new Error("Invalid stored identity object: missing vot");
   }
 
+  if (
+    (parsedPostIdentityRequest.govuk_signin_journey_id &&
+      !parsedPostIdentityRequest.vcs) ||
+    (!parsedPostIdentityRequest.govuk_signin_journey_id &&
+      parsedPostIdentityRequest.vcs)
+  ) {
+    throw new Error("Both: govuk_signin_journey_id and vcs must be present.");
+  }
+
+  if (!isValidJWT(parsedPostIdentityRequest.si.jwt)) {
+    throw new Error("Invalid stored identity object jwt");
+  }
+
+  if (parsedPostIdentityRequest.vcs) {
+    validateVcs(parsedPostIdentityRequest.vcs);
+  }
+
   return parsedPostIdentityRequest;
+}
+
+function validateVcs(vcs: VcDetails[]): void {
+  // Validate vc length is at least 1
+  if (vcs.length < 1) {
+    throw new Error("Minimum vcs array length is 1");
+  }
+
+  // Validate state and jwt
+  const isValidVcs = vcs.every(
+    (item) => item.state && item.vc && isValidJWT(item.vc),
+  );
+
+  if (!isValidVcs) {
+    throw new Error("Invalid JWT in vcs list.");
+  }
+
+  // Validate each vc is unique
+  const uniqueSignatures = new Set(
+    vcs.map((item) => getSignatureFromJwt(item.vc)),
+  );
+
+  if (uniqueSignatures.size !== vcs.length) {
+    throw new Error("Signatures are duplicated in vcs list.");
+  }
 }
 
 function parseInvalidateIdentityRequest(

--- a/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
+++ b/di-ipv-evcs-stub/lambdas/src/handlers/evcsHandler.ts
@@ -235,7 +235,9 @@ function parsePostIdentityRequest(
     (!parsedPostIdentityRequest.govuk_signin_journey_id &&
       parsedPostIdentityRequest.vcs)
   ) {
-    throw new Error("Either both govuk_signin_journey_id and vcs must be present or none of those.");
+    throw new Error(
+      "Either both govuk_signin_journey_id and vcs must be present or none of those.",
+    );
   }
 
   if (parsedPostIdentityRequest.vcs) {

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -31,7 +31,6 @@ import {
   PatchRequest,
   PostIdentityRequest,
   PostRequest,
-  PutRequest,
 } from "../domain/requests";
 import { VcDetails } from "../domain/vcDetails";
 import { StoredIdentityResponse } from "../domain/sharedTypes";
@@ -40,6 +39,7 @@ import { StoredIdentityRecordType } from "../domain/enums/StoredIdentityRecordTy
 import { dynamoClient } from "../clients/dynamodbClient";
 import { PostVcsRequest } from "../domain/requests/postVcsRequest";
 import { PatchVcsRequest } from "../domain/requests/patchVcsRequest";
+import { getErrorMessage } from "../common/utils";
 
 export async function processPostUserVCsRequest(
   userId: string,
@@ -200,7 +200,7 @@ export async function processPatchUserVCsRequestV2(
 }
 
 export async function processPostIdentityRequest(
-  request: PutRequest | PostIdentityRequest,
+  request: PostIdentityRequest,
 ): Promise<ServiceResponse> {
   console.info("Put user record");
   const userId = request.userId;
@@ -208,15 +208,10 @@ export async function processPostIdentityRequest(
   try {
     const transactItems: TransactWriteItem[] = [];
 
-    if ("vcs" in request) {
-      const newUserVcs = request.vcs;
-      const ttl = await getTtl();
-
+    if (request.vcs) {
       // Read user's existing VCs
-      const getResponse = await processGetUserVCsRequest(userId, [
-        VcState.CURRENT,
-        VcState.PENDING_RETURN,
-      ]);
+      const allVcStates: VcState[] = Object.values(VcState);
+      const getResponse = await processGetUserVCsRequest(userId, allVcStates);
 
       if (
         getResponse.statusCode !== StatusCodes.Success ||
@@ -229,34 +224,44 @@ export async function processPostIdentityRequest(
         return createServiceResponse(StatusCodes.InternalServerError, "");
       }
 
-      // Update existing user VCs in EVCS with new states
-      const existingUserVcs = getResponse.response.vcs;
-      const newVcSignatures = newUserVcs.map(({ vc }) =>
+      const existingVcs = getResponse.response.vcs;
+      const existingVcsSignatures = existingVcs.map(({ vc }) =>
         getSignatureFromJwt(vc),
       );
+      const newVcs = request.vcs;
 
-      // We skip creating an update request for an existing VC that is in the
-      // put request as TransactWriteItems cannot perform multiple operations
-      // on the same item. The put method will replace the existing vc anyway
-      // so we get to save an operation
-      const updateExistingVcsRequests = existingUserVcs
-        .filter(({ vc }) => !newVcSignatures.includes(getSignatureFromJwt(vc)))
-        .map(({ vc, state: currentState, metadata }) => {
-          const vcSignature = getSignatureFromJwt(vc);
+      const vcsToUpdate = newVcs.filter(({ vc }) =>
+        existingVcsSignatures.includes(getSignatureFromJwt(vc)),
+      );
 
-          const mappedVcToUpdateItem = createUpdateItemInput({
-            vcSignature,
-            state: getUpdatedState(vcSignature, newVcSignatures, currentState),
-            metadata,
-            userId,
-            ttl,
-          }) as Update;
+      try {
+        validateVcsStateTransitions(existingVcs, vcsToUpdate);
+      } catch (error) {
+        return {
+          response: { messageId: getErrorMessage(error) },
+          statusCode: StatusCodes.Conflict,
+        };
+      }
 
-          return { Update: mappedVcToUpdateItem };
-        });
+      const ttl = await getTtl();
+      const updateExistingVcsRequests = vcsToUpdate.map((vc) => {
+        const vcSignature = getSignatureFromJwt(vc.vc);
+        const mappedVcToUpdateItem = createUpdateItemInput({
+          userId: userId,
+          vcSignature: vcSignature,
+          state: vc.state,
+          metadata: vc.metadata,
+          provenance: vc.provenance,
+          ttl: ttl,
+        }) as Update;
 
-      // Write new VCs with new state using PUT
-      const putNewUserVsRequests = newUserVcs.map(
+        return { Update: mappedVcToUpdateItem };
+      });
+
+      const vcsToAdd = newVcs.filter(
+        ({ vc }) => !existingVcsSignatures.includes(getSignatureFromJwt(vc)),
+      );
+      const putNewUserVsRequests = vcsToAdd.map(
         ({ vc, state, metadata, provenance }: VcDetails) => {
           const vcItemForStorage: EvcsVcItem = {
             userId,
@@ -275,18 +280,16 @@ export async function processPostIdentityRequest(
     }
 
     // Save stored identity object if present
-    if (request.si) {
-      const storedIdentityItem: EvcsStoredIdentityItem = {
-        userId: request.userId,
-        recordType: StoredIdentityRecordType.GPG45,
-        storedIdentity: request.si.jwt,
-        levelOfConfidence: request.si.vot,
-        metadata: request.si.metadata,
-        isValid: true,
-        expired: false,
-      };
-      transactItems.push({ Put: createPutItem(storedIdentityItem) });
-    }
+    const storedIdentityItem: EvcsStoredIdentityItem = {
+      userId: request.userId,
+      recordType: StoredIdentityRecordType.GPG45,
+      storedIdentity: request.si.jwt,
+      levelOfConfidence: request.si.vot,
+      metadata: request.si.metadata,
+      isValid: true,
+      expired: false,
+    };
+    transactItems.push({ Put: createPutItem(storedIdentityItem) });
 
     await dynamoClient.transactWriteItems({
       TransactItems: transactItems,
@@ -297,6 +300,41 @@ export async function processPostIdentityRequest(
     console.error("Failed to complete transaction.", error);
     return createServiceResponse(StatusCodes.InternalServerError, "");
   }
+}
+
+function validateVcsStateTransitions(
+  existingVcs: VcDetails[],
+  newVcs: VcDetails[],
+): void {
+  const newVcSignatures = newVcs.map(({ vc }) => getSignatureFromJwt(vc));
+
+  const existingMatchingVcs = existingVcs.filter(({ vc }) =>
+    newVcSignatures.includes(getSignatureFromJwt(vc)),
+  );
+
+  existingMatchingVcs.forEach((existingMatchingVc) => {
+    const currentState = existingMatchingVc.state;
+    const newState = newVcs.find(
+      (newVc) =>
+        getSignatureFromJwt(newVc.vc) ===
+        getSignatureFromJwt(existingMatchingVc.vc),
+    )?.state;
+    if (!newState) {
+      throw Error("Couldn't find matching jwt signatures");
+    }
+
+    const allowedTransitions = stateTransitions[newState];
+
+    if (allowedTransitions.length === 0) {
+      return;
+    }
+
+    if (!allowedTransitions.includes(currentState)) {
+      throw new Error(
+        `State VC transition from: ${currentState} to ${newState} is not allowed`,
+      );
+    }
+  });
 }
 
 export async function processGetIdentityRequest(
@@ -563,22 +601,4 @@ function isEvcsVcItem(
   evcsSaveItem: EvcsVcItem | EvcsStoredIdentityItem,
 ): evcsSaveItem is EvcsVcItem {
   return (evcsSaveItem as EvcsVcItem).vcSignature !== undefined;
-}
-
-function getUpdatedState(
-  currentVcSignature: string,
-  newVcSignatures: string[],
-  currentVcState: VcState,
-): VcState {
-  if (!newVcSignatures.includes(currentVcSignature)) {
-    switch (currentVcState) {
-      case VcState.CURRENT:
-        return VcState.HISTORIC;
-      case VcState.PENDING_RETURN:
-        return VcState.ABANDONED;
-      default:
-        return currentVcState;
-    }
-  }
-  return currentVcState;
 }

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -304,34 +304,27 @@ export async function processPostIdentityRequest(
 
 function validateVcsStateTransitions(
   existingVcs: VcDetails[],
-  newVcs: VcDetails[],
+  vcsToUpdate: VcDetails[],
 ): void {
-  const newVcSignatures = newVcs.map(({ vc }) => getSignatureFromJwt(vc));
-
-  const existingMatchingVcs = existingVcs.filter(({ vc }) =>
-    newVcSignatures.includes(getSignatureFromJwt(vc)),
+  const newVcsSignatureToState = new Map(
+    vcsToUpdate.map((vc) => [getSignatureFromJwt(vc.vc), vc.state]),
   );
 
-  existingMatchingVcs.forEach((existingMatchingVc) => {
-    const currentState = existingMatchingVc.state;
-    const newState = newVcs.find(
-      (newVc) =>
-        getSignatureFromJwt(newVc.vc) ===
-        getSignatureFromJwt(existingMatchingVc.vc),
-    )?.state;
+  existingVcs.forEach((existingVc) => {
+    const newState = newVcsSignatureToState.get(
+      getSignatureFromJwt(existingVc.vc),
+    );
     if (!newState) {
-      throw Error("Couldn't find matching jwt signatures");
-    }
-
-    const allowedTransitions = stateTransitions[newState];
-
-    if (allowedTransitions.length === 0) {
       return;
     }
 
-    if (!allowedTransitions.includes(currentState)) {
+    const allowedTransitions = stateTransitions[newState];
+    const hasRules = allowedTransitions.length > 0;
+    const isAllowed = allowedTransitions.includes(existingVc.state);
+
+    if (hasRules && !isAllowed) {
       throw new Error(
-        `State VC transition from: ${currentState} to ${newState} is not allowed`,
+        `State VC transition from: ${existingVc.state} to ${newState} is not allowed`,
       );
     }
   });

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -39,7 +39,7 @@ import { StoredIdentityRecordType } from "../domain/enums/StoredIdentityRecordTy
 import { dynamoClient } from "../clients/dynamodbClient";
 import { PostVcsRequest } from "../domain/requests/postVcsRequest";
 import { PatchVcsRequest } from "../domain/requests/patchVcsRequest";
-import { getErrorMessage } from "../common/utils";
+import { getErrorMessage, getSignatureFromJwt } from "../common/utils";
 
 export async function processPostUserVCsRequest(
   userId: string,
@@ -591,10 +591,6 @@ async function getTtl(): Promise<number> {
     process.env.EVCS_STUB_TTL ?? "604800",
   );
   return Math.floor(Date.now() / 1000) + evcsTtlSeconds;
-}
-
-function getSignatureFromJwt(jwt: string): string {
-  return jwt.split(".")[2];
 }
 
 function isEvcsVcItem(

--- a/di-ipv-evcs-stub/lambdas/test/handlers/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/handlers/evcsHandler.test.ts
@@ -156,6 +156,28 @@ const TEST_MALFORMED_VC_JWT_2 = {
   },
 };
 
+const TEST_MALFORMED_VC_EMPTY_PARTS = {
+  vc: ".two.parts", // pragma: allowlist secret
+  state: VcState.CURRENT,
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
+const TEST_MALFORMED_VC_FOUR_PARTS = {
+  vc: "one.two.three.four", // pragma: allowlist secret
+  state: VcState.CURRENT,
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
 const TEST_POST_INVALID_STATE_REQUEST = [
   {
     vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
@@ -518,6 +540,20 @@ describe("evcs handlers", () => {
           govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
         }),
         case: "missing jwt part",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_EMPTY_PARTS],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vc has empty part",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_FOUR_PARTS],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vc has more than 3 parts",
       },
       {
         request: buildPostIdentityRequest({

--- a/di-ipv-evcs-stub/lambdas/test/handlers/evcsHandler.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/handlers/evcsHandler.test.ts
@@ -44,6 +44,7 @@ const EVCS_VERIFY_KEY =
   "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIMqVMxm2EdlSRjPkCV5NDyN9/RMmJLerY4H0vkXDjEDTg=="; // pragma: allowlist secret
 
 const TEST_USER_ID: string = "urn:uuid:d1823066-2137-4380-b0ba-4b61947e08e6";
+const TEST_GOV_UK_SINGIN_JOURNEY_ID: string = "test-journey-id";
 const TEST_VC_STRING =
   "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ"; // pragma: allowlist secret
 const TEST_METADATA = {
@@ -53,7 +54,7 @@ const TEST_METADATA = {
   testProperty: "testProperty",
 };
 
-const TEST_POST_REQUEST = [
+const TEST_VALID_VCS_ARRAY = [
   {
     vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
     state: VcState.CURRENT,
@@ -78,6 +79,83 @@ const TEST_POST_REQUEST = [
     state: VcState.PENDING_RETURN,
   },
 ];
+
+const TEST_DUPLICATED_VCS_ARRAY = [
+  {
+    vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
+    state: VcState.CURRENT,
+    metadata: {
+      reason: "test-created",
+      timestampMs: "1714478033959",
+      txmaEventId: "txma-event-id",
+      testProperty: "testProperty",
+    },
+  },
+  {
+    vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
+    state: VcState.CURRENT,
+    metadata: {
+      reason: "test-created",
+      timestampMs: "1714478033959",
+      txmaEventId: "txma-event-id",
+      testProperty: "testProperty",
+    },
+  },
+];
+
+const TEST_MALFORMED_VC_MISSING_STATE = {
+  vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
+const TEST_MALFORMED_VC_MISSING_VC = {
+  state: VcState.CURRENT,
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
+const TEST_MALFORMED_VC_PAYLOAD = {
+  vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.malformed.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
+  state: VcState.CURRENT,
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
+const TEST_MALFORMED_VC_JWT_1 = {
+  vc: "not+base+64.not+base+64.not+base+64", // pragma: allowlist secret
+  state: VcState.CURRENT,
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
+const TEST_MALFORMED_VC_JWT_2 = {
+  vc: "two.parts", // pragma: allowlist secret
+  state: VcState.CURRENT,
+  metadata: {
+    reason: "test-created",
+    timestampMs: "1714478033959",
+    txmaEventId: "txma-event-id",
+    testProperty: "testProperty",
+  },
+};
+
 const TEST_POST_INVALID_STATE_REQUEST = [
   {
     vc: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJhNjkzNjFkLTAzOTctNGU4OS04ZmFlLTI4YjFjMmZlZDYxNCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOkpHMFJKSTFwWWJuYW5idlBzLWo0ajUtYS1QRmNtaHJ5OVF1OU5DRXA1ZDQiLCJuYmYiOjE2NzAzMzY0NDEsImlzcyI6Imh0dHBzOi8vaWRlbnRpdHkuYWNjb3VudC5nb3YudWsvIiwidm90IjoiUDIiLCJleHAiOjE2ODI5NTkwMzEsImlhdCI6MTY4Mjk1ODczMSwidnRtIjoiaHR0cHM6Ly9vaWRjLmFjY291bnQuZ292LnVrL3RydXN0bWFyayIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJKYW5lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJXcmlnaHQiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IkphbmUiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IldyaWdodCIsInR5cGUiOiJGYW1pbHlOYW1lIn1dLCJ2YWxpZFVudGlsIjoiMjAxOS0wNC0wMSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19fSwiYXVkIjoiaXB2QXVkaWVuY2UifQ.qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ", // pragma: allowlist secret
@@ -150,7 +228,7 @@ const TEST_HEADERS_NO_SUBJECT = {
 } as APIGatewayProxyEventHeaders;
 
 const TEST_POST_EVENT = {
-  body: JSON.stringify(TEST_POST_REQUEST),
+  body: JSON.stringify(TEST_VALID_VCS_ARRAY),
   pathParameters: TEST_PATH_PARAM,
 } as APIGatewayProxyEvent;
 
@@ -193,7 +271,7 @@ describe("evcs handlers", () => {
       expect(response.statusCode).toBe(202);
       expect(processPostUserVCsRequest).toHaveBeenCalledWith(
         TEST_USER_ID,
-        TEST_POST_REQUEST,
+        TEST_VALID_VCS_ARRAY,
       );
     });
 
@@ -354,6 +432,27 @@ describe("evcs handlers", () => {
       expect(processPostIdentityRequest).toHaveBeenCalledWith(testRequest);
     });
 
+    it("should return 202 for valid request with vcs and govuk journey id", async () => {
+      // arrange
+      vi.mocked(processPostIdentityRequest).mockResolvedValue({
+        statusCode: 202,
+        response: {},
+      });
+      const testRequest = buildPostIdentityRequest({
+        vcs: TEST_VALID_VCS_ARRAY,
+        govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+      });
+
+      // act
+      const response = (await postIdentityHandler(
+        createEvent<PostIdentityRequest>(testRequest),
+      )) as APIGatewayProxyStructuredResultV2;
+
+      // assert
+      expect(response.statusCode).toBe(202);
+      expect(processPostIdentityRequest).toHaveBeenCalledWith(testRequest);
+    });
+
     it("should return a 500 if saving to EVCS fails", async () => {
       // arrange
       vi.mocked(processPostIdentityRequest).mockResolvedValue({
@@ -393,26 +492,75 @@ describe("evcs handlers", () => {
         }),
         case: "si.jwt is missing",
       },
-      // TODO PYIC-8458: These tests should be uncommented in phase 2 when the
-      //  /identity endpoint accepts a vcs list as the request parsing should
-      // handle these criteria
-      // {
-      //   request: buildPutRequest({ vcs: undefined }),
-      //   case: "vcs is missing",
-      // },
-      // {
-      //   request: buildPutRequest({ vcs: [] }),
-      //   case: "vcs is empty",
-      // },
-      // {
-      //   request: buildPutRequest({
-      //     vcs: [
-      //       { vc: "some.vc.sig", state: VcState.CURRENT },
-      //       { vc: "some.vc.sig", state: VcState.HISTORIC },
-      //     ],
-      //   }),
-      //   case: "duplicate vcs with different states",
-      // },
+      {
+        request: buildPostIdentityRequest({
+          si: { jwt: "second.part-is.not-valid-payload", vot: Vot.P2 },
+        }),
+        case: "si.jwt is missing",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_MISSING_STATE],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vc is missing state",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_JWT_1],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vs is not base64Url encoded",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_JWT_2],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "missing jwt part",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_MISSING_VC],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "missing vc",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [TEST_MALFORMED_VC_PAYLOAD],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vc has invalid payload",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: TEST_DUPLICATED_VCS_ARRAY,
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vcs are duplicated",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: TEST_VALID_VCS_ARRAY,
+          govuk_signin_journey_id: undefined,
+        }),
+        case: "govuk_signin_journey_id is missing and vcs are present",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: undefined,
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vcs is missing and govuk_signing_journey_id is present",
+      },
+      {
+        request: buildPostIdentityRequest({
+          vcs: [],
+          govuk_signin_journey_id: TEST_GOV_UK_SINGIN_JOURNEY_ID,
+        }),
+        case: "vcs array length is less than 1",
+      },
     ])("should return a 400 if $case", async ({ request }) => {
       // act
       const response = (await postIdentityHandler(

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -21,7 +21,12 @@ import {
   processPostUserVCsRequestV2,
 } from "../../src/services/evcsService";
 import { PostIdentityRequest } from "../../src/domain/requests";
-import { StatusCodes, VCProvenance, VcState } from "../../src/domain/enums";
+import {
+  stateTransitions,
+  StatusCodes,
+  VCProvenance,
+  VcState,
+} from "../../src/domain/enums";
 import "aws-sdk-client-mock-vitest";
 import { config } from "../../src/common/config";
 import { Vot } from "../../src/domain/enums/vot";
@@ -270,57 +275,19 @@ describe("evcsService", () => {
       });
     });
 
-    it.each([
-      // ABANDONED (allowed from: PENDING, PENDING_RETURN, VERIFICATION)
-      { from: VcState.ABANDONED, to: VcState.ABANDONED },
-      { from: VcState.CURRENT, to: VcState.ABANDONED },
-      { from: VcState.HISTORIC, to: VcState.ABANDONED },
-      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.ABANDONED },
-      { from: VcState.ACCOUNT_DELETED, to: VcState.ABANDONED },
+    const invalidTransitions = Object.values(VcState).flatMap((to) => {
+      const allowed = stateTransitions[to];
+      if (allowed.length === 0) {
+        return [];
+      }
+      return Object.values(VcState)
+        .filter((from) => !allowed.includes(from))
+        .map((from) => ({ from, to }));
+    });
 
-      // CURRENT (allowed from: PENDING_RETURN, PENDING)
-      { from: VcState.ABANDONED, to: VcState.CURRENT },
-      { from: VcState.CURRENT, to: VcState.CURRENT },
-      { from: VcState.HISTORIC, to: VcState.CURRENT },
-      { from: VcState.VERIFICATION, to: VcState.CURRENT },
-      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.CURRENT },
-      { from: VcState.ACCOUNT_DELETED, to: VcState.CURRENT },
-
-      // HISTORIC (allowed from: CURRENT)
-      { from: VcState.ABANDONED, to: VcState.HISTORIC },
-      { from: VcState.HISTORIC, to: VcState.HISTORIC },
-      { from: VcState.PENDING, to: VcState.HISTORIC },
-      { from: VcState.PENDING_RETURN, to: VcState.HISTORIC },
-      { from: VcState.VERIFICATION, to: VcState.HISTORIC },
-      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.HISTORIC },
-      { from: VcState.ACCOUNT_DELETED, to: VcState.HISTORIC },
-
-      // PENDING_RETURN (allowed from: PENDING)
-      { from: VcState.ABANDONED, to: VcState.PENDING_RETURN },
-      { from: VcState.CURRENT, to: VcState.PENDING_RETURN },
-      { from: VcState.HISTORIC, to: VcState.PENDING_RETURN },
-      { from: VcState.PENDING_RETURN, to: VcState.PENDING_RETURN },
-      { from: VcState.VERIFICATION, to: VcState.PENDING_RETURN },
-      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.PENDING_RETURN },
-      { from: VcState.ACCOUNT_DELETED, to: VcState.PENDING_RETURN },
-
-      // VERIFICATION_ARCHIVED (allowed from: VERIFICATION)
-      { from: VcState.ABANDONED, to: VcState.VERIFICATION_ARCHIVED },
-      { from: VcState.CURRENT, to: VcState.VERIFICATION_ARCHIVED },
-      { from: VcState.HISTORIC, to: VcState.VERIFICATION_ARCHIVED },
-      { from: VcState.PENDING, to: VcState.VERIFICATION_ARCHIVED },
-      { from: VcState.PENDING_RETURN, to: VcState.VERIFICATION_ARCHIVED },
-      {
-        from: VcState.VERIFICATION_ARCHIVED,
-        to: VcState.VERIFICATION_ARCHIVED,
-      },
-      { from: VcState.ACCOUNT_DELETED, to: VcState.VERIFICATION_ARCHIVED },
-      // ACCOUNT_DELETED (allowed from: ANY)
-      // VERIFICATION (allowed from: ANY)
-      // PENDING (allowed from: ANY)
-    ])(
+    it.each(invalidTransitions)(
       "should return 409 if vcs state transitions is not allowed",
-      async ({ from, to }: { from: VcState; to: VcState }) => {
+      async ({ from, to }) => {
         // Arrange
         dbMock
           .on(QueryCommand)

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -20,7 +20,7 @@ import {
   processPostIdentityRequest,
   processPostUserVCsRequestV2,
 } from "../../src/services/evcsService";
-import { PostIdentityRequest, PutRequest } from "../../src/domain/requests";
+import { PostIdentityRequest } from "../../src/domain/requests";
 import { StatusCodes, VCProvenance, VcState } from "../../src/domain/enums";
 import "aws-sdk-client-mock-vitest";
 import { config } from "../../src/common/config";
@@ -35,6 +35,7 @@ vi.useFakeTimers().setSystemTime(new Date("2025-01-01"));
 const dbMock = mockClient(DynamoDB);
 
 const TEST_USER_ID: string = "urn:uuid:d1823066-2137-4380-b0ba-4b61947e08e6";
+const TEST_GOVUK_SIGNIN_JOURNEY_ID: string = "test-journey-id";
 
 const TEST_VC1_SIGNATURE =
   "qf0yp7B1an7cEwBui7GFCF9NNCJhHxTZuMSh5ehZPmZ4J527okK3pRgdSpWX8DlBFiZS-rXA496egfcfI-neGQ"; // pragma: allowlist secret"
@@ -131,8 +132,9 @@ describe("evcsService", () => {
       // Arrange
       dbMock.on(QueryCommand).resolves(createEvcsUserVcsQueryResponse([]));
 
-      const putRequest: PutRequest = {
+      const postIdentityRequest: PostIdentityRequest = {
         userId: TEST_USER_ID,
+        govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
         vcs: [
           {
             vc: TEST_VC1,
@@ -146,7 +148,7 @@ describe("evcsService", () => {
       };
 
       // Act
-      const response = await processPostIdentityRequest(putRequest);
+      const response = await processPostIdentityRequest(postIdentityRequest);
 
       // Assert
       expect(response.statusCode).toBe(StatusCodes.Accepted);
@@ -174,13 +176,14 @@ describe("evcsService", () => {
         createEvcsUserVcsQueryResponse([
           {
             vc: TEST_VC1,
-            state: VcState.HISTORIC,
+            state: VcState.PENDING_RETURN,
           },
         ]),
       );
 
-      const putRequest: PutRequest = {
+      const postIdentityRequest: PostIdentityRequest = {
         userId: TEST_USER_ID,
+        govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
         vcs: [
           {
             vc: TEST_VC1,
@@ -197,7 +200,7 @@ describe("evcsService", () => {
       };
 
       // Act
-      const response = await processPostIdentityRequest(putRequest);
+      const response = await processPostIdentityRequest(postIdentityRequest);
 
       // Assert
       expect(response.statusCode).toBe(StatusCodes.Accepted);
@@ -205,12 +208,9 @@ describe("evcsService", () => {
 
       expect(dbMock).toHaveReceivedCommandWith(TransactWriteItemsCommand, {
         TransactItems: [
-          createStubUserVcPutItem({
+          createUserVcUpdateItem({
             vcSignature: TEST_VC1_SIGNATURE,
-            vc: TEST_VC1,
-            metadata: TEST_METADATA,
             state: VcState.CURRENT,
-            provenance: VCProvenance.EXTERNAL,
           }),
           createStoredIdentityPutItem({
             recordType: StoredIdentityRecordType.GPG45,
@@ -222,39 +222,7 @@ describe("evcsService", () => {
       });
     });
 
-    it("should return 200 response if SI not provided", async () => {
-      // Arrange
-      dbMock.on(QueryCommand).resolves(createEvcsUserVcsQueryResponse([]));
-
-      const putRequest: PutRequest = {
-        userId: TEST_USER_ID,
-        vcs: [
-          {
-            vc: TEST_VC1,
-            state: VcState.CURRENT,
-          },
-        ],
-      };
-
-      // Act
-      const response = await processPostIdentityRequest(putRequest);
-
-      // Assert
-      expect(response.statusCode).toBe(StatusCodes.Accepted);
-      expect(dbMock).toHaveReceivedCommand(QueryCommand);
-
-      expect(dbMock).toHaveReceivedCommandWith(TransactWriteItemsCommand, {
-        TransactItems: [
-          createStubUserVcPutItem({
-            vcSignature: TEST_VC1_SIGNATURE,
-            vc: TEST_VC1,
-            state: VcState.CURRENT,
-          }),
-        ],
-      });
-    });
-
-    it("should return 200 response, update existing VCs and add new ones if successful transaction", async () => {
+    it("should return 200 response, create new VC, override SI, and NOT update existing VCs not included in the request, if successful transaction", async () => {
       // Arrange
       dbMock.on(QueryCommand).resolves(
         createEvcsUserVcsQueryResponse([
@@ -263,8 +231,9 @@ describe("evcsService", () => {
         ]),
       );
 
-      const putRequest: PutRequest = {
+      const postIdentityRequest: PostIdentityRequest = {
         userId: TEST_USER_ID,
+        govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
         vcs: [
           {
             vc: TEST_VC3,
@@ -278,7 +247,7 @@ describe("evcsService", () => {
       };
 
       // Act
-      const response = await processPostIdentityRequest(putRequest);
+      const response = await processPostIdentityRequest(postIdentityRequest);
 
       // Assert
       expect(response.statusCode).toBe(StatusCodes.Accepted);
@@ -286,14 +255,6 @@ describe("evcsService", () => {
 
       expect(dbMock).toHaveReceivedCommandWith(TransactWriteItemsCommand, {
         TransactItems: [
-          createUserVcUpdateItem({
-            vcSignature: TEST_VC1_SIGNATURE,
-            state: VcState.HISTORIC,
-          }),
-          createUserVcUpdateItem({
-            vcSignature: TEST_VC2_SIGNATURE,
-            state: VcState.ABANDONED,
-          }),
           createStubUserVcPutItem({
             vcSignature: TEST_VC3_SIGNATURE,
             vc: TEST_VC3,
@@ -309,22 +270,109 @@ describe("evcsService", () => {
       });
     });
 
+    it.each([
+      // ABANDONED (allowed from: PENDING, PENDING_RETURN, VERIFICATION)
+      { from: VcState.ABANDONED, to: VcState.ABANDONED },
+      { from: VcState.CURRENT, to: VcState.ABANDONED },
+      { from: VcState.HISTORIC, to: VcState.ABANDONED },
+      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.ABANDONED },
+      { from: VcState.ACCOUNT_DELETED, to: VcState.ABANDONED },
+
+      // CURRENT (allowed from: PENDING_RETURN, PENDING)
+      { from: VcState.ABANDONED, to: VcState.CURRENT },
+      { from: VcState.CURRENT, to: VcState.CURRENT },
+      { from: VcState.HISTORIC, to: VcState.CURRENT },
+      { from: VcState.VERIFICATION, to: VcState.CURRENT },
+      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.CURRENT },
+      { from: VcState.ACCOUNT_DELETED, to: VcState.CURRENT },
+
+      // HISTORIC (allowed from: CURRENT)
+      { from: VcState.ABANDONED, to: VcState.HISTORIC },
+      { from: VcState.HISTORIC, to: VcState.HISTORIC },
+      { from: VcState.PENDING, to: VcState.HISTORIC },
+      { from: VcState.PENDING_RETURN, to: VcState.HISTORIC },
+      { from: VcState.VERIFICATION, to: VcState.HISTORIC },
+      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.HISTORIC },
+      { from: VcState.ACCOUNT_DELETED, to: VcState.HISTORIC },
+
+      // PENDING_RETURN (allowed from: PENDING)
+      { from: VcState.ABANDONED, to: VcState.PENDING_RETURN },
+      { from: VcState.CURRENT, to: VcState.PENDING_RETURN },
+      { from: VcState.HISTORIC, to: VcState.PENDING_RETURN },
+      { from: VcState.PENDING_RETURN, to: VcState.PENDING_RETURN },
+      { from: VcState.VERIFICATION, to: VcState.PENDING_RETURN },
+      { from: VcState.VERIFICATION_ARCHIVED, to: VcState.PENDING_RETURN },
+      { from: VcState.ACCOUNT_DELETED, to: VcState.PENDING_RETURN },
+
+      // VERIFICATION_ARCHIVED (allowed from: VERIFICATION)
+      { from: VcState.ABANDONED, to: VcState.VERIFICATION_ARCHIVED },
+      { from: VcState.CURRENT, to: VcState.VERIFICATION_ARCHIVED },
+      { from: VcState.HISTORIC, to: VcState.VERIFICATION_ARCHIVED },
+      { from: VcState.PENDING, to: VcState.VERIFICATION_ARCHIVED },
+      { from: VcState.PENDING_RETURN, to: VcState.VERIFICATION_ARCHIVED },
+      {
+        from: VcState.VERIFICATION_ARCHIVED,
+        to: VcState.VERIFICATION_ARCHIVED,
+      },
+      { from: VcState.ACCOUNT_DELETED, to: VcState.VERIFICATION_ARCHIVED },
+      // ACCOUNT_DELETED (allowed from: ANY)
+      // VERIFICATION (allowed from: ANY)
+      // PENDING (allowed from: ANY)
+    ])(
+      "should return 409 if vcs state transitions is not allowed",
+      async ({ from, to }: { from: VcState; to: VcState }) => {
+        // Arrange
+        dbMock
+          .on(QueryCommand)
+          .resolves(
+            createEvcsUserVcsQueryResponse([{ vc: TEST_VC1, state: from }]),
+          );
+
+        const postIdentityRequest: PostIdentityRequest = {
+          userId: TEST_USER_ID,
+          govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
+          vcs: [
+            {
+              vc: TEST_VC1,
+              state: to,
+            },
+          ],
+          si: {
+            jwt: TEST_VC2,
+            vot: Vot.P2,
+          },
+        };
+
+        // Act
+        const response = await processPostIdentityRequest(postIdentityRequest);
+
+        // Assert
+        expect(response.statusCode).toBe(StatusCodes.Conflict);
+        expect(dbMock).not.toHaveReceivedCommand(TransactWriteItemsCommand);
+      },
+    );
+
     it("should return 500 status code if it fails to get existing user VCs", async () => {
       // Arrange
       dbMock.on(QueryCommand).rejects(new Error("Failed to get existing VCs"));
 
-      const putRequest: PutRequest = {
+      const postIdentityRequest: PostIdentityRequest = {
         userId: TEST_USER_ID,
+        govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
         vcs: [
           {
             vc: TEST_VC3,
             state: VcState.CURRENT,
           },
         ],
+        si: {
+          jwt: TEST_VC2,
+          vot: Vot.P2,
+        },
       };
 
       // Act
-      const response = await processPostIdentityRequest(putRequest);
+      const response = await processPostIdentityRequest(postIdentityRequest);
 
       // Assert
       expect(response.statusCode).toBe(StatusCodes.InternalServerError);
@@ -338,18 +386,23 @@ describe("evcsService", () => {
         .on(TransactWriteItemsCommand)
         .rejects(new Error("Failed to complete transaction"));
 
-      const putRequest: PutRequest = {
+      const postIdentityRequest: PostIdentityRequest = {
         userId: TEST_USER_ID,
+        govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
         vcs: [
           {
             vc: TEST_VC3,
             state: VcState.CURRENT,
           },
         ],
+        si: {
+          jwt: TEST_VC2,
+          vot: Vot.P2,
+        },
       };
 
       // Act
-      const response = await processPostIdentityRequest(putRequest);
+      const response = await processPostIdentityRequest(postIdentityRequest);
 
       // Assert
       expect(response.statusCode).toBe(StatusCodes.InternalServerError);

--- a/di-ipv-evcs-stub/openAPI/evcs-external.yaml
+++ b/di-ipv-evcs-stub/openAPI/evcs-external.yaml
@@ -257,6 +257,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         403:
           $ref: '#/components/responses/Forbidden'
+        409:
+          $ref: '#/components/responses/Conflict'
         500:
           $ref: '#/components/responses/ServerError'
       x-amazon-apigateway-request-validator: ALL
@@ -504,6 +506,14 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
   schemas:
+    GovUkSignInJourneyId:
+      type: object
+      description: An object that specifies the user's GOV.UK Sign In Journey Id
+      example:
+        govuk_signin_journey_id: "45GJHHJuJuPoi-76FGBHjgvjlpi"
+      properties:
+        govuk_signin_journey_id:
+          type: string
     PostUserVCRequestBody:
       description: Request body for EVCS post user VCs request
       type: array
@@ -614,6 +624,11 @@ components:
       description: The request body for the /identity POST endpoint to store a user's stored identity record
       allOf:
         - $ref: "#/components/schemas/UserIdRequestBody"
+        - $ref: "#/components/schemas/GovUkSignInJourneyId"
+        - type: object
+          properties:
+            vcs:
+              $ref: "#/components/schemas/PersistVCsArray"
         - type: object
           properties:
             si:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- POST /identity endpoint now accepts vcs array and govuk_signin_journey_id
- vc can be updated according to the allowed state transitions, otherwise will be rejected with 409
- vc can be added with any state
- vcs are validated
- si is validated

### Why did it change

In phase 1, a POST /identity endpoint was added to the EVCS stub which accepts a stored identity object to be stored in EVCS. 

To align with the EVCS API updates, we need to update the POST /identity endpoint to accept a VCs list so they can be saved to EVCS. This will be used to replace the existing POST /vcs/<userId> endpoint where we need to create an SI record and create/update a user’s VCs.

The api spec can be found [here](https://github.com/govuk-one-login/ipv-identity-reuse-storage/blob/7b551a6d0a0c3735988af5cc63045aa459324ca5/src/specs/api.yaml#L512-L565).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8458](https://govukverify.atlassian.net/browse/PYIC-8458)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-8458]: https://govukverify.atlassian.net/browse/PYIC-8458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ