### PR TITLE
PYIC-9145 Check all VCs not just CURRENT in processPostUserVCsRequestV2

### DIFF
--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -90,7 +90,7 @@ export async function processPostUserVCsRequestV2(
     }
 
     // Check that none of the posted VCs already exist
-    const vcRecords = await getCurrentVcsForUser(postRequest.userId);
+    const vcRecords = await getAllVcsForUser(postRequest.userId);
     const requestVcs = postRequest.vcs.map((vcDetails) => vcDetails.vc);
 
     if (
@@ -543,6 +543,25 @@ async function saveUserEvcsItem(
 ): Promise<PutItemCommandOutput> {
   const putItemInput = createPutItem(evcsItem);
   return dynamoClient.putItem(putItemInput);
+}
+
+async function getAllVcsForUser(
+  userId: string,
+): Promise<Record<string, AttributeValue>[]> {
+  const value = await dynamoClient.query({
+    TableName: config.evcsStubUserVCsTableName,
+    KeyConditionExpression: "#userId = :userId",
+    ExpressionAttributeNames: {
+      "#userId": "userId",
+    },
+    ExpressionAttributeValues: {
+      ":userId": {
+        S: userId,
+      },
+    },
+  });
+
+  return value.Items || [];
 }
 
 async function getCurrentVcsForUser(


### PR DESCRIPTION
## Proposed changes

### What changed

Use getAllVcsForUser (no state filter) so the duplicate signature check catches VCs in any state including ABANDONED, matching real EVCS behaviour.

### Why did it change

Real EVCS checks for any existing VCs regardless of state

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-9145](https://govukverify.atlassian.net/browse/PYIC-9145)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-9145]: https://govukverify.atlassian.net/browse/PYIC-9145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ