### PR TITLE
PYIC-9002: Update PATCH /vcs endpoint to fetch all user vcs.

### DIFF
--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -136,40 +136,55 @@ export async function processPatchUserVCsRequestV2(
     console.info(`Patch user record.`);
 
     // Check that the request VCs already exist
-    const vcRecords = await getCurrentVcsForUser(patchRequest.userId);
-    const requestSignatures = patchRequest.vcs.map(
-      (vcDetails) => vcDetails.signature,
+    const allVcStates: VcState[] = Object.values(VcState);
+    const getResponse = await processGetUserVCsRequest(
+      patchRequest.userId,
+      allVcStates,
     );
-    const dynamoVcsBySignature = Object.fromEntries(
-      vcRecords.map((vcRecord) => [
-        getSignatureFromJwt(vcRecord.vc.S || ""),
-        vcRecord,
+    if (
+      getResponse.statusCode !== StatusCodes.Success ||
+      !getResponse.response ||
+      (!!getResponse.response && !("vcs" in getResponse.response))
+    ) {
+      console.error(
+        `Failed to read existing user VCs from EVCS with ${getResponse.statusCode}`,
+      );
+      return createServiceResponse(StatusCodes.InternalServerError);
+    }
+
+    const existingVcs = getResponse.response.vcs;
+
+    const requestVcSignatureToState = new Map(
+      patchRequest.vcs.map((vcItem) => [vcItem.signature, vcItem.state]),
+    );
+    const existingVcSignatureToState = new Map(
+      existingVcs.map((vcItem) => [
+        getSignatureFromJwt(vcItem.vc),
+        vcItem.state,
       ]),
     );
 
-    if (
-      requestSignatures.some((signature) => !dynamoVcsBySignature[signature])
-    ) {
-      return createServiceResponseWithMessage(
-        StatusCodes.NotFound,
-        "At least one request VC doesn't exist in EVCS",
-      );
+    for (const requestSignature of requestVcSignatureToState.keys()) {
+      const existingState = existingVcSignatureToState.get(requestSignature);
+      if (!existingState) {
+        return createServiceResponseWithMessage(
+          StatusCodes.NotFound,
+          "At least one request VC doesn't exist in EVCS",
+        );
+      }
     }
 
     // Check that the state transitions are allowed
-    const invalidStateTransitionFound = patchRequest.vcs.some((requestVc) => {
-      const validSourceStates = stateTransitions[requestVc.state];
-      const existingVc = dynamoVcsBySignature[requestVc.signature];
-      return (
-        !existingVc.state.S ||
-        !validSourceStates.includes(existingVc.state.S as VcState)
+    try {
+      validateStateTransitions(
+        existingVcSignatureToState,
+        requestVcSignatureToState,
       );
-    });
-    if (invalidStateTransitionFound) {
-      return createServiceResponseWithMessage(
-        StatusCodes.Conflict,
-        "At least one state transition is invalid",
-      );
+    } catch (error) {
+      return {
+        response: { messageId: getErrorMessage(error) },
+        statusCode: StatusCodes.Conflict,
+      };
     }
 
     const allPromises: Promise<UpdateItemCommandOutput>[] = [];
@@ -233,7 +248,26 @@ export async function processPostIdentityRequest(
       );
 
       try {
-        validateVcsStateTransitions(existingVcs, vcsToUpdate);
+        const vcsToUpdateSignatures = vcsToUpdate.map((vc) =>
+          getSignatureFromJwt(vc.vc),
+        );
+        const existingVcsToUpdate = existingVcs.filter((vc) => {
+          const existingVcSignature = getSignatureFromJwt(vc.vc);
+          return vcsToUpdateSignatures.includes(existingVcSignature);
+        });
+        const existingVcsSignatureToState = new Map(
+          existingVcsToUpdate.map((vc) => [
+            getSignatureFromJwt(vc.vc),
+            vc.state,
+          ]),
+        );
+        const updatableVcsSignatureToState = new Map(
+          vcsToUpdate.map((vc) => [getSignatureFromJwt(vc.vc), vc.state]),
+        );
+        validateStateTransitions(
+          existingVcsSignatureToState,
+          updatableVcsSignatureToState,
+        );
       } catch (error) {
         return {
           response: { messageId: getErrorMessage(error) },
@@ -300,32 +334,31 @@ export async function processPostIdentityRequest(
   }
 }
 
-function validateVcsStateTransitions(
-  existingVcs: VcDetails[],
-  vcsToUpdate: VcDetails[],
-): void {
-  const newVcsSignatureToState = new Map(
-    vcsToUpdate.map((vc) => [getSignatureFromJwt(vc.vc), vc.state]),
-  );
-
-  existingVcs.forEach((existingVc) => {
-    const newState = newVcsSignatureToState.get(
-      getSignatureFromJwt(existingVc.vc),
-    );
+function validateStateTransitions(
+  existingVcsSignatureToState: Map<string, VcState>,
+  newVcsSignatureToState: Map<string, VcState>,
+) {
+  for (const [
+    existingSignature,
+    existingState,
+  ] of existingVcsSignatureToState) {
+    const newState = newVcsSignatureToState.get(existingSignature);
     if (!newState) {
-      return;
+      throw new Error(
+        "No matching signature while validating state transitions.",
+      );
     }
 
     const allowedTransitions = stateTransitions[newState];
     const hasRules = allowedTransitions.length > 0;
-    const isAllowed = allowedTransitions.includes(existingVc.state);
+    const isAllowed = allowedTransitions.includes(existingState);
 
     if (hasRules && !isAllowed) {
       throw new Error(
-        `State VC transition from: ${existingVc.state} to ${newState} is not allowed`,
+        `State VC transition from: ${existingState} to ${newState} is not allowed`,
       );
     }
-  });
+  }
 }
 
 export async function processGetIdentityRequest(

--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -248,22 +248,16 @@ export async function processPostIdentityRequest(
       );
 
       try {
-        const vcsToUpdateSignatures = vcsToUpdate.map((vc) =>
-          getSignatureFromJwt(vc.vc),
-        );
-        const existingVcsToUpdate = existingVcs.filter((vc) => {
-          const existingVcSignature = getSignatureFromJwt(vc.vc);
-          return vcsToUpdateSignatures.includes(existingVcSignature);
-        });
-        const existingVcsSignatureToState = new Map(
-          existingVcsToUpdate.map((vc) => [
-            getSignatureFromJwt(vc.vc),
-            vc.state,
-          ]),
-        );
         const updatableVcsSignatureToState = new Map(
           vcsToUpdate.map((vc) => [getSignatureFromJwt(vc.vc), vc.state]),
         );
+        const existingVcsSignatureToState = new Map<string, VcState>();
+        for (const vc of existingVcs) {
+          const sig = getSignatureFromJwt(vc.vc);
+          if (updatableVcsSignatureToState.has(sig)) {
+            existingVcsSignatureToState.set(sig, vc.state);
+          }
+        }
         validateStateTransitions(
           existingVcsSignatureToState,
           updatableVcsSignatureToState,

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -112,7 +112,11 @@ const INVALID_FROM_TO_STATE_TRANSITIONS = Object.values(VcState).flatMap(
 
 const VALID_FROM_TO_STATE_TRANSITIONS = (
   Object.entries(stateTransitions) as [VcState, VcState[]][]
-).flatMap(([to, fromStates]) => fromStates.map((from) => ({ from, to })));
+).flatMap(([to, fromStates]) => {
+  const sources = fromStates.length === 0 ? Object.values(VcState) : fromStates;
+
+  return sources.map((from) => ({ from, to }));
+});
 
 describe("evcsService", () => {
   beforeEach(() => {
@@ -191,57 +195,60 @@ describe("evcsService", () => {
       });
     });
 
-    it("should return 200 response with updated vc if successful transaction", async () => {
-      // Arrange
-      dbMock.on(QueryCommand).resolves(
-        createEvcsUserVcsQueryResponse([
-          {
-            vc: TEST_VC1,
-            state: VcState.PENDING_RETURN,
-          },
-        ]),
-      );
+    it.each(VALID_FROM_TO_STATE_TRANSITIONS)(
+      "should return 200 response with updated vc with state transition from $from to $to if successful transaction",
+      async ({ from, to }) => {
+        // Arrange
+        dbMock.on(QueryCommand).resolves(
+          createEvcsUserVcsQueryResponse([
+            {
+              vc: TEST_VC1,
+              state: from,
+            },
+          ]),
+        );
 
-      const postIdentityRequest: PostIdentityRequest = {
-        userId: TEST_USER_ID,
-        govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
-        vcs: [
-          {
-            vc: TEST_VC1,
-            state: VcState.CURRENT,
+        const postIdentityRequest: PostIdentityRequest = {
+          userId: TEST_USER_ID,
+          govuk_signin_journey_id: TEST_GOVUK_SIGNIN_JOURNEY_ID,
+          vcs: [
+            {
+              vc: TEST_VC1,
+              state: to,
+              metadata: TEST_METADATA,
+              provenance: VCProvenance.EXTERNAL,
+            },
+          ],
+          si: {
+            jwt: TEST_VC2,
+            vot: Vot.P2,
             metadata: TEST_METADATA,
-            provenance: VCProvenance.EXTERNAL,
           },
-        ],
-        si: {
-          jwt: TEST_VC2,
-          vot: Vot.P2,
-          metadata: TEST_METADATA,
-        },
-      };
+        };
 
-      // Act
-      const response = await processPostIdentityRequest(postIdentityRequest);
+        // Act
+        const response = await processPostIdentityRequest(postIdentityRequest);
 
-      // Assert
-      expect(response.statusCode).toBe(StatusCodes.Accepted);
-      expect(dbMock).toHaveReceivedCommand(QueryCommand);
+        // Assert
+        expect(response.statusCode).toBe(StatusCodes.Accepted);
+        expect(dbMock).toHaveReceivedCommand(QueryCommand);
 
-      expect(dbMock).toHaveReceivedCommandWith(TransactWriteItemsCommand, {
-        TransactItems: [
-          createUserVcUpdateItem({
-            vcSignature: TEST_VC1_SIGNATURE,
-            state: VcState.CURRENT,
-          }),
-          createStoredIdentityPutItem({
-            recordType: StoredIdentityRecordType.GPG45,
-            storedIdentity: TEST_VC2,
-            levelOfConfidence: Vot.P2,
-            metadata: TEST_METADATA,
-          }),
-        ],
-      });
-    });
+        expect(dbMock).toHaveReceivedCommandWith(TransactWriteItemsCommand, {
+          TransactItems: [
+            createUserVcUpdateItem({
+              vcSignature: TEST_VC1_SIGNATURE,
+              state: to,
+            }),
+            createStoredIdentityPutItem({
+              recordType: StoredIdentityRecordType.GPG45,
+              storedIdentity: TEST_VC2,
+              levelOfConfidence: Vot.P2,
+              metadata: TEST_METADATA,
+            }),
+          ],
+        });
+      },
+    );
 
     it("should return 200 response, create new VC, override SI, and NOT update existing VCs not included in the request, if successful transaction", async () => {
       // Arrange

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -98,6 +98,22 @@ const TEST_METADATA = {
 
 const MOCK_TTL = "3600";
 
+const INVALID_FROM_TO_STATE_TRANSITIONS = Object.values(VcState).flatMap(
+  (to) => {
+    const allowed = stateTransitions[to];
+    if (allowed.length === 0) {
+      return [];
+    }
+    return Object.values(VcState)
+      .filter((from) => !allowed.includes(from))
+      .map((from) => ({ from, to }));
+  },
+);
+
+const VALID_FROM_TO_STATE_TRANSITIONS = (
+  Object.entries(stateTransitions) as [VcState, VcState[]][]
+).flatMap(([to, fromStates]) => fromStates.map((from) => ({ from, to })));
+
 describe("evcsService", () => {
   beforeEach(() => {
     dbMock.reset();
@@ -275,18 +291,8 @@ describe("evcsService", () => {
       });
     });
 
-    const invalidTransitions = Object.values(VcState).flatMap((to) => {
-      const allowed = stateTransitions[to];
-      if (allowed.length === 0) {
-        return [];
-      }
-      return Object.values(VcState)
-        .filter((from) => !allowed.includes(from))
-        .map((from) => ({ from, to }));
-    });
-
-    it.each(invalidTransitions)(
-      "should return 409 if vcs state transitions is not allowed",
+    it.each(INVALID_FROM_TO_STATE_TRANSITIONS)(
+      "should return 409 if vcs state transitions is not allowed from $from to $to",
       async ({ from, to }) => {
         // Arrange
         dbMock
@@ -638,26 +644,35 @@ describe("evcsService", () => {
   });
 
   describe("processPatchUserVCsRequestV2", () => {
-    it("should return 409 response when provided invalid VC state transition", async () => {
-      // Arrange
-      const request = structuredClone(TEST_PATCH_REQUEST);
-      // Current to abandoned is not allowed
-      request.vcs[0].state = VcState.ABANDONED;
-      dbMock
-        .on(QueryCommand)
-        .resolves(
-          createEvcsUserVcsQueryResponse([
-            { vc: TEST_VC1, state: VcState.CURRENT },
-          ]),
-        );
+    it.each(INVALID_FROM_TO_STATE_TRANSITIONS)(
+      "should return 409 if vcs state transitions is not allowed from $from to $to",
+      async ({ from, to }) => {
+        // Arrange
+        dbMock
+          .on(QueryCommand)
+          .resolves(
+            createEvcsUserVcsQueryResponse([{ vc: TEST_VC1, state: from }]),
+          );
 
-      // Act
-      const response = await processPatchUserVCsRequestV2(request);
+        const patchVcsRequest: PatchVcsRequest = {
+          userId: "testUserId",
+          govuk_signin_journey_id: "testJourneyId",
+          vcs: [
+            {
+              signature: TEST_VC1_SIGNATURE,
+              state: to,
+            },
+          ],
+        };
 
-      // Assert
-      expect(response.statusCode).toBe(StatusCodes.Conflict);
-      expect(dbMock).not.toHaveReceivedCommand(UpdateItemCommand);
-    });
+        // Act
+        const response = await processPatchUserVCsRequestV2(patchVcsRequest);
+
+        // Assert
+        expect(response.statusCode).toBe(StatusCodes.Conflict);
+        expect(dbMock).not.toHaveReceivedCommand(UpdateItemCommand);
+      },
+    );
 
     it("should return 404 response when provided a VC that doesn't exist", async () => {
       // Arrange
@@ -672,34 +687,35 @@ describe("evcsService", () => {
       expect(dbMock).not.toHaveReceivedCommand(UpdateItemCommand);
     });
 
-    it("should return 204 response when provided valid VCs", async () => {
-      // Arrange
-      const request = structuredClone(TEST_PATCH_REQUEST);
-      // Current to historic is allowed
-      request.vcs[0].state = VcState.HISTORIC;
-      dbMock
-        .on(QueryCommand)
-        .resolves(
-          createEvcsUserVcsQueryResponse([
-            { vc: TEST_VC1, state: VcState.CURRENT },
-          ]),
+    it.each(VALID_FROM_TO_STATE_TRANSITIONS)(
+      "should return 204 response when provided valid VCs with state transition from $from to $to",
+      async ({ from, to }) => {
+        // Arrange
+        const request = structuredClone(TEST_PATCH_REQUEST);
+        // Current to historic is allowed
+        request.vcs[0].state = to;
+        dbMock
+          .on(QueryCommand)
+          .resolves(
+            createEvcsUserVcsQueryResponse([{ vc: TEST_VC1, state: from }]),
+          );
+
+        // Act
+        const response = await processPatchUserVCsRequestV2(request);
+
+        // Assert
+        expect(response.statusCode).toBe(StatusCodes.NoContent);
+        expect(dbMock).toHaveReceivedCommandWith(
+          UpdateItemCommand,
+          createUpdateItemInput({
+            userId: request.userId,
+            vcSignature: TEST_VC1_SIGNATURE,
+            state: request.vcs[0].state,
+            ttl: 1735693200,
+          }),
         );
-
-      // Act
-      const response = await processPatchUserVCsRequestV2(request);
-
-      // Assert
-      expect(response.statusCode).toBe(StatusCodes.NoContent);
-      expect(dbMock).toHaveReceivedCommandWith(
-        UpdateItemCommand,
-        createUpdateItemInput({
-          userId: request.userId,
-          vcSignature: TEST_VC1_SIGNATURE,
-          state: request.vcs[0].state,
-          ttl: 1735693200,
-        }),
-      );
-    });
+      },
+    );
   });
 
   function getTestTtl() {

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -699,7 +699,6 @@ describe("evcsService", () => {
       async ({ from, to }) => {
         // Arrange
         const request = structuredClone(TEST_PATCH_REQUEST);
-        // Current to historic is allowed
         request.vcs[0].state = to;
         dbMock
           .on(QueryCommand)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- When PATCH /vcs endpoint is triggered it now fetch all user VCs in every state.
- Extracted validateStateTransition function and reused in in PATCH /vcs and POST /identity endpoints

- when PATCH /vcs validates state transitions as empty array then it will be considered as valid transition from any state
This change is made according to [documentation included in trust and reuse team repo](https://github.com/govuk-one-login/ipv-identity-reuse-storage/blob/7b551a6d0a0c3735988af5cc63045aa459324ca5/src/data-types/constants.ts#L93).

- added test cases to cover all happy and unhappy state transitions for PATCH /vcs and POST /identity endpoints 


### Why did it change

To allow VCs update from any state and validate it against stateTransition object.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-9002](https://govukverify.atlassian.net/browse/PYIC-9002)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-9002]: https://govukverify.atlassian.net/browse/PYIC-9002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ