### PR TITLE
BAU: add pre-commit hooks ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,17 @@ updates:
     - dependabot
     commit-message:
       prefix: BAU
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+    - dependabot
+    commit-message:
+      prefix: BAU
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Proposed changes
### What changed

Add pre-commit hooks ecosystem to dependabot config

### Why did it change

[Dependabot now supports pre-commit hooks](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/)