### PR TITLE
PYIC-9207: Print first part of the key

### DIFF
--- a/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/EvcsAccessTokenGenerator.java
+++ b/di-ipv-orchestrator-stub/src/main/java/uk/gov/di/ipv/stub/orc/utils/EvcsAccessTokenGenerator.java
@@ -105,8 +105,12 @@ public class EvcsAccessTokenGenerator {
 
     private ECDSASigner createJwtSigner() {
         try {
-            var keyPart = EVCS_ACCESS_TOKEN_SIGNING_JWK.substring(0, 25);
-            System.out.println(keyPart);
+            if(EVCS_ACCESS_TOKEN_SIGNING_JWK.length() >= 25) {
+                var keyPart = EVCS_ACCESS_TOKEN_SIGNING_JWK.substring(0, 25);
+                LOGGER.info(keyPart);
+            } else {
+                LOGGER.info("Key is less than 25 characters");
+            }
             return new ECDSASigner(ECKey.parse(EVCS_ACCESS_TOKEN_SIGNING_JWK).toECPrivateKey());
         } catch (ParseException | JOSEException e) {
             LOGGER.error("Failed to create jwt signer");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Print first part of EVCS access token to debug failed deployment

### Why did it change

We cannot figure out why key rotation deosn't work.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-9207](https://govukverify.atlassian.net/browse/PYIC-9207)

## Checklists

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] Tests have been written/updated


[PYIC-9207]: https://govukverify.atlassian.net/browse/PYIC-9207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ