### PR TITLE
[IPS-2341] Change CODEOWNERS from ID-SRE to REX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @govuk-one-login/identity-sre @govuk-one-login/core-team
+* @govuk-one-login/reliability-engineering-x @govuk-one-login/core-team
 /di-ipv-ais-stub/ @govuk-one-login/core-team
 /di-piv-cimit-stub/ @govuk-one-login/core-team
 /di-ipv-core-stub/ @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team
@@ -10,7 +10,7 @@
 /di-ipv-sis-stub/ @govuk-one-login/core-team
 /di-ipv-ticf-stub/ @govuk-one-login/core-team
 /experian-fraud-stub/ @govuk-one-login/cri-lime-team
-/update-ecs-env-vars/ @govuk-one-login/identity-sre
+/update-ecs-env-vars/ @govuk-one-login/reliability-engineering-x
 
 # Github workflows
 /.github/actions/deploy-evcs-stub/ @govuk-one-login/core-team @govuk-one-login/trust-and-reuse-leads @govuk-one-login/trust-and-reuse-team
@@ -19,8 +19,8 @@
 /.github/workflows/core-cri-preprod-stub.yml @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team
 /.github/workflows/core-cri-stub.yml @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team
 /.github/workflows/core-passport-stub.yml @govuk-one-login/cri-lime-team @govuk-one-login/cri-orange-team
-/.github/workflows/deploy-update-ecs-env-vars.yml @govuk-one-login/identity-sre
+/.github/workflows/deploy-update-ecs-env-vars.yml @govuk-one-login/reliability-engineering-x
 /.github/workflows/evcs-stub.yml @govuk-one-login/core-team @govuk-one-login/trust-and-reuse-leads @govuk-one-login/trust-and-reuse-team
-/.github/workflows/gradle_graph.yml @govuk-one-login/identity-sre
-/.github/workflows/public-jwk-creator.yml @govuk-one-login/identity-sre
-/.github/workflows/template_checks.yml @govuk-one-login/identity-sre
+/.github/workflows/gradle_graph.yml @govuk-one-login/reliability-engineering-x
+/.github/workflows/public-jwk-creator.yml @govuk-one-login/reliability-engineering-x
+/.github/workflows/template_checks.yml @govuk-one-login/reliability-engineering-x


### PR DESCRIPTION
Identity SRE have become a cross cutting SRE team under a new name, this changes the ownership from the old team to the new team

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Changing CODEOWNERS from IDSRE to REX

### What changed

CODEOWNERS were changed from @govuk-one-login/identity-sre to @govuk-one-login/reliability-engineering-x

### Why did it change

Identity SRE have become a cross cutting SRE team under a new name, this changes the ownership from the old team to the new team

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-2341](https://govukverify.atlassian.net/browse/IPS-2341)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [ ] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [ ] Tests have been written/updated


[IPS-2341]: https://govukverify.atlassian.net/browse/IPS-2341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ