### PR TITLE
PYIC-9131: Allow manual triggering of stub deployment

### DIFF
--- a/.github/workflows/deploy-credential-issuer-stub.yml
+++ b/.github/workflows/deploy-credential-issuer-stub.yml
@@ -1,6 +1,7 @@
 name: Deploy Credential Issuer Stub code to instances that need updating
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow cri stub workflow to be manually triggered

### Why did it change

It didn't run this morning due to GitHub issue

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-9131](https://govukverify.atlassian.net/browse/PYIC-9131)



[PYIC-9131]: https://govukverify.atlassian.net/browse/PYIC-9131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ