### PR TITLE
PYIC-9161: Validate state transitions only for VCs included in request

### DIFF
--- a/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
+++ b/di-ipv-evcs-stub/lambdas/src/services/evcsService.ts
@@ -181,6 +181,7 @@ export async function processPatchUserVCsRequestV2(
         requestVcSignatureToState,
       );
     } catch (error) {
+      console.error(getErrorMessage(error));
       return {
         response: { messageId: getErrorMessage(error) },
         statusCode: StatusCodes.Conflict,
@@ -330,26 +331,23 @@ export async function processPostIdentityRequest(
 
 function validateStateTransitions(
   existingVcsSignatureToState: Map<string, VcState>,
-  newVcsSignatureToState: Map<string, VcState>,
+  requestVcsSignatureToState: Map<string, VcState>,
 ) {
-  for (const [
-    existingSignature,
-    existingState,
-  ] of existingVcsSignatureToState) {
-    const newState = newVcsSignatureToState.get(existingSignature);
-    if (!newState) {
+  for (const [requestSignature, requestState] of requestVcsSignatureToState) {
+    const existingState = existingVcsSignatureToState.get(requestSignature);
+    if (!existingState) {
       throw new Error(
         "No matching signature while validating state transitions.",
       );
     }
 
-    const allowedTransitions = stateTransitions[newState];
+    const allowedTransitions = stateTransitions[requestState];
     const hasRules = allowedTransitions.length > 0;
     const isAllowed = allowedTransitions.includes(existingState);
 
     if (hasRules && !isAllowed) {
       throw new Error(
-        `State VC transition from: ${existingState} to ${newState} is not allowed`,
+        `State VC transition from: ${existingState} to ${requestState} is not allowed`,
       );
     }
   }

--- a/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
+++ b/di-ipv-evcs-stub/lambdas/test/services/evcsService.test.ts
@@ -722,6 +722,61 @@ describe("evcsService", () => {
         );
       },
     );
+
+    it("should update only requested VCs when user has more VCs than in the request", async () => {
+      // Arrange
+      dbMock.on(QueryCommand).resolves(
+        createEvcsUserVcsQueryResponse([
+          { vc: TEST_VC1, state: VcState.CURRENT },
+          { vc: TEST_VC2, state: VcState.CURRENT },
+          { vc: TEST_VC3, state: VcState.CURRENT },
+        ]),
+      );
+
+      const request: PatchVcsRequest = {
+        userId: "testUserId",
+        govuk_signin_journey_id: "testJourneyId",
+        vcs: [
+          { signature: TEST_VC1_SIGNATURE, state: VcState.HISTORIC },
+          { signature: TEST_VC2_SIGNATURE, state: VcState.HISTORIC },
+        ],
+      };
+
+      // Act
+      const response = await processPatchUserVCsRequestV2(request);
+
+      // Assert
+      expect(response.statusCode).toBe(StatusCodes.NoContent);
+      expect(dbMock).toHaveReceivedCommandTimes(UpdateItemCommand, 2);
+      expect(dbMock).toHaveReceivedCommandWith(
+        UpdateItemCommand,
+        createUpdateItemInput({
+          userId: request.userId,
+          vcSignature: TEST_VC1_SIGNATURE,
+          state: VcState.HISTORIC,
+          ttl: 1735693200,
+        }),
+      );
+      expect(dbMock).toHaveReceivedCommandWith(
+        UpdateItemCommand,
+        createUpdateItemInput({
+          userId: request.userId,
+          vcSignature: TEST_VC2_SIGNATURE,
+          state: VcState.HISTORIC,
+          ttl: 1735693200,
+        }),
+      );
+
+      expect(dbMock).not.toHaveReceivedCommandWith(
+        UpdateItemCommand,
+        expect.objectContaining({
+          Key: {
+            userId: { S: request.userId },
+            vcSignature: { S: TEST_VC3_SIGNATURE },
+          },
+        }),
+      );
+    });
   });
 
   function getTestTtl() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Refactored `validateStateTransitions` function in `evcsService.ts` to iterate over request VCs instead of existing VCs
- Added test case to verify partial VC updates work correctly when user has more VCs than included in the request
- Added logging error when validation fail and throw an error

### Why did it change

Users with expired DL VCs >180 days were not being redirected to Reprove Identity when the `evcsApiUpdates` feature flag was enabled.

The root cause was that `validateStateTransitions` was iterating over all existing VCs and attempting to find matching VCs in the request. When a VC existed in EVCS but wasn't included in the PATCH request, the validation would fail because it couldn't find a matching signature in the request.

The fix changes the iteration logic to process only the VCs specified in the request, validating their state transitions against the corresponding existing VCs. This ensures VCs not included in the request are left untouched and don't interfere with validation.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-9161](https://govukverify.atlassian.net/browse/PYIC-9161)
- API tests [PR](https://github.com/govuk-one-login/ipv-core-back/pull/4041)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-9161]: https://govukverify.atlassian.net/browse/PYIC-9161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ