### PR TITLE
PYIC-9131: Double loadbalancer healthcheck timeout

### DIFF
--- a/di-ipv-credential-issuer-stub/core-dev-deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/address/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/bav/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/bav/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/claimed-identity/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/claimed-identity/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/dcmaw/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/dcmaw/template.yaml
@@ -331,6 +331,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/driving-licence/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/driving-licence/template.yaml
@@ -331,6 +331,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/dwp-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/dwp-kbv/template.yaml
@@ -331,6 +331,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-1/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/error-testing-2/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/experian-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/experian-kbv/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/face-to-face/template.yaml
@@ -342,6 +342,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/fraud/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/nino/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/nino/template.yaml
@@ -327,6 +327,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/core-dev-deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/core-dev-deploy/passport/template.yaml
@@ -331,6 +331,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/address/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/address/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/bav/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/bav/template.yaml
@@ -367,6 +367,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/claimed-identity/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/claimed-identity/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/dcmaw/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/dcmaw/template.yaml
@@ -376,6 +376,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/driving-licence/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/driving-licence/template.yaml
@@ -376,6 +376,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/dwp-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/dwp-kbv/template.yaml
@@ -376,6 +376,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-1/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/error-testing-2/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/experian-kbv/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/experian-kbv/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/face-to-face/template.yaml
@@ -384,6 +384,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/fraud/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/nino/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/nino/template.yaml
@@ -372,6 +372,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080

--- a/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
+++ b/di-ipv-credential-issuer-stub/deploy/passport/template.yaml
@@ -370,6 +370,7 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
       Matcher:
         HttpCode: 200
       Port: 8080


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Double loadbalancer healthcheck timeout to 10 seconds

### Why did it change

It looks like the failed deployments are due to healthcheck timeouts

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-9131](https://govukverify.atlassian.net/browse/PYIC-9131)



[PYIC-9131]: https://govukverify.atlassian.net/browse/PYIC-9131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ