### PR TITLE
SPT-1904: Migrated Trust and Reuse Hosted Zone to shared stack

### DIFF
--- a/di-ipv-evcs-stub/core-dev-deploy/template.yaml
+++ b/di-ipv-evcs-stub/core-dev-deploy/template.yaml
@@ -44,9 +44,9 @@ Mappings:
     "175872367215": # IPV Core dev02
       Name: Dev02StubsHostedZoneId
     "110869144943": # Reuse stubs dev
-      Name: ReusePublicHostedZoneId
+      Name: shared-ReusePublicHostedZoneId
     "054367266435": # Reuse stubs build
-      Name: ReusePublicHostedZoneId
+      Name: shared-ReusePublicHostedZoneId
 
 Conditions:
   IsDev01:

--- a/di-ipv-evcs-stub/deploy/template.yaml
+++ b/di-ipv-evcs-stub/deploy/template.yaml
@@ -153,9 +153,9 @@ Mappings:
     "388905755587": # IPV Core Prod
       Name: RootPublicHostedZoneId
     "110869144943": # Reuse stubs dev
-      Name: ReusePublicHostedZoneId
+      Name: shared-ReusePublicHostedZoneId
     "054367266435": # Reuse stubs build
-      Name: ReusePublicHostedZoneId
+      Name: shared-ReusePublicHostedZoneId
 
 Resources:
   # lambda to stub EVCS - evcsCreateUserVCs


### PR DESCRIPTION
## Proposed changes

### What changed

Migrated Trust and Reuse Team Hosted Zone to `shared` stack. Related PR https://github.com/govuk-one-login/ipv-stubs-common-infra/pull/297

### Why did it change

Previously the Hosted Zone was created as part of the `ais-sub-producer` stack. However, this made no sense especially as more stubs are being added to the https://github.com/govuk-one-login/ipv-reuse-service-stubs repository.

### Issue tracking

- [SPT-1904](https://govukverify.atlassian.net/browse/SPT-1904)


[SPT-1904]: https://govukverify.atlassian.net/browse/SPT-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ